### PR TITLE
Trust the standard ingress proxy by default

### DIFF
--- a/App/config.ts
+++ b/App/config.ts
@@ -28,9 +28,10 @@ export const config = {
     // and always in multi-tenant mode. Multi-tenant mode rejects false.
     secureCookies: "auto" as "auto" | boolean,
     sessionMaxAgeDays: 7,
-    // Number of trusted reverse-proxy hops in front of Express. Keep 0 when
-    // Genosyn is directly reachable; the common ingress/reverse-proxy setup is 1.
-    trustedProxyHops: 0,
+    // Number of trusted reverse-proxy hops in front of Express. The Docker
+    // deployment is normally reached through one ingress/reverse-proxy hop.
+    // Set this to 0 only when Genosyn is directly reachable.
+    trustedProxyHops: 1,
     // Hosts in this exact, case-insensitive list may resolve to loopback,
     // private, link-local, or other non-public addresses. Leave empty for a
     // public SaaS. Add an internal hostname only when the operator explicitly

--- a/App/server/services/runtimeSecurity.test.ts
+++ b/App/server/services/runtimeSecurity.test.ts
@@ -67,6 +67,10 @@ test("multi-tenant mode always enables automatic secure cookies", () => {
   assert.equal(secureSessionCookies(), true);
 });
 
+test("stock deployments trust the standard ingress hop", () => {
+  assert.equal(config.security.trustedProxyHops, 1);
+});
+
 test("numeric runtime invariants fail before boot", () => {
   mutable.security.trustedProxyHops = -1;
   assert.throws(validateRuntimeSecurity, /trustedProxyHops must be a non-negative integer/);

--- a/Home/client/docs/pages/SelfHosting.tsx
+++ b/Home/client/docs/pages/SelfHosting.tsx
@@ -59,7 +59,9 @@ export function SelfHosting() {
     previousEncryptionSecrets: [],
     secureCookies: "auto",
     sessionMaxAgeDays: 7,
-    trustedProxyHops: 0,
+    // The standard Docker deployment sits behind one reverse proxy.
+    // Set 0 only when Genosyn is directly reachable.
+    trustedProxyHops: 1,
     outboundPrivateHostAllowlist: [],
     outboundRequestTimeoutMs: 15_000,
     outboundMaxResponseBytes: 25 * 1024 * 1024,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -197,7 +197,7 @@ export const config = {
     previousEncryptionSecrets: [],
     secureCookies: "auto",
     sessionMaxAgeDays: 7,
-    trustedProxyHops: 0,
+    trustedProxyHops: 1,
     outboundPrivateHostAllowlist: [],
     bootstrapMasterAdminEmail: "",
   },


### PR DESCRIPTION
## Summary

- default `security.trustedProxyHops` to one for the standard Docker/ingress deployment
- retain and document `0` for installations where Genosyn is directly reachable
- add regression coverage for the stock proxy setting and keep the self-hosting docs and roadmap config shape aligned

## Why

The production login endpoint accepted valid credentials and returned `200`, but emitted no session cookie. With an HTTPS public URL, `cookie-session` marks the cookie Secure; because the stock configuration did not trust the ingress proxy, Express saw the internal HTTP hop and the cookie library silently refused to write it. The client then failed `/api/auth/me` and redirected back to `/login` without an error.

This is part of **M28 — Shared SaaS foundation**.

## Validation

- `App`: `npm run lint`
- `App`: `npm run typecheck`
- `App`: `npm test` — 1,478 passing
- `App`: `npm run build`
- `Home`: `npm run lint`
- `Home`: `npm run typecheck`
- `Home`: `npm run build`
- reproduced the production failure before the change: valid login response, missing `Set-Cookie`, subsequent unauthenticated session

## Manual verification after deployment

1. Submit valid credentials through the production login page.
2. Confirm `POST /api/auth/login` returns a signed `genosyn.sid` cookie.
3. Confirm `GET /api/auth/me` returns `200` and the app opens the authenticated company view.
