### PR TITLE
Add secure OpenAI subscription authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,13 @@ autonomously with AI employees**.
   **Skills** (playbooks), and **Routines** (scheduled cron-driven work). All
   three are plain markdown stored on the employee / skill / routine DB rows —
   there are no `SOUL.md` / `README.md` files on disk any more.
-- Each company can register multiple **AI Models** — a direct connection to a
-  model API: **Anthropic** (Claude), **OpenAI** (GPT), or a **custom**
-  OpenAI-compatible endpoint (Ollama, vLLM, llama.cpp, a gateway) — and assign
-  them to employees. Genosyn talks to the model API in-process and runs the
-  tool-use loop itself; there are no provider CLIs.
+- Each company can register multiple **AI Models**: **Anthropic** (Claude),
+  **OpenAI** (GPT), or a **custom** OpenAI-compatible endpoint (Ollama, vLLM,
+  llama.cpp, a gateway) — and assign them to employees. API-key and custom
+  models run through Genosyn's direct in-process model loop. A source-managed
+  Linux OpenAI model may instead use ChatGPT subscription access through the
+  official pinned `@openai/codex` app-server; this is a narrow official runtime
+  path, not a return to generic provider CLI harnesses.
 
 Read `ROADMAP.md` for the full vocabulary, milestones, and backlog. **Do not
 duplicate content from ROADMAP.md here** — link to it.
@@ -172,15 +174,31 @@ data/
 
 - **The database is the source of truth** for Soul, Skill, and Routine prose
   (`AIEmployee.soulBody`, `Skill.body`, `Routine.body`), for captured Run
-  transcripts (`Run.logContent`), and for **model credentials** — API keys and
-  custom-endpoint URLs live encrypted in `AIModel.configJson`. Do not
+  transcripts (`Run.logContent`), and for **model credentials** — API keys,
+  custom-endpoint URLs, and OpenAI subscription credentials live encrypted in
+  `AIModel.configJson`. Do not
   reintroduce `SOUL.md` / `skills/<slug>/README.md` / `routines/<slug>/README.md`
-  on disk, and never write model credentials to disk.
-- There are **no per-provider credential dirs** (`.claude`, `.codex`, … are
-  gone) and **no materialized MCP config files**. Genosyn talks to the model
-  API in-process and hands the model its tools directly:
+  on disk, and never write model credentials into an employee working tree or
+  a persistent provider directory. The OpenAI subscription path is the only
+  file-backed exception: each device login and Run gets a locked temporary
+  `CODEX_HOME`. A managed ChatGPT session is materialized there; a Business /
+  Enterprise access token is injected only into the child process environment.
+  The directory is removed afterward.
+- There are **no persistent per-provider credential dirs** (`.claude`,
+  `.codex`, … are gone), generic provider CLI harnesses, or materialized MCP
+  config files. API-key and custom models receive tools from Genosyn's
+  in-process loop; OpenAI subscription models run through the official
+  pinned `@openai/codex` app-server with the same Genosyn-owned tool registry:
     * built-in **coding tools** (`bash`, `read_file`, `write_file`,
-      `edit_file`, `list_dir`, `glob`, `grep`), rooted at the employee cwd;
+      `edit_file`, `list_dir`, `glob`, `grep`), rooted at the employee cwd.
+      Subscription auth is available only when coding tools use `bubblewrap`,
+      whose private PID and `/tmp` namespaces isolate the sibling app-server's
+      materialized credential. Every model turn in a bubblewrap deployment
+      exposes only the sandboxed `bash` tool from this family; the in-process
+      file tools are omitted install-wide so a concurrent non-subscription turn
+      cannot race a symlink into that credential. Repository clone/fetch runs
+      through the same namespace boundary. Host or disabled execution modes
+      make subscription auth unavailable;
     * the built-in **genosyn** tools, dispatched in-process to the loopback
       internal API (`server/mcp/toolManifest.ts` + `routes/mcpInternal.ts`)
       with a short-lived MCP token. The model is shown a **working set** of
@@ -190,11 +208,19 @@ data/
       `server/mcp-browser/` that the agent connects to as an MCP client — when
       `AIEmployee.browserEnabled` is true;
     * any company-configured **MCP servers** (stdio/HTTP), which the agent
-      connects to as an MCP client.
+      connects to as an MCP client. User-configured stdio servers are omitted
+      whenever coding tools use `bubblewrap`; HTTP servers remain available.
   The agent runtime lives in `server/services/agent/`. What stays on disk under
   the employee dir is only the working tree the coding tools operate on:
   materialized git repos, the browser storage-state snapshot, and whatever the
   tools write into cwd.
+- OpenAI subscription device sessions and managed refresh-token locks are
+  process-local. The supported topology for this auth mode is one
+  source-managed Linux App process; the standard Docker installer and
+  horizontally scaled installs must use API-key models until the container
+  policy and coordination primitives are ready. Subscription turns serialize
+  on the per-model lock and do not expose `delegate_parallel_work`; a delegated
+  copy would otherwise wait on the lock held by its parent.
 - The `data/` directory is gitignored. Never commit anything inside it.
 - Slugs are derived once at create-time via `slugify`; renames update the
   display name but not the slug (so URLs stay stable).
@@ -354,9 +380,14 @@ Don't tag manually, don't edit version numbers in `package.json` files.
   Run row. The filesystem under `data/` is only for the employee working tree
   (git repos, browser state, tool artifacts) — never model credentials, which
   live encrypted on the `AIModel` row.
-- Reintroducing provider CLIs, per-provider credential dirs, subscription/OAuth
-  sign-in, or materialized MCP config files. Models are called directly via
-  their API from the in-process agent (`server/services/agent/`).
+- Reintroducing generic provider CLI harnesses, persistent per-provider
+  credential dirs, Anthropic subscription/OAuth routing, or materialized MCP
+  config files. API-key and custom models are called directly via the
+  in-process agent (`server/services/agent/`). The only subscription exception
+  is source-managed Linux OpenAI through the official pinned `@openai/codex`
+  app-server, with managed session files confined to a locked temporary
+  `CODEX_HOME` and access tokens confined to the child process environment for
+  a Run.
 - Naming a user-configurable MCP server `genosyn` or `browser`. Both names are
   reserved for built-in tools — `genosyn` runs in-process (dispatched to
   `routes/mcpInternal.ts`); `browser` is a stdio binary at `server/mcp-browser/`.

--- a/App/Dockerfile
+++ b/App/Dockerfile
@@ -2,10 +2,11 @@
 # Multi-stage build for the Genosyn App (Express API + React client).
 # Client is built with Vite and served as static assets by the Express server.
 #
-# The App talks to model APIs (Anthropic / OpenAI / any OpenAI-compatible
-# endpoint) directly, in-process — there are no provider CLIs to bundle. The
-# runtime image only needs the toolset the built-in tools use: a shell + git
-# for the coding/repo tools and Chromium for the browser tool.
+# API-key and custom models talk to their APIs directly in-process. The pinned
+# `@openai/codex` dependency contributes one narrow official app-server binary
+# for self-hosted OpenAI subscription models; generic provider CLIs remain
+# removed. The rest of the runtime toolset is a shell + git for Genosyn's
+# coding/repo tools and Chromium for its browser tool.
 
 # ---------- deps ----------
 FROM node:22-alpine AS deps

--- a/App/README.md
+++ b/App/README.md
@@ -53,18 +53,36 @@ User-generated content (Soul, Skills, Routines, Run logs) lives in the DB.
 With the default driver that's `./data/app.sqlite`; flip
 `config.db.driver` to `postgres` and everything (entities + migrations) moves
 with you. Model credentials are entered in the app and stored encrypted
-(AES-256-GCM) in the DB — never on disk — so the filesystem side of
-`config.dataDir` only holds any artifacts an employee writes into its working
-directory. Everything under `data/` is gitignored.
+(AES-256-GCM) in the DB — never in an employee working directory or a
+persistent provider directory. OpenAI subscription device login and Runs use a
+locked temporary `CODEX_HOME` required by the official Codex app-server. A
+managed ChatGPT session is materialized there; an access token is injected only
+into the child process environment. The directory is removed afterward. The
+filesystem side of `config.dataDir` only holds artifacts an employee writes
+into its working directory. Everything under `data/` is gitignored.
 
 ## Runner
 
-The cron-driven runner in `server/services/runner.ts` drives an in-process
-agent loop that talks directly to the employee's model API (Anthropic, OpenAI,
-or any OpenAI-compatible custom endpoint) with a prompt composed from the
-employee's Soul + Skills + Routine. The loop hands the model tools directly:
-built-in coding tools (bash, read_file, write_file, edit_file, glob, grep),
-the genosyn MCP tools (routines/todos/journal/memory/bases/attachments),
-browser tools when enabled, and any company-configured MCP servers. The agent
-transcript is written to `Run.logContent` (capped at 256KB). When no model or
-API key is configured, the run is marked `skipped` with an explanatory log.
+The cron-driven runner in `server/services/runner.ts` drives the employee's
+active model with a prompt composed from their Soul + Skills + Routine.
+Anthropic and OpenAI API keys, plus OpenAI-compatible custom endpoints, use
+the direct in-process agent loop. A source-managed Linux OpenAI subscription
+model uses the official pinned `@openai/codex` app-server with an isolated
+temporary `CODEX_HOME` and a separate empty scratch directory; generic provider
+CLI harnesses remain removed. Subscription auth requires coding tools to use
+working Linux `bubblewrap`; host and disabled execution modes are rejected.
+Every model turn in a bubblewrap deployment receives only sandboxed `bash` from
+the coding family. Host-process file tools are omitted install-wide so a
+concurrent API-key or custom-model turn cannot race a workspace symlink into
+the subscription credential. Server-managed repository clone/fetch and
+credential wiring use the same boundary, a cleared environment, and only the
+configured remote. The model receives the genosyn MCP tools
+(routines/todos/journal/memory/bases/attachments), browser tools when enabled,
+and company-configured HTTP MCP servers. User-configured stdio MCP servers are
+omitted install-wide in bubblewrap mode so an arbitrary same-UID child cannot
+inspect a subscription credential. The agent transcript is written to
+`Run.logContent` (capped at 256KB). When no model or usable credential is
+configured, the run is marked `skipped` with an explanatory log. Subscription
+auth currently supports a source-managed, single-App-process Linux deployment;
+use API-key models with the standard Docker installer or when horizontally
+scaling App replicas.

--- a/App/client/lib/api.ts
+++ b/App/client/lib/api.ts
@@ -453,7 +453,16 @@ export type RunLog = {
   attempt?: number;
 };
 export type Provider = "anthropic" | "openai" | "custom";
-export type AuthMode = "apikey" | "customEndpoint";
+export type AuthMode = "apikey" | "subscription" | "customEndpoint";
+export type SubscriptionCredentialKind = "chatgptSession" | "accessToken";
+export type SubscriptionDeviceSession = {
+  id: string;
+  status: "running" | "succeeded" | "failed" | "cancelled";
+  output: string | null;
+  loginUrl: string | null;
+  userCode: string | null;
+  error: string | null;
+};
 export type AIModel = {
   id: string;
   employeeId: string;
@@ -468,6 +477,16 @@ export type AIModel = {
   /** Env var the provider conventionally reads (informational), or null. */
   apiKeyEnv: string | null;
   supportsApiKey: boolean;
+  /** Whether this provider can authenticate with a consumer subscription. */
+  supportsSubscription: boolean;
+  /** Whether subscription sign-in is available on this Genosyn install. */
+  subscriptionAvailable: boolean;
+  /** Human-readable reason device sign-in is unavailable, when applicable. */
+  subscriptionUnavailableReason: string | null;
+  /** The stored subscription credential shape, without exposing the secret. */
+  subscriptionCredentialKind: SubscriptionCredentialKind | null;
+  /** Whether subscription turns can use bash inside an isolated sandbox. */
+  subscriptionShellAvailable: boolean;
   supportsCustomEndpoint: boolean;
   customEndpointHost: string | null;
   customEndpointModelId: string | null;
@@ -512,12 +531,7 @@ export type ConversationSummary = {
   lastMessageAt: string | null;
 };
 export type ConversationMessageRole = "user" | "assistant";
-export type ConversationMessageStatus =
-  | "working"
-  | "ok"
-  | "skipped"
-  | "error"
-  | "busy";
+export type ConversationMessageStatus = "working" | "ok" | "skipped" | "error" | "busy";
 /** Tool-driven write the AI employee performed during this chat turn. */
 export type MessageAction = {
   action: string;

--- a/App/client/pages/employeeTabs.tsx
+++ b/App/client/pages/employeeTabs.tsx
@@ -31,6 +31,7 @@ import {
   MemoryItem,
   McpServer,
   McpTransport,
+  SubscriptionDeviceSession,
   Team,
 } from "../lib/api";
 import { copyToClipboard } from "../lib/clipboard";
@@ -112,8 +113,7 @@ function SoulCard({ company, emp }: { company: Company; emp: Employee }) {
               )}
             </div>
             <div className="text-xs text-slate-500 dark:text-slate-400">
-              {emp.name}&apos;s constitution — the markdown {emp.name} reads
-              before every task.
+              {emp.name}&apos;s constitution — the markdown {emp.name} reads before every task.
             </div>
           </div>
         </div>
@@ -137,14 +137,12 @@ function SoulCard({ company, emp }: { company: Company; emp: Employee }) {
 
 // ---------- Model (Settings) tab ----------
 
-const PROVIDER_DEFAULTS: Record<
-  Provider,
-  { label: string; model: string; authMode: AuthMode }
-> = {
+const PROVIDER_DEFAULTS: Record<Provider, { label: string; model: string; authMode: AuthMode }> = {
   anthropic: { label: "Anthropic (Claude)", model: "claude-opus-4-6", authMode: "apikey" },
   openai: { label: "OpenAI (GPT)", model: "gpt-4o", authMode: "apikey" },
   custom: { label: "Custom OpenAI-compatible endpoint", model: "", authMode: "customEndpoint" },
 };
+const OPENAI_SUBSCRIPTION_DEFAULT_MODEL = "gpt-5.6-terra";
 
 /**
  * Employee Settings. Soul + Model used to share one scroll-heavy page; now
@@ -233,19 +231,11 @@ export function BrowserSettingsPage() {
   return <EmployeeBrowserAccessCard company={company} emp={emp} />;
 }
 
-function EmployeeOrgCard({
-  company,
-  emp,
-}: {
-  company: Company;
-  emp: Employee;
-}) {
+function EmployeeOrgCard({ company, emp }: { company: Company; emp: Employee }) {
   const [teams, setTeams] = React.useState<Team[] | null>(null);
   const [peers, setPeers] = React.useState<Employee[] | null>(null);
   const [teamId, setTeamId] = React.useState<string>(emp.teamId ?? "");
-  const [reportsTo, setReportsTo] = React.useState<string>(
-    emp.reportsToEmployeeId ?? "",
-  );
+  const [reportsTo, setReportsTo] = React.useState<string>(emp.reportsToEmployeeId ?? "");
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const { toast } = useToast();
@@ -276,13 +266,10 @@ function EmployeeOrgCard({
     setError(null);
     setSaving(true);
     try {
-      await api.patch<Employee>(
-        `/api/companies/${company.id}/employees/${emp.id}`,
-        {
-          teamId: teamId || null,
-          reportsToEmployeeId: reportsTo || null,
-        },
-      );
+      await api.patch<Employee>(`/api/companies/${company.id}/employees/${emp.id}`, {
+        teamId: teamId || null,
+        reportsToEmployeeId: reportsTo || null,
+      });
       toast("Org chart updated", "success");
       window.dispatchEvent(new CustomEvent("genosyn:employee-updated"));
     } catch (err) {
@@ -296,21 +283,17 @@ function EmployeeOrgCard({
     <Card>
       <CardBody className="flex flex-col gap-3">
         <div>
-          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">
-            Org chart
-          </div>
+          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Org chart</div>
           <div className="text-xs text-slate-500 dark:text-slate-400">
-            The team this employee belongs to and who they report to. Manager
-            is used by the <code className="font-mono">create_handoff</code>{" "}
+            The team this employee belongs to and who they report to. Manager is used by the{" "}
+            <code className="font-mono">create_handoff</code>{" "}
             <code className="font-mono">toManager: true</code> shortcut.
           </div>
         </div>
         <form className="flex flex-col gap-3" onSubmit={submit}>
           <FormError message={error} />
           <label className="flex flex-col gap-1 text-xs">
-            <span className="font-medium text-slate-700 dark:text-slate-300">
-              Team
-            </span>
+            <span className="font-medium text-slate-700 dark:text-slate-300">Team</span>
             <select
               className="rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900"
               value={teamId}
@@ -326,9 +309,7 @@ function EmployeeOrgCard({
             </select>
           </label>
           <label className="flex flex-col gap-1 text-xs">
-            <span className="font-medium text-slate-700 dark:text-slate-300">
-              Reports to
-            </span>
+            <span className="font-medium text-slate-700 dark:text-slate-300">Reports to</span>
             <select
               className="rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-900"
               value={reportsTo}
@@ -355,9 +336,7 @@ function EmployeeOrgCard({
 }
 
 function EmployeeAvatarCard({ company, emp }: { company: Company; emp: Employee }) {
-  const [avatarKey, setAvatarKey] = React.useState<string | null>(
-    emp.avatarKey ?? null,
-  );
+  const [avatarKey, setAvatarKey] = React.useState<string | null>(emp.avatarKey ?? null);
   const [uploading, setUploading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const fileRef = React.useRef<HTMLInputElement | null>(null);
@@ -372,10 +351,11 @@ function EmployeeAvatarCard({ company, emp }: { company: Company; emp: Employee 
     try {
       const fd = new FormData();
       fd.append("file", file);
-      const res = await fetch(
-        `/api/companies/${company.id}/employees/${emp.id}/avatar`,
-        { method: "POST", credentials: "same-origin", body: fd },
-      );
+      const res = await fetch(`/api/companies/${company.id}/employees/${emp.id}/avatar`, {
+        method: "POST",
+        credentials: "same-origin",
+        body: fd,
+      });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
         let msg = res.statusText;
@@ -414,8 +394,8 @@ function EmployeeAvatarCard({ company, emp }: { company: Company; emp: Employee 
             Profile picture
           </div>
           <div className="text-xs text-slate-500 dark:text-slate-400">
-            Shown in the sidebar, employee list, and workspace chat. PNG, JPEG,
-            GIF, or WebP up to 5&nbsp;MB.
+            Shown in the sidebar, employee list, and workspace chat. PNG, JPEG, GIF, or WebP up to
+            5&nbsp;MB.
           </div>
         </div>
         <FormError message={error} />
@@ -514,12 +494,9 @@ function EmployeeBasicsCard({ company, emp }: { company: Company; emp: Employee 
     <Card>
       <CardBody className="flex flex-col gap-3">
         <div>
-          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">
-            Basics
-          </div>
+          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Basics</div>
           <div className="text-xs text-slate-500 dark:text-slate-400">
-            Renaming the slug updates the URL for this employee and renames its
-            directory under{" "}
+            Renaming the slug updates the URL for this employee and renames its directory under{" "}
             <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
               data/companies/{company.slug}/employees/
             </code>
@@ -572,13 +549,7 @@ function normalizeSlug(raw: string): string {
  * opts in per employee, then narrows further with the allow list /
  * approval mode.
  */
-function EmployeeBrowserAccessCard({
-  company,
-  emp,
-}: {
-  company: Company;
-  emp: Employee;
-}) {
+function EmployeeBrowserAccessCard({ company, emp }: { company: Company; emp: Employee }) {
   const [enabled, setEnabled] = React.useState<boolean>(!!emp.browserEnabled);
   const [allowedHosts, setAllowedHosts] = React.useState<string>(emp.browserAllowedHosts ?? "");
   const [approval, setApproval] = React.useState<boolean>(!!emp.browserApprovalRequired);
@@ -600,10 +571,9 @@ function EmployeeBrowserAccessCard({
     setEnabled(next);
     setSavingToggle(true);
     try {
-      await api.patch<Employee>(
-        `/api/companies/${company.id}/employees/${emp.id}`,
-        { browserEnabled: next },
-      );
+      await api.patch<Employee>(`/api/companies/${company.id}/employees/${emp.id}`, {
+        browserEnabled: next,
+      });
       toast(next ? "Browser access enabled" : "Browser access disabled", "success");
       window.dispatchEvent(new CustomEvent("genosyn:employee-updated"));
     } catch (err) {
@@ -619,14 +589,10 @@ function EmployeeBrowserAccessCard({
     setApproval(next);
     setSavingApproval(true);
     try {
-      await api.patch<Employee>(
-        `/api/companies/${company.id}/employees/${emp.id}`,
-        { browserApprovalRequired: next },
-      );
-      toast(
-        next ? "Browser submits will require approval" : "Approval gate disabled",
-        "success",
-      );
+      await api.patch<Employee>(`/api/companies/${company.id}/employees/${emp.id}`, {
+        browserApprovalRequired: next,
+      });
+      toast(next ? "Browser submits will require approval" : "Approval gate disabled", "success");
     } catch (err) {
       setApproval(!next);
       toast((err as Error).message || "Could not update approval mode", "error");
@@ -639,10 +605,9 @@ function EmployeeBrowserAccessCard({
     if (savingHosts) return;
     setSavingHosts(true);
     try {
-      await api.patch<Employee>(
-        `/api/companies/${company.id}/employees/${emp.id}`,
-        { browserAllowedHosts: allowedHosts },
-      );
+      await api.patch<Employee>(`/api/companies/${company.id}/employees/${emp.id}`, {
+        browserAllowedHosts: allowedHosts,
+      });
       toast("Allow list saved", "success");
     } catch (err) {
       toast((err as Error).message || "Could not save allow list", "error");
@@ -676,9 +641,8 @@ function EmployeeBrowserAccessCard({
                 <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
                   browser_fill
                 </code>
-                , and screenshot tools so the employee can read and interact
-                with web pages. Off by default — narrow further with the
-                allow list and approval mode below.
+                , and screenshot tools so the employee can read and interact with web pages. Off by
+                default — narrow further with the allow list and approval mode below.
               </p>
             </div>
           </div>
@@ -744,8 +708,7 @@ function EmployeeBrowserAccessCard({
                   <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
                     browser_submit
                   </code>{" "}
-                  queue an Approval row instead of firing immediately. The
-                  employee resumes via{" "}
+                  queue an Approval row instead of firing immediately. The employee resumes via{" "}
                   <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
                     browser_resume
                   </code>{" "}
@@ -917,6 +880,7 @@ function ModelForm({
 }) {
   const [provider, setProvider] = React.useState<Provider>(initial.provider);
   const [modelStr, setModelStr] = React.useState(initial.model);
+  const [authMode, setAuthMode] = React.useState<AuthMode>(initial.authMode);
   const [saving, setSaving] = React.useState(false);
   // Custom-endpoint inputs live on the same form so onboarding is one submit.
   const [baseURL, setBaseURL] = React.useState("");
@@ -925,11 +889,18 @@ function ModelForm({
   const { toast } = useToast();
 
   const isCustom = provider === "custom";
-  const authMode: AuthMode = isCustom ? "customEndpoint" : "apikey";
 
   const onProvider = (p: Provider) => {
     setProvider(p);
     setModelStr(PROVIDER_DEFAULTS[p].model);
+    setAuthMode(PROVIDER_DEFAULTS[p].authMode);
+  };
+
+  const onOpenAIAuthentication = (next: "apikey" | "subscription") => {
+    setAuthMode(next);
+    setModelStr(
+      next === "subscription" ? OPENAI_SUBSCRIPTION_DEFAULT_MODEL : PROVIDER_DEFAULTS.openai.model,
+    );
   };
 
   return (
@@ -982,7 +953,17 @@ function ModelForm({
           <option value="openai">OpenAI (GPT)</option>
           <option value="custom">Custom OpenAI-compatible endpoint</option>
         </Select>
-        {!isCustom && (
+        {provider === "openai" && (
+          <Select
+            label="Authentication"
+            value={authMode}
+            onChange={(e) => onOpenAIAuthentication(e.target.value as "apikey" | "subscription")}
+          >
+            <option value="apikey">OpenAI API key</option>
+            <option value="subscription">ChatGPT subscription</option>
+          </Select>
+        )}
+        {provider === "anthropic" && (
           <Input
             label="Model"
             value={modelStr}
@@ -991,6 +972,14 @@ function ModelForm({
           />
         )}
       </div>
+      {provider === "openai" && (
+        <Input
+          label="Model"
+          value={modelStr}
+          onChange={(e) => setModelStr(e.target.value)}
+          required
+        />
+      )}
       {isCustom && (
         <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div className="grid gap-3 sm:grid-cols-2">
@@ -1017,25 +1006,25 @@ function ModelForm({
             placeholder="leave blank if not needed"
           />
           <div className="text-xs text-slate-500 dark:text-slate-400">
-            Point this employee at a self-hosted OpenAI-compatible server —
-            Ollama, vLLM, llama.cpp, LM Studio. Base URL + key are stored
-            encrypted at rest.
+            Point this employee at a self-hosted OpenAI-compatible server — Ollama, vLLM, llama.cpp,
+            LM Studio. Base URL + key are stored encrypted at rest.
           </div>
         </div>
       )}
       {!isCustom && (
         <div className="text-xs text-slate-500 dark:text-slate-400">
           {provider === "anthropic"
-            ? "Claude via the Anthropic API. Add the API key after saving."
-            : "GPT via the OpenAI API. Add the API key after saving."}
+            ? "Claude subscriptions cannot be connected. Create an API key in the Anthropic Console and use API billing."
+            : authMode === "subscription"
+              ? "Self-hosted Linux with bubblewrap is required. Sign in with ChatGPT after saving this model."
+              : "GPT via the OpenAI API. Add the API key after saving."}
         </div>
       )}
       <div>
         <Button
           type="submit"
           disabled={
-            saving ||
-            (isCustom && (baseURL.trim().length === 0 || modelId.trim().length === 0))
+            saving || (isCustom && (baseURL.trim().length === 0 || modelId.trim().length === 0))
           }
         >
           {saving ? "Saving…" : submitLabel}
@@ -1106,20 +1095,27 @@ function ModelCard({
           ? `Pointed at ${model.customEndpointHost}`
           : "Custom endpoint configured";
       }
+      if (model.authMode === "subscription") {
+        return model.subscriptionCredentialKind === "accessToken"
+          ? "Connected with a Business or Enterprise access token"
+          : "Connected to a ChatGPT subscription";
+      }
       return `Authenticated with ${model.apiKeyEnv ?? "API"} key`;
     }
     if (model.authMode === "customEndpoint") {
       return "Enter the server's base URL and model id below to connect.";
     }
+    if (model.authMode === "subscription") {
+      return model.subscriptionAvailable
+        ? "Sign in with ChatGPT below to connect."
+        : (model.subscriptionUnavailableReason ??
+            "ChatGPT subscription sign-in is unavailable on this install.");
+    }
     return `No ${model.apiKeyEnv ?? "API"} key on file yet — paste one below to connect.`;
   })();
 
   return (
-    <Card
-      className={
-        model.isActive ? "ring-1 ring-indigo-300 dark:ring-indigo-500/40" : undefined
-      }
-    >
+    <Card className={model.isActive ? "ring-1 ring-indigo-300 dark:ring-indigo-500/40" : undefined}>
       <CardBody className="flex flex-col gap-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
@@ -1140,11 +1136,7 @@ function ModelCard({
           <div className="flex shrink-0 items-center gap-1">
             {!model.isActive && (
               <Button size="sm" variant="ghost" onClick={activate} disabled={activating}>
-                {activating ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Check size={14} />
-                )}
+                {activating ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
                 Make active
               </Button>
             )}
@@ -1157,22 +1149,15 @@ function ModelCard({
         {!connected && model.authMode === "apikey" && (
           <ApiKeyPanel company={company} emp={emp} model={model} onSaved={onChanged} />
         )}
+        {model.authMode === "subscription" && (
+          <SubscriptionPanel company={company} emp={emp} model={model} onSaved={onChanged} />
+        )}
         {model.authMode === "customEndpoint" && (
-          <CustomEndpointPanel
-            company={company}
-            emp={emp}
-            model={model}
-            onSaved={onChanged}
-          />
+          <CustomEndpointPanel company={company} emp={emp} model={model} onSaved={onChanged} />
         )}
 
-        {connected && (
-          <ContextWindowPanel
-            company={company}
-            emp={emp}
-            model={model}
-            onChanged={onChanged}
-          />
+        {connected && model.authMode !== "subscription" && (
+          <ContextWindowPanel company={company} emp={emp} model={model} onChanged={onChanged} />
         )}
 
         <details className="rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
@@ -1281,8 +1266,8 @@ function ContextWindowPanel({
               </>
             ) : (
               <>
-                Unknown — runs on this model {"can't"} budget their context, and will
-                only notice an over-long prompt once the provider rejects it.
+                Unknown — runs on this model {"can't"} budget their context, and will only notice an
+                over-long prompt once the provider rejects it.
               </>
             )}
           </div>
@@ -1347,8 +1332,8 @@ function ContextWindowPanel({
           </Button>
           <p className="w-full text-xs text-slate-500 dark:text-slate-400">
             Whatever the server was launched with — vLLM{"'"}s <code>--max-model-len</code>,
-            llama.cpp{"'"}s <code>-c</code>, or the model{"'"}s documented limit. A number
-            set here wins over anything the provider reports.
+            llama.cpp{"'"}s <code>-c</code>, or the model{"'"}s documented limit. A number set here
+            wins over anything the provider reports.
           </p>
         </form>
       )}
@@ -1381,6 +1366,283 @@ function ActiveBadge() {
 
 function apiKeyPlaceholder(p: Provider): string {
   return p === "openai" ? "sk-…" : "sk-ant-…";
+}
+
+/**
+ * OpenAI subscription authentication. The normal path starts the server-side
+ * device flow and polls its short-lived session while the member signs in in a
+ * separate tab. Business and Enterprise installations can instead supply a
+ * directly issued access token through the advanced form.
+ */
+function SubscriptionPanel({
+  company,
+  emp,
+  model,
+  onSaved,
+}: {
+  company: Company;
+  emp: Employee;
+  model: AIModel;
+  onSaved: () => void;
+}) {
+  const { toast } = useToast();
+  const [deviceSession, setDeviceSession] = React.useState<SubscriptionDeviceSession | null>(null);
+  const [starting, setStarting] = React.useState(false);
+  const [cancelling, setCancelling] = React.useState(false);
+  const [pollError, setPollError] = React.useState<string | null>(null);
+  const [accessToken, setAccessToken] = React.useState("");
+  const [savingToken, setSavingToken] = React.useState(false);
+  const connected = model.status === "connected";
+  const deviceSignInAvailable = model.supportsSubscription && model.subscriptionAvailable;
+  const base = `/api/companies/${company.id}/employees/${emp.id}/models/${model.id}/subscription`;
+
+  const receiveDeviceSession = React.useCallback(
+    (next: SubscriptionDeviceSession) => {
+      setDeviceSession(next);
+      setPollError(null);
+      if (next.status === "succeeded") {
+        toast("ChatGPT subscription connected", "success");
+        onSaved();
+      }
+    },
+    [onSaved, toast],
+  );
+
+  const deviceSessionId = deviceSession?.id;
+  const deviceSessionStatus = deviceSession?.status;
+
+  React.useEffect(() => {
+    if (!deviceSessionId || deviceSessionStatus !== "running") return;
+
+    let stopped = false;
+    let timer: number | undefined;
+    const poll = async () => {
+      try {
+        const next = await api.get<SubscriptionDeviceSession>(`${base}/device/${deviceSessionId}`);
+        if (stopped) return;
+        receiveDeviceSession(next);
+        if (next.status === "running") {
+          timer = window.setTimeout(poll, 1_500);
+        }
+      } catch (err) {
+        if (stopped) return;
+        setPollError((err as Error).message);
+        timer = window.setTimeout(poll, 2_500);
+      }
+    };
+
+    timer = window.setTimeout(poll, 1_000);
+    return () => {
+      stopped = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [base, deviceSessionId, deviceSessionStatus, receiveDeviceSession]);
+
+  async function startDeviceSignIn() {
+    setStarting(true);
+    setPollError(null);
+    try {
+      const session = await api.post<SubscriptionDeviceSession>(`${base}/device`);
+      receiveDeviceSession(session);
+    } catch (err) {
+      toast((err as Error).message, "error");
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function cancelDeviceSignIn() {
+    if (!deviceSession || deviceSession.status !== "running") return;
+    setCancelling(true);
+    try {
+      await api.del(`${base}/device/${deviceSession.id}`);
+      setDeviceSession((current) =>
+        current ? { ...current, status: "cancelled", error: null } : current,
+      );
+      setPollError(null);
+      toast("ChatGPT sign-in cancelled");
+    } catch (err) {
+      toast((err as Error).message, "error");
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  async function saveAccessToken(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingToken(true);
+    try {
+      await api.post(`${base}/access-token`, { accessToken });
+      setAccessToken("");
+      setDeviceSession(null);
+      toast("OpenAI subscription access token saved", "success");
+      onSaved();
+    } catch (err) {
+      toast((err as Error).message, "error");
+    } finally {
+      setSavingToken(false);
+    }
+  }
+
+  const deviceRunning = deviceSession?.status === "running";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+      <div>
+        <div className="text-xs font-medium text-slate-700 dark:text-slate-200">
+          ChatGPT subscription
+        </div>
+        <div className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+          {connected
+            ? "Connected. Sign in again below whenever you need to replace the stored subscription credentials."
+            : "Connect the ChatGPT account this AI Employee should use."}
+        </div>
+      </div>
+
+      {!deviceSignInAvailable && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
+          Browser sign-in is unavailable:{" "}
+          {model.subscriptionUnavailableReason ??
+            "this Genosyn install does not support ChatGPT device sign-in."}
+        </div>
+      )}
+
+      {!model.subscriptionShellAvailable && (
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          Subscription turns receive the shell tool only when coding tools are enabled in bubblewrap
+          mode. It is unavailable on this install; subscription turns do not expose the host-process
+          file tools.
+        </div>
+      )}
+
+      {deviceRunning && (
+        <div
+          className="flex flex-col gap-3 rounded-md bg-slate-50 p-3 dark:bg-slate-900"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-2 text-xs font-medium text-slate-700 dark:text-slate-200">
+            <Loader2 size={14} className="animate-spin" />
+            Waiting for you to finish signing in
+          </div>
+          {deviceSession.loginUrl && (
+            <a
+              className="inline-flex w-fit items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+              href={deviceSession.loginUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open ChatGPT sign-in <ExternalLink size={13} />
+            </a>
+          )}
+          {deviceSession.userCode && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs text-slate-500 dark:text-slate-400">One-time code</span>
+              <code className="rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-semibold tracking-wider text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100">
+                {deviceSession.userCode}
+              </code>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={async () => {
+                  const copied = await copyToClipboard(deviceSession.userCode ?? "");
+                  toast(
+                    copied ? "Code copied" : "Could not copy the code",
+                    copied ? "success" : "error",
+                  );
+                }}
+              >
+                <Copy size={13} /> Copy
+              </Button>
+            </div>
+          )}
+          {pollError && (
+            <div className="text-xs text-amber-700 dark:text-amber-300">
+              Could not check sign-in status ({pollError}). Retrying…
+            </div>
+          )}
+        </div>
+      )}
+
+      {deviceSession?.status === "failed" && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {deviceSession.error ?? "ChatGPT sign-in failed. Start a new sign-in to try again."}
+        </div>
+      )}
+      {deviceSession?.status === "cancelled" && (
+        <div className="text-xs text-slate-500 dark:text-slate-400">Sign-in was cancelled.</div>
+      )}
+      {deviceSession?.status === "succeeded" && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+          ChatGPT subscription connected.
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {deviceSignInAvailable && !deviceRunning && (
+          <Button type="button" size="sm" onClick={startDeviceSignIn} disabled={starting}>
+            {starting && <Loader2 size={14} className="animate-spin" />}
+            {starting
+              ? "Starting…"
+              : connected || deviceSession?.status === "succeeded"
+                ? "Reconnect with ChatGPT"
+                : "Sign in with ChatGPT"}
+          </Button>
+        )}
+        {deviceRunning && (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={cancelDeviceSignIn}
+            disabled={cancelling}
+          >
+            {cancelling ? "Cancelling…" : "Cancel sign-in"}
+          </Button>
+        )}
+      </div>
+
+      {model.subscriptionAvailable && (
+        <details className="border-t border-slate-200 pt-3 dark:border-slate-700">
+          <summary className="cursor-pointer text-xs text-slate-600 dark:text-slate-300">
+            Advanced: Business or Enterprise access token
+          </summary>
+          <form className="mt-3 flex flex-col gap-2" onSubmit={saveAccessToken}>
+            <Input
+              label="Access token"
+              type="password"
+              value={accessToken}
+              onChange={(e) => setAccessToken(e.target.value)}
+              placeholder={
+                model.subscriptionCredentialKind === "accessToken"
+                  ? "•••••••• (replace existing token)"
+                  : "Paste an access token"
+              }
+              autoComplete="off"
+              required
+            />
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              Use this only when your OpenAI Business or Enterprise setup issues a direct access
+              token. It is stored encrypted at rest.
+            </div>
+            <div>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={savingToken || accessToken.trim().length === 0}
+              >
+                {savingToken
+                  ? "Saving…"
+                  : model.subscriptionCredentialKind === "accessToken"
+                    ? "Replace access token"
+                    : "Save access token"}
+              </Button>
+            </div>
+          </form>
+        </details>
+      )}
+    </div>
+  );
 }
 
 function ApiKeyPanel({
@@ -1506,11 +1768,15 @@ function CustomEndpointPanel({
         type="password"
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
-        placeholder={model.customEndpointHasApiKey ? "•••••••• (replace to update)" : "leave blank if not needed"}
+        placeholder={
+          model.customEndpointHasApiKey
+            ? "•••••••• (replace to update)"
+            : "leave blank if not needed"
+        }
       />
       <div className="text-xs text-slate-500 dark:text-slate-400">
-        Point this employee at a self-hosted OpenAI-compatible server. Base URL +
-        key are stored encrypted at rest.
+        Point this employee at a self-hosted OpenAI-compatible server. Base URL + key are stored
+        encrypted at rest.
       </div>
       <div>
         <Button type="submit" disabled={saving || baseURL.length === 0 || modelId.length === 0}>
@@ -1609,9 +1875,7 @@ export function JournalPage() {
   ): Promise<boolean> {
     try {
       const updated = await api.patch<JournalEntryT>(`${base}/journal/${id}`, patch);
-      setEntries((prev) =>
-        prev ? prev.map((e) => (e.id === id ? updated : e)) : prev,
-      );
+      setEntries((prev) => (prev ? prev.map((e) => (e.id === id ? updated : e)) : prev));
       return true;
     } catch (err) {
       toast((err as Error).message, "error");
@@ -1627,9 +1891,10 @@ export function JournalPage() {
           <p className="text-xs text-slate-500 dark:text-slate-400">
             A daily diary of what this employee did. Routine runs land here automatically.
             <strong className="text-slate-700 dark:text-slate-200">
-              {" "}The last 7 days are auto-injected into every chat and routine run
-            </strong>
-            {" "}— they&apos;re how the employee remembers what happened yesterday.
+              {" "}
+              The last 7 days are auto-injected into every chat and routine run
+            </strong>{" "}
+            — they&apos;re how the employee remembers what happened yesterday.
           </p>
           <form onSubmit={addNote} className="mt-3 flex flex-col gap-2">
             <Input
@@ -1759,11 +2024,7 @@ function JournalEntryRow({
             </div>
             {editing && (
               <div className="mt-2 flex gap-1.5">
-                <Button
-                  size="sm"
-                  onClick={save}
-                  disabled={saving || !draftTitle.trim()}
-                >
+                <Button size="sm" onClick={save} disabled={saving || !draftTitle.trim()}>
                   {saving ? "Saving…" : "Save"}
                 </Button>
                 <Button
@@ -1779,20 +2040,10 @@ function JournalEntryRow({
           </div>
           {!editing && (
             <div className="flex shrink-0 gap-1">
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={start}
-                aria-label="Edit entry"
-              >
+              <Button size="sm" variant="ghost" onClick={start} aria-label="Edit entry">
                 <Edit3 size={12} />
               </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={onDelete}
-                aria-label="Delete entry"
-              >
+              <Button size="sm" variant="ghost" onClick={onDelete} aria-label="Delete entry">
                 <Trash2 size={12} />
               </Button>
             </div>
@@ -1856,10 +2107,7 @@ export function MemoryPage() {
     }
   }
 
-  async function update(
-    id: string,
-    patch: { title?: string; body?: string },
-  ): Promise<boolean> {
+  async function update(id: string, patch: { title?: string; body?: string }): Promise<boolean> {
     try {
       const updated = await api.patch<MemoryItem>(`${base}/memory/${id}`, patch);
       setItems((prev) => (prev ? prev.map((x) => (x.id === id ? updated : x)) : prev));
@@ -1893,8 +2141,13 @@ export function MemoryPage() {
         <CardBody>
           <p className="text-xs text-slate-500 dark:text-slate-400">
             Durable facts and preferences this employee should recall in
-            <strong className="text-slate-700 dark:text-slate-200"> every conversation and routine run</strong>
-            . Unlike the free-form Soul, each memory item is a single short fact you can add, edit, or delete without touching the others. {emp.name} can also curate these themselves via MCP tools.
+            <strong className="text-slate-700 dark:text-slate-200">
+              {" "}
+              every conversation and routine run
+            </strong>
+            . Unlike the free-form Soul, each memory item is a single short fact you can add, edit,
+            or delete without touching the others. {emp.name} can also curate these themselves via
+            MCP tools.
           </p>
           <form onSubmit={add} className="mt-3 flex flex-col gap-2">
             <Input
@@ -2020,11 +2273,7 @@ function MemoryRow({
             </div>
             {editing && (
               <div className="mt-2 flex gap-1.5">
-                <Button
-                  size="sm"
-                  onClick={save}
-                  disabled={saving || !draftTitle.trim()}
-                >
+                <Button size="sm" onClick={save} disabled={saving || !draftTitle.trim()}>
                   {saving ? "Saving…" : "Save"}
                 </Button>
                 <Button
@@ -2040,20 +2289,10 @@ function MemoryRow({
           </div>
           {!editing && (
             <div className="flex shrink-0 gap-1">
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={start}
-                aria-label="Edit memory"
-              >
+              <Button size="sm" variant="ghost" onClick={start} aria-label="Edit memory">
                 <Edit3 size={12} />
               </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={onDelete}
-                aria-label="Delete memory"
-              >
+              <Button size="sm" variant="ghost" onClick={onDelete} aria-label="Delete memory">
                 <Trash2 size={12} />
               </Button>
             </div>
@@ -2196,17 +2435,13 @@ function ExternalMcpPanel({ company, emp }: { company: Company; emp: Employee })
     <Card>
       <CardBody className="flex flex-col gap-3">
         <div className="flex items-start gap-2">
-          <ExternalLink
-            size={14}
-            className="mt-0.5 shrink-0 text-slate-500 dark:text-slate-400"
-          />
+          <ExternalLink size={14} className="mt-0.5 shrink-0 text-slate-500 dark:text-slate-400" />
           <div className="min-w-0">
             <div className="text-sm font-medium">Connect an external harness</div>
             <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-              Point any MCP client — Claude Desktop, Cursor, or your own agent —
-              at the URL below to use {emp.name}
-              {"’"}s built-in Genosyn tools over Streamable HTTP.
-              Authenticate with an{" "}
+              Point any MCP client — Claude Desktop, Cursor, or your own agent — at the URL below to
+              use {emp.name}
+              {"’"}s built-in Genosyn tools over Streamable HTTP. Authenticate with an{" "}
               <NavLink
                 to={`/c/${company.slug}/settings/api-keys`}
                 className="underline hover:text-slate-700 dark:hover:text-slate-200"
@@ -2290,10 +2525,7 @@ function NewMcpModal({
         .map((p) => p.trim())
         .filter(Boolean);
       if (guardedTools.length) body.guardedTools = guardedTools;
-      await api.post(
-        `/api/companies/${company.id}/employees/${emp.id}/mcp`,
-        body,
-      );
+      await api.post(`/api/companies/${company.id}/employees/${emp.id}/mcp`, body);
       onCreated();
     } catch (err) {
       toast((err as Error).message, "error");
@@ -2313,15 +2545,13 @@ function NewMcpModal({
           required
         />
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-slate-700 dark:text-slate-200">Transport</label>
+          <label className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Transport
+          </label>
           <div className="flex gap-2">
             {(["stdio", "http"] as const).map((t) => (
               <label key={t} className="flex items-center gap-1.5 text-sm">
-                <input
-                  type="radio"
-                  checked={transport === t}
-                  onChange={() => setTransport(t)}
-                />
+                <input type="radio" checked={transport === t} onChange={() => setTransport(t)} />
                 {t}
               </label>
             ))}
@@ -2374,9 +2604,8 @@ function NewMcpModal({
             placeholder="e.g. ads_create_*, ads_update_*"
           />
           <p className="text-xs text-slate-500 dark:text-slate-400">
-            Tool names matching these patterns (<code>*</code> wildcard) queue a
-            human Approval instead of running. Guard anything that mutates —
-            budget changes, sends, deletes.
+            Tool names matching these patterns (<code>*</code> wildcard) queue a human Approval
+            instead of running. Guard anything that mutates — budget changes, sends, deletes.
           </p>
         </div>
         <div className="flex gap-2">

--- a/App/config.ts
+++ b/App/config.ts
@@ -49,11 +49,14 @@ export const config = {
     bootstrapMasterAdminEmail: "",
   },
 
-  // AI Employee execution controls. `bubblewrap` runs every shell invocation
-  // in a Linux user/mount/PID namespace with only the employee workspace
-  // writable. The runtime image includes bwrap. Shared SaaS mode requires it
-  // and disables network access inside the coding sandbox; networked work goes
-  // through governed Integration, browser, and HTTP surfaces instead.
+  // AI Employee execution controls. `host` preserves the existing local and
+  // Docker deployment behavior. ChatGPT subscription auth is available only
+  // when an operator deliberately selects `bubblewrap` on a Linux deployment
+  // whose user-namespace policy passes Genosyn's startup probe. Bubblewrap runs
+  // every shell invocation and repository Git child in user/mount/PID
+  // namespaces with only the employee workspace writable. Shared SaaS requires
+  // bubblewrap and disables network access inside the coding sandbox; networked
+  // work goes through governed Integration, browser, and HTTP surfaces instead.
   agent: {
     codingTools: {
       enabled: true,

--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -14,6 +14,7 @@
         "@clickhouse/client": "^1.18.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@noble/hashes": "^1.4.0",
+        "@openai/codex": "0.146.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@simplewebauthn/server": "^13.3.2",
         "@types/archiver": "^7.0.0",
@@ -1557,6 +1558,128 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0.tgz",
+      "integrity": "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-arm64.tgz",
+      "integrity": "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-x64.tgz",
+      "integrity": "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-arm64.tgz",
+      "integrity": "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz",
+      "integrity": "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-arm64.tgz",
+      "integrity": "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.146.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-x64.tgz",
+      "integrity": "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@otplib/core": {

--- a/App/package.json
+++ b/App/package.json
@@ -27,6 +27,7 @@
     "@clickhouse/client": "^1.18.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@noble/hashes": "^1.4.0",
+    "@openai/codex": "0.146.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.2",
     "@types/archiver": "^7.0.0",

--- a/App/server/db/entities/AIModel.ts
+++ b/App/server/db/entities/AIModel.ts
@@ -2,20 +2,23 @@ import { dateTimeColumnType } from "./columnTypes.js";
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm";
 
 export type Provider = "anthropic" | "openai" | "custom";
-export type AuthMode = "apikey" | "customEndpoint";
+export type AuthMode = "apikey" | "subscription" | "customEndpoint";
 /** Where `AIModel.contextWindow` came from. Null alongside a null window. */
 export type ContextWindowSource = "probed" | "manual";
 
 /**
  * An AIModel is one of the brains an AI Employee can run on. An employee can
  * register several (`employeeId` is indexed, not unique) and flip exactly one
- * to active at a time via `isActive` — the runner + chat seams talk to the
- * active one's API directly. Credentials are always encrypted in `configJson`:
- * there are no on-disk provider credentials any more.
+ * to active at a time via `isActive`. API-key and custom models run through the
+ * in-process provider loop. OpenAI subscription models run through the pinned
+ * official Codex app-server with the same Genosyn tool registry. Credentials
+ * are always encrypted in `configJson`; a managed ChatGPT session is
+ * materialized only into a private temporary `CODEX_HOME` for login/a turn.
  *
- * `provider` names the model API Genosyn calls in-process:
+ * `provider` names the model backend:
  *   - `anthropic` → the Anthropic Messages API (Claude), authMode `apikey`
- *   - `openai`    → the OpenAI Chat Completions API (GPT), authMode `apikey`
+ *   - `openai`    → the OpenAI API (`apikey`) or official Codex app-server
+ *                   (`subscription`, trusted self-hosted installs only)
  *   - `custom`    → any OpenAI-compatible endpoint (Ollama, vLLM, llama.cpp,
  *                   LM Studio, a gateway), authMode `customEndpoint`
  *
@@ -26,6 +29,9 @@ export type ContextWindowSource = "probed" | "manual";
  *
  * configJson shape:
  *   - apikey:         `{ apiKeyEncrypted, apiKeyPreview }`
+ *   - subscription:   `{ codexAuthEncrypted, subscriptionCredentialKind }`
+ *                     or `{ codexAccessTokenEncrypted,
+ *                           subscriptionCredentialKind }`
  *   - customEndpoint: `{ baseURLEncrypted, baseURLPreview, modelId,
  *                        apiKeyEncrypted?, apiKeyPreview? }`
  * All `*Encrypted` fields are AES-256-GCM via `lib/secret.ts`.

--- a/App/server/mcp/toolManifest.ts
+++ b/App/server/mcp/toolManifest.ts
@@ -1487,7 +1487,7 @@ export const STATIC_TOOLS: McpToolSpec[] = [
   {
     name: "list_code_repositories",
     description:
-      "List the Code Repositories you have been granted access to in this company. Each git repo is already checked out in your working directory at `code-repos/<slug>/`, with credentials and your committer identity configured for you — so you can `cd` into the path and use ordinary `git` to read, branch, commit, and (when your access level is `write`) push. Each row carries the repo name, slug, localPath, defaultBranch, your accessLevel (`read` / `write`), the clone URL, and the last sync status. There is no MCP tool for committing or pushing — do that with `git` inside the checkout.",
+      "List the Code Repositories you have been granted access to in this company. Each row carries the repo name, slug, localPath, defaultBranch, your accessLevel (`read` / `write`), the clone URL, and the last sync status. When coding tools are enabled, Genosyn prepares the checkout and credentials before work starts; bubblewrap deployments isolate that Git process too. There is no MCP tool for committing or pushing — do that with `git` inside the checkout.",
     inputSchema: { type: "object", properties: {}, additionalProperties: false },
   },
   {

--- a/App/server/middleware/validate.ts
+++ b/App/server/middleware/validate.ts
@@ -24,3 +24,15 @@ export function validateBody<T>(schema: ZodSchema<T>) {
     next();
   };
 }
+
+/** Validate and replace route params using the same boundary semantics as bodies. */
+export function validateParams<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.params);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "ValidationError", issues: parsed.error.issues });
+    }
+    req.params = parsed.data as Request["params"];
+    next();
+  };
+}

--- a/App/server/routes/models.ts
+++ b/App/server/routes/models.ts
@@ -4,10 +4,11 @@ import { AppDataSource } from "../db/datasource.js";
 import { AIModel } from "../db/entities/AIModel.js";
 import { AIEmployee } from "../db/entities/AIEmployee.js";
 import { Company } from "../db/entities/Company.js";
-import { validateBody } from "../middleware/validate.js";
+import { validateBody, validateParams } from "../middleware/validate.js";
 import {
   requireAuth,
   requireCompanyMember,
+  requireCompanyRole,
   requireCompanyRoleForMutations,
 } from "../middleware/auth.js";
 import { PROVIDERS, isModelConnected } from "../services/providers.js";
@@ -17,6 +18,17 @@ import { previewBaseURL, readCustomEndpoint } from "../services/customEndpoint.j
 import { canProbeContextWindow, probeContextWindow } from "../services/agent/contextWindow.js";
 import { recordAudit } from "../services/audit.js";
 import { assertSafeOutboundUrl } from "../lib/outboundUrl.js";
+import { config } from "../../config.js";
+import {
+  cancelSubscriptionDeviceLogin,
+  cancelSubscriptionDeviceLoginsForModel,
+  getSubscriptionDeviceLogin,
+  saveSubscriptionAccessToken,
+  startSubscriptionDeviceLogin,
+  SubscriptionCredentialConflictError,
+  subscriptionCredentialKind,
+  subscriptionUnavailableReason,
+} from "../services/codexSubscription.js";
 
 /**
  * Per-employee Model routes, mounted at
@@ -24,10 +36,10 @@ import { assertSafeOutboundUrl } from "../lib/outboundUrl.js";
  *
  * An employee can register several models and keep exactly one active. A model
  * is a direct connection to a model API — Anthropic (Claude), OpenAI (GPT), or a
- * custom OpenAI-compatible endpoint. Credentials are entered here and stored
- * encrypted in `configJson`; there is no CLI to install and no subscription
- * sign-in — those disappeared with the harnesses. `POST /:id/activate` flips
- * which model the runner + chat seams use.
+ * custom OpenAI-compatible endpoint. OpenAI models can also use a ChatGPT
+ * subscription through the pinned official Codex app-server on trusted
+ * self-hosted installs. Every credential remains encrypted in `configJson`.
+ * `POST /:id/activate` flips which model the runner + chat seams use.
  */
 export const modelsRouter = Router({ mergeParams: true });
 modelsRouter.use(requireAuth);
@@ -35,14 +47,22 @@ modelsRouter.use(requireCompanyMember);
 modelsRouter.use(requireCompanyRoleForMutations("admin"));
 
 const providerSchema = z.enum(["anthropic", "openai", "custom"]);
-const authModeSchema = z.enum(["apikey", "customEndpoint"]);
+const authModeSchema = z.enum(["apikey", "subscription", "customEndpoint"]);
+const modelItemParamsSchema = z.object({
+  cid: z.string().uuid(),
+  eid: z.string().uuid(),
+  id: z.string().uuid(),
+});
+const deviceSessionParamsSchema = modelItemParamsSchema.extend({
+  sessionId: z.string().uuid(),
+});
 
 type PublicModel = {
   id: string;
   employeeId: string;
   provider: "anthropic" | "openai" | "custom";
   model: string;
-  authMode: "apikey" | "customEndpoint";
+  authMode: "apikey" | "subscription" | "customEndpoint";
   /** True if this is the brain the runner + chat seams use for the employee. */
   isActive: boolean;
   connectedAt: string | null;
@@ -52,6 +72,15 @@ type PublicModel = {
   apiKeyEnv: string | null;
   /** Does this provider connect with a plain API key? */
   supportsApiKey: boolean;
+  /** Does this provider support the official consumer-subscription runtime? */
+  supportsSubscription: boolean;
+  /** Is subscription auth allowed by this install's security mode? */
+  subscriptionAvailable: boolean;
+  subscriptionUnavailableReason: string | null;
+  /** Which encrypted subscription credential is present, without its value. */
+  subscriptionCredentialKind: "chatgptSession" | "accessToken" | null;
+  /** Whether subscription turns may safely receive the bash coding tool. */
+  subscriptionShellAvailable: boolean;
   /** Does this provider connect via a custom OpenAI-compatible endpoint? */
   supportsCustomEndpoint: boolean;
   /** Host-only preview of the configured base URL — `null` when unset. */
@@ -121,6 +150,14 @@ function toPublic(m: AIModel, isActive: boolean): PublicModel {
     apiKeyMasked: apiKeyEncrypted ? "sk-…••••" : null,
     apiKeyEnv: spec.apiKeyEnv,
     supportsApiKey: spec.supportsApiKey,
+    supportsSubscription: spec.supportsSubscription,
+    subscriptionAvailable: spec.supportsSubscription && subscriptionUnavailableReason() === null,
+    subscriptionUnavailableReason: spec.supportsSubscription
+      ? subscriptionUnavailableReason()
+      : null,
+    subscriptionCredentialKind: subscriptionCredentialKind(m),
+    subscriptionShellAvailable:
+      config.agent.codingTools.enabled && config.agent.codingTools.executionMode === "bubblewrap",
     supportsCustomEndpoint: spec.supportsCustomEndpoint,
     customEndpointHost,
     customEndpointModelId,
@@ -153,7 +190,13 @@ async function refreshContextWindow(m: AIModel): Promise<void> {
   if (found === null || found === m.contextWindow) return;
   m.contextWindow = found;
   m.contextWindowSource = "probed";
-  await AppDataSource.getRepository(AIModel).save(m);
+  await AppDataSource.getRepository(AIModel).update(
+    { id: m.id },
+    {
+      contextWindow: found,
+      contextWindowSource: "probed",
+    },
+  );
 }
 
 /** Shape a single model for the wire, computing its `isActive` live. */
@@ -182,6 +225,15 @@ function unsupportedAuthError(
   const spec = PROVIDERS[provider];
   if (authMode === "apikey" && !spec.supportsApiKey) {
     return `${provider} connects via a custom endpoint, not an API key.`;
+  }
+  if (authMode === "subscription" && !spec.supportsSubscription) {
+    return provider === "anthropic"
+      ? "Anthropic does not allow third-party products to use Claude consumer subscriptions. Use an Anthropic Console API key."
+      : `${provider} does not support subscription authentication.`;
+  }
+  if (authMode === "subscription") {
+    const unavailable = subscriptionUnavailableReason();
+    if (unavailable) return unavailable;
   }
   if (authMode === "customEndpoint" && !spec.supportsCustomEndpoint) {
     return `${provider} connects with an API key, not a custom endpoint.`;
@@ -259,17 +311,41 @@ modelsRouter.put("/:id", validateBody(updateSchema), async (req, res) => {
   if (unsupported) return res.status(400).json({ error: unsupported });
 
   const repo = AppDataSource.getRepository(AIModel);
-  const m = ctx.m;
+  await cancelSubscriptionDeviceLoginsForModel(ctx.m.id);
+  const m = await repo.findOneBy({ id: ctx.m.id, employeeId: ctx.emp.id });
+  if (!m) return res.status(404).json({ error: "Model not found" });
   const changedAuth = m.authMode !== body.authMode || m.provider !== body.provider;
-  m.provider = body.provider;
-  m.model = body.model;
-  m.authMode = body.authMode;
+  const changedModel = m.model !== body.model;
   // If provider or auth mode switched, any prior credentials are invalid.
   if (changedAuth) {
-    m.configJson = "{}";
-    m.connectedAt = null;
+    await repo.update(
+      { id: m.id, employeeId: ctx.emp.id },
+      {
+        provider: body.provider,
+        model: body.model,
+        authMode: body.authMode,
+        configJson: "{}",
+        connectedAt: null,
+        contextWindow: null,
+        contextWindowSource: null,
+      },
+    );
+  } else {
+    // Partial update is load-bearing for managed ChatGPT auth: a concurrent
+    // refresh may rotate its token, and saving this stale entity would restore
+    // the invalid pre-refresh configJson.
+    await repo.update(
+      { id: m.id, employeeId: ctx.emp.id },
+      {
+        provider: body.provider,
+        model: body.model,
+        authMode: body.authMode,
+        ...(changedModel ? { contextWindow: null, contextWindowSource: null } : {}),
+      },
+    );
   }
-  await repo.save(m);
+  const saved = await repo.findOneBy({ id: m.id, employeeId: ctx.emp.id });
+  if (!saved) return res.status(404).json({ error: "Model not found" });
   await recordAudit({
     companyId: ctx.co.id,
     actorUserId: req.userId ?? null,
@@ -277,9 +353,13 @@ modelsRouter.put("/:id", validateBody(updateSchema), async (req, res) => {
     targetType: "employee",
     targetId: ctx.emp.id,
     targetLabel: ctx.emp.name,
-    metadata: { provider: m.provider, model: m.model, authMode: m.authMode },
+    metadata: {
+      provider: saved.provider,
+      model: saved.model,
+      authMode: saved.authMode,
+    },
   });
-  res.json(await publicModel(m, ctx.emp));
+  res.json(await publicModel(saved, ctx.emp));
 });
 
 // POST /api/companies/:cid/employees/:eid/models/:id/activate — switch brain.
@@ -335,6 +415,132 @@ modelsRouter.post("/:id/apikey", validateBody(apiKeySchema), async (req, res) =>
   });
   res.json(await publicModel(m, ctx.emp));
 });
+
+// POST /api/companies/:cid/employees/:eid/models/:id/subscription/device
+//
+// Start OpenAI's managed device-code flow inside an isolated temporary
+// CODEX_HOME. Poll the returned session id below; the service encrypts the
+// completed managed session into this model row and deletes the temporary dir.
+modelsRouter.post(
+  "/:id/subscription/device",
+  validateParams(modelItemParamsSchema),
+  async (req, res) => {
+    const p = req.params as Record<string, string>;
+    const ctx = await loadModelContext(p.cid, p.eid, p.id);
+    if ("error" in ctx) return res.status(404).json({ error: ctx.error });
+    if (ctx.m.provider !== "openai" || ctx.m.authMode !== "subscription") {
+      return res.status(400).json({
+        error: "Only OpenAI AI Models in subscription mode can sign in with ChatGPT.",
+      });
+    }
+    const unavailable = subscriptionUnavailableReason();
+    if (unavailable) return res.status(400).json({ error: unavailable });
+    try {
+      const session = await startSubscriptionDeviceLogin(ctx.m.id, {
+        companyId: ctx.co.id,
+        actorUserId: req.userId!,
+      });
+      await recordAudit({
+        companyId: ctx.co.id,
+        actorUserId: req.userId ?? null,
+        action: "model.subscription.login.start",
+        targetType: "employee",
+        targetId: ctx.emp.id,
+        targetLabel: ctx.emp.name,
+        metadata: { provider: "openai", model: ctx.m.model },
+      });
+      res.json(session);
+    } catch (error) {
+      res.status(502).json({
+        error:
+          error instanceof Error ? error.message : "Could not start ChatGPT subscription sign-in.",
+      });
+    }
+  },
+);
+
+// GET /:id/subscription/device/:sessionId — poll the short-lived login state.
+modelsRouter.get(
+  "/:id/subscription/device/:sessionId",
+  validateParams(deviceSessionParamsSchema),
+  requireCompanyRole("admin"),
+  async (req, res) => {
+    const p = req.params as Record<string, string>;
+    const ctx = await loadModelContext(p.cid, p.eid, p.id);
+    if ("error" in ctx) return res.status(404).json({ error: ctx.error });
+    const session = getSubscriptionDeviceLogin(ctx.m.id, p.sessionId);
+    if (!session) {
+      return res.status(404).json({ error: "Subscription sign-in session not found" });
+    }
+    res.json(session);
+  },
+);
+
+// DELETE /:id/subscription/device/:sessionId — cancel a pending login.
+modelsRouter.delete(
+  "/:id/subscription/device/:sessionId",
+  validateParams(deviceSessionParamsSchema),
+  async (req, res) => {
+    const p = req.params as Record<string, string>;
+    const ctx = await loadModelContext(p.cid, p.eid, p.id);
+    if ("error" in ctx) return res.status(404).json({ error: ctx.error });
+    const session = await cancelSubscriptionDeviceLogin(ctx.m.id, p.sessionId);
+    if (!session) {
+      return res.status(404).json({ error: "Subscription sign-in session not found" });
+    }
+    res.json(session);
+  },
+);
+
+// POST /:id/subscription/access-token
+//
+// Trusted Business/Enterprise automation may receive a supported Codex access
+// token. It is injected as CODEX_ACCESS_TOKEN only into the one short-lived
+// app-server process; unlike the internal chatgptAuthTokens RPC, no external
+// token fields are handed to an unstable protocol method.
+const subscriptionAccessTokenSchema = z.object({
+  accessToken: z.string().trim().min(20).max(16_384),
+});
+
+modelsRouter.post(
+  "/:id/subscription/access-token",
+  validateParams(modelItemParamsSchema),
+  validateBody(subscriptionAccessTokenSchema),
+  async (req, res) => {
+    const p = req.params as Record<string, string>;
+    const ctx = await loadModelContext(p.cid, p.eid, p.id);
+    if ("error" in ctx) return res.status(404).json({ error: ctx.error });
+    const m = ctx.m;
+    if (m.provider !== "openai" || m.authMode !== "subscription") {
+      return res.status(400).json({
+        error: "Only OpenAI AI Models in subscription mode accept a Codex access token.",
+      });
+    }
+    const unavailable = subscriptionUnavailableReason();
+    if (unavailable) return res.status(400).json({ error: unavailable });
+
+    const { accessToken } = req.body as z.infer<typeof subscriptionAccessTokenSchema>;
+    let saved: AIModel;
+    try {
+      saved = await saveSubscriptionAccessToken(m.id, accessToken);
+    } catch (error) {
+      if (!(error instanceof SubscriptionCredentialConflictError)) throw error;
+      return res.status(409).json({
+        error: error.message,
+      });
+    }
+    await recordAudit({
+      companyId: ctx.co.id,
+      actorUserId: req.userId ?? null,
+      action: "model.subscription.accessToken.set",
+      targetType: "employee",
+      targetId: ctx.emp.id,
+      targetLabel: ctx.emp.name,
+      metadata: { provider: "openai", model: m.model },
+    });
+    res.json(await publicModel(saved, ctx.emp));
+  },
+);
 
 // POST /api/companies/:cid/employees/:eid/models/:id/custom-endpoint
 //
@@ -440,11 +646,11 @@ modelsRouter.post("/:id/refresh", async (req, res) => {
   const nowConnected = isModelConnected(m);
   if (nowConnected && !m.connectedAt) {
     m.connectedAt = new Date();
-    await AppDataSource.getRepository(AIModel).save(m);
+    await AppDataSource.getRepository(AIModel).update({ id: m.id }, { connectedAt: m.connectedAt });
   }
   if (!nowConnected && m.connectedAt) {
     m.connectedAt = null;
-    await AppDataSource.getRepository(AIModel).save(m);
+    await AppDataSource.getRepository(AIModel).update({ id: m.id }, { connectedAt: null });
   }
   // Also the operator's retry path when the probe missed at save time (endpoint
   // still booting, GPU host asleep) — cheap enough to just re-ask.
@@ -471,6 +677,11 @@ modelsRouter.put("/:id/context-window", validateBody(contextWindowSchema), async
   const ctx = await loadModelContext(p.cid, p.eid, p.id);
   if ("error" in ctx) return res.status(404).json({ error: ctx.error });
   const m = ctx.m;
+  if (m.authMode === "subscription") {
+    return res.status(400).json({
+      error: "OpenAI Codex manages context for subscription models.",
+    });
+  }
   const { contextWindow } = req.body as z.infer<typeof contextWindowSchema>;
 
   if (contextWindow === null) {
@@ -510,6 +721,7 @@ modelsRouter.delete("/:id", async (req, res) => {
   if ("error" in ctx) return res.status(404).json({ error: ctx.error });
   const repo = AppDataSource.getRepository(AIModel);
   const m = ctx.m;
+  await cancelSubscriptionDeviceLoginsForModel(m.id);
   const remaining = (await repo.find({ where: { employeeId: ctx.emp.id } })).filter(
     (r) => r.id !== m.id,
   );

--- a/App/server/services/agent/bubblewrap.ts
+++ b/App/server/services/agent/bubblewrap.ts
@@ -1,0 +1,102 @@
+import path from "node:path";
+
+export type BubblewrapCommandOptions = {
+  /** Host directory exposed read/write as `/workspace`. */
+  workspaceRoot: string;
+  /** Host working directory, which must be inside `workspaceRoot`. */
+  cwd: string;
+  /** Executable resolved inside the sandbox's explicit PATH. */
+  executable: string;
+  args: string[];
+  /** Complete child environment; bubblewrap clears everything else. */
+  env: Record<string, string>;
+  unshareNetwork?: boolean;
+};
+
+/**
+ * Build the namespace boundary shared by AI Employee shell calls and
+ * server-managed Git. Keeping this in one place prevents repository
+ * materialization from becoming a same-UID escape around the coding sandbox.
+ */
+export function buildBubblewrapCommandArgs(options: BubblewrapCommandOptions): string[] {
+  const root = path.resolve(options.workspaceRoot);
+  const cwd = path.resolve(options.cwd);
+  const relativeCwd = path.relative(root, cwd);
+  if (
+    relativeCwd === ".." ||
+    relativeCwd.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeCwd)
+  ) {
+    throw new Error("Bubblewrap working directory must stay inside the workspace.");
+  }
+
+  const sandboxCwd =
+    relativeCwd.length === 0 ? "/workspace" : `/workspace/${relativeCwd.split(path.sep).join("/")}`;
+  const args = [
+    "--die-with-parent",
+    "--new-session",
+    "--unshare-user",
+    "--unshare-pid",
+    "--unshare-ipc",
+    "--unshare-uts",
+    "--unshare-cgroup",
+    "--proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--tmpfs",
+    "/tmp",
+    "--ro-bind",
+    "/bin",
+    "/bin",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind-try",
+    "/lib",
+    "/lib",
+    "--ro-bind-try",
+    "/lib64",
+    "/lib64",
+    "--ro-bind-try",
+    "/etc/ssl",
+    "/etc/ssl",
+    "--ro-bind-try",
+    "/etc/ca-certificates",
+    "/etc/ca-certificates",
+    "--ro-bind-try",
+    "/etc/ssh",
+    "/etc/ssh",
+    "--ro-bind-try",
+    "/etc/hosts",
+    "/etc/hosts",
+    "--ro-bind-try",
+    "/etc/resolv.conf",
+    "/etc/resolv.conf",
+    "--ro-bind-try",
+    "/etc/nsswitch.conf",
+    "/etc/nsswitch.conf",
+    "--ro-bind-try",
+    "/etc/passwd",
+    "/etc/passwd",
+    "--ro-bind-try",
+    "/etc/group",
+    "/etc/group",
+    "--bind",
+    root,
+    "/workspace",
+    "--chdir",
+    sandboxCwd,
+    "--clearenv",
+  ];
+  if (options.unshareNetwork) args.push("--unshare-net");
+
+  for (const [name, value] of Object.entries(options.env)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || value.includes("\0")) {
+      throw new Error(`Invalid bubblewrap environment entry: ${name}`);
+    }
+    args.push("--setenv", name, value);
+  }
+  args.push("--", options.executable, ...options.args);
+  return args;
+}

--- a/App/server/services/agent/codexAppServer.test.ts
+++ b/App/server/services/agent/codexAppServer.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { CodexAppServer } from "./codexAppServer.js";
+
+const FAKE_SERVER = String.raw`
+import readline from "node:readline";
+
+const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+const waiting = new Map();
+const send = (value) => process.stdout.write(JSON.stringify(value) + "\n");
+
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({
+      id: message.id,
+      result: {
+        userAgent: "fake",
+        codexHome: process.env.CODEX_HOME,
+        platformFamily: "test",
+        platformOs: "test",
+      },
+    });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.method === "notifyMe") {
+    send({ id: message.id, result: {} });
+    send({ method: "fake/ready", params: { ok: true } });
+    return;
+  }
+  if (message.method === "echo") {
+    send({ id: message.id, result: message.params });
+    return;
+  }
+  if (message.method === "badJsonHang") {
+    process.stdout.write("not-json\n");
+    setInterval(() => undefined, 1000);
+    return;
+  }
+  if (message.method === "triggerTool") {
+    waiting.set(700, { requestId: message.id, kind: "tool" });
+    send({
+      id: 700,
+      method: "item/tool/call",
+      params: {
+        threadId: "thread",
+        turnId: "turn",
+        callId: "call",
+        namespace: null,
+        tool: "lookup",
+        arguments: { id: "ABC" },
+      },
+    });
+    return;
+  }
+  if (message.method === "triggerDenied") {
+    waiting.set(701, { requestId: message.id, kind: "denied" });
+    send({
+      id: 701,
+      method: "item/fileChange/requestApproval",
+      params: { threadId: "thread", turnId: "turn" },
+    });
+    return;
+  }
+  if (waiting.has(message.id)) {
+    const pending = waiting.get(message.id);
+    waiting.delete(message.id);
+    send({
+      id: pending.requestId,
+      result:
+        pending.kind === "tool"
+          ? message.result
+          : { denied: Boolean(message.error), errorCode: message.error?.code ?? null },
+    });
+  }
+});
+`;
+
+test("Codex app-server transport performs the handshake and streams notifications", async () => {
+  await withFakeServer(async ({ entrypoint, home, cwd }) => {
+    const notifications: string[] = [];
+    const server = await CodexAppServer.start({
+      entrypoint,
+      cwd,
+      env: { PATH: process.env.PATH, CODEX_HOME: home, HOME: home },
+    });
+    const stop = server.onNotification((method) => notifications.push(method));
+    const echoed = await server.request<{ value: number }>("echo", { value: 42 });
+    assert.deepEqual(echoed, { value: 42 });
+    await server.request("notifyMe");
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(notifications, ["fake/ready"]);
+    stop();
+    await server.close();
+  });
+});
+
+test("Codex app-server routes dynamic calls and fails closed on other requests", async () => {
+  await withFakeServer(async ({ entrypoint, home, cwd }) => {
+    const seen: string[] = [];
+    const server = await CodexAppServer.start({
+      entrypoint,
+      cwd,
+      env: { PATH: process.env.PATH, CODEX_HOME: home, HOME: home },
+      onServerRequest: async (method, params) => {
+        seen.push(method);
+        if (method !== "item/tool/call") throw new Error("denied");
+        return {
+          contentItems: [{ type: "inputText", text: JSON.stringify(params) }],
+          success: true,
+        };
+      },
+    });
+
+    const tool = await server.request<{ success: boolean }>("triggerTool");
+    assert.equal(tool.success, true);
+    const denied = await server.request<{ denied: boolean; errorCode: number }>("triggerDenied");
+    assert.deepEqual(denied, { denied: true, errorCode: -32000 });
+    assert.deepEqual(seen, ["item/tool/call", "item/fileChange/requestApproval"]);
+    await server.close();
+  });
+});
+
+test("protocol failures terminate a child that would otherwise stay alive", async () => {
+  await withFakeServer(async ({ entrypoint, home, cwd }) => {
+    const server = await CodexAppServer.start({
+      entrypoint,
+      cwd,
+      env: { PATH: process.env.PATH, CODEX_HOME: home, HOME: home },
+    });
+    await assert.rejects(server.request("badJsonHang"), /emitted invalid JSON/);
+    await server.close();
+  });
+});
+
+async function withFakeServer(
+  run: (paths: { entrypoint: string; home: string; cwd: string }) => Promise<void>,
+): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "genosyn-codex-test-"));
+  const home = path.join(root, "home");
+  const cwd = path.join(root, "work");
+  const entrypoint = path.join(root, "fake-app-server.mjs");
+  await fs.mkdir(home, { mode: 0o700 });
+  await fs.mkdir(cwd, { mode: 0o700 });
+  await fs.writeFile(entrypoint, FAKE_SERVER, { mode: 0o600 });
+  try {
+    await run({ entrypoint, home, cwd });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}

--- a/App/server/services/agent/codexAppServer.ts
+++ b/App/server/services/agent/codexAppServer.ts
@@ -1,0 +1,457 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+
+const MAX_STDOUT_BUFFER = 32 * 1024 * 1024;
+const MAX_STDERR_BUFFER = 64 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const CLOSE_TERM_MS = 1_000;
+const CLOSE_KILL_MS = 3_000;
+const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+type JsonObject = Record<string, unknown>;
+type JsonRpcId = number | string;
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type NotificationHandler = (method: string, params: unknown) => void;
+type ServerRequestHandler = (method: string, params: unknown) => Promise<unknown>;
+
+export type CodexAppServerOptions = {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  /** Config overrides use the same `key=value` syntax as `codex -c`. */
+  configOverrides?: string[];
+  requestTimeoutMs?: number;
+  onServerRequest?: ServerRequestHandler;
+  /** Test seam; production resolves the pinned `@openai/codex` entry point. */
+  entrypoint?: string;
+};
+
+export class CodexAppServerError extends Error {
+  readonly code: number | string | null;
+  readonly data: unknown;
+
+  constructor(message: string, code: number | string | null = null, data?: unknown) {
+    super(message);
+    this.name = "CodexAppServerError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+/**
+ * Minimal JSONL client for the official `codex app-server` protocol.
+ *
+ * The process is deliberately short-lived. Callers provide an isolated
+ * `CODEX_HOME`, use ephemeral threads, and close the server after one login or
+ * AI Employee turn. This class owns only transport concerns; credential
+ * materialization and Genosyn tool dispatch live in the sibling services.
+ */
+export class CodexAppServer {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly requestTimeoutMs: number;
+  private readonly onServerRequest?: ServerRequestHandler;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private readonly notifications = new Set<NotificationHandler>();
+  private readonly exits = new Set<(error: Error | null) => void>();
+  private nextId = 1;
+  private stdoutBuffer = "";
+  private stderrBuffer = "";
+  private closed = false;
+  private processExited = false;
+  private exitError: Error | null = null;
+  private readonly exited: Promise<void>;
+  private resolveExited!: () => void;
+
+  private constructor(child: ChildProcessWithoutNullStreams, options: CodexAppServerOptions) {
+    this.child = child;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.onServerRequest = options.onServerRequest;
+    this.exited = new Promise<void>((resolve) => {
+      this.resolveExited = resolve;
+    });
+    this.attachProcessListeners();
+  }
+
+  static async start(options: CodexAppServerOptions): Promise<CodexAppServer> {
+    const entrypoint = options.entrypoint ?? resolveCodexEntrypoint();
+    const args = ["app-server", "--stdio", "--strict-config"];
+    for (const override of options.configOverrides ?? []) {
+      args.push("-c", override);
+    }
+
+    const child = spawn(process.execPath, [entrypoint, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    });
+    const server = new CodexAppServer(child, options);
+
+    try {
+      const initialized = await server.request<{ codexHome?: string }>(
+        "initialize",
+        {
+          clientInfo: {
+            name: "genosyn",
+            title: "Genosyn",
+            version: process.env.APP_VERSION || "dev",
+          },
+          capabilities: {
+            experimentalApi: true,
+            requestAttestation: false,
+          },
+        },
+        20_000,
+      );
+      if (options.env.CODEX_HOME) {
+        const [expectedHome, reportedHome] = await Promise.all([
+          fs.realpath(options.env.CODEX_HOME),
+          typeof initialized.codexHome === "string"
+            ? fs.realpath(initialized.codexHome)
+            : Promise.resolve(""),
+        ]);
+        if (!reportedHome || reportedHome !== expectedHome) {
+          throw new CodexAppServerError(
+            "OpenAI Codex app-server did not honor Genosyn's isolated CODEX_HOME.",
+            "CODEX_HOME_MISMATCH",
+          );
+        }
+      }
+      await server.notify("initialized");
+      return server;
+    } catch (error) {
+      await server.close();
+      throw error;
+    }
+  }
+
+  async request<T>(
+    method: string,
+    params: unknown = {},
+    timeoutMs = this.requestTimeoutMs,
+  ): Promise<T> {
+    this.assertOpen();
+    const id = this.nextId++;
+
+    const response = new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new CodexAppServerError(
+            `OpenAI Codex app-server timed out waiting for ${method}.`,
+            "TIMEOUT",
+          ),
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+        timer,
+      });
+    });
+
+    try {
+      await this.writeMessage({ id, method, params });
+    } catch (error) {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        pending.reject(asError(error));
+      }
+    }
+    return response;
+  }
+
+  async notify(method: string, params?: unknown): Promise<void> {
+    this.assertOpen();
+    await this.writeMessage(params === undefined ? { method } : { method, params });
+  }
+
+  onNotification(handler: NotificationHandler): () => void {
+    this.notifications.add(handler);
+    return () => this.notifications.delete(handler);
+  }
+
+  onExit(handler: (error: Error | null) => void): () => void {
+    this.exits.add(handler);
+    if (this.processExited) queueMicrotask(() => handler(this.exitError));
+    return () => this.exits.delete(handler);
+  }
+
+  stderrSummary(): string {
+    return cleanDiagnostic(this.stderrBuffer);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      await this.exited;
+      return;
+    }
+
+    this.closed = true;
+    if (!this.child.stdin.destroyed) this.child.stdin.end();
+    const terminate = setTimeout(() => {
+      if (this.child.exitCode === null && this.child.signalCode === null) {
+        signalChild(this.child, "SIGTERM");
+      }
+    }, CLOSE_TERM_MS);
+    const force = setTimeout(() => {
+      if (this.child.exitCode === null && this.child.signalCode === null) {
+        signalChild(this.child, "SIGKILL");
+      }
+    }, CLOSE_KILL_MS);
+    terminate.unref?.();
+    force.unref?.();
+    await this.exited;
+    clearTimeout(terminate);
+    clearTimeout(force);
+  }
+
+  private attachProcessListeners(): void {
+    this.child.stdout.setEncoding("utf8");
+    this.child.stderr.setEncoding("utf8");
+
+    this.child.stdout.on("data", (chunk: string) => this.consumeStdout(chunk));
+    this.child.stderr.on("data", (chunk: string) => {
+      this.stderrBuffer = appendCapped(this.stderrBuffer, chunk, MAX_STDERR_BUFFER);
+    });
+    this.child.on("error", (error) => {
+      this.fail(error);
+      void this.close();
+    });
+    this.child.on("close", (code, signal) => {
+      let error: Error | null = null;
+      if (!this.closed) {
+        const detail = this.stderrSummary();
+        error = new CodexAppServerError(
+          `OpenAI Codex app-server exited unexpectedly (${signal ?? `code ${code ?? "unknown"}`})${
+            detail ? `: ${detail}` : "."
+          }`,
+          code,
+        );
+      }
+      this.finalizeProcessExit(error);
+    });
+  }
+
+  private consumeStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    if (this.stdoutBuffer.length > MAX_STDOUT_BUFFER) {
+      this.failAndClose(
+        new CodexAppServerError(
+          "OpenAI Codex app-server emitted an oversized protocol message.",
+          "MESSAGE_TOO_LARGE",
+        ),
+      );
+      return;
+    }
+
+    for (;;) {
+      const newline = this.stdoutBuffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+
+      let message: unknown;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        this.failAndClose(
+          new CodexAppServerError("OpenAI Codex app-server emitted invalid JSON.", "INVALID_JSON"),
+        );
+        return;
+      }
+      this.handleMessage(message);
+    }
+  }
+
+  private handleMessage(value: unknown): void {
+    const message = asObject(value);
+    if (!message) return;
+
+    const id = rpcId(message.id);
+    const method = typeof message.method === "string" ? message.method : null;
+    if (id !== null && !method) {
+      const pending = this.pending.get(id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+      const error = asObject(message.error);
+      if (error) {
+        pending.reject(
+          new CodexAppServerError(
+            typeof error.message === "string" ? error.message : "OpenAI Codex request failed.",
+            typeof error.code === "number" || typeof error.code === "string" ? error.code : null,
+            error.data,
+          ),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if (!method) return;
+    if (id !== null) {
+      void this.handleServerRequest(id, method, message.params);
+      return;
+    }
+    for (const handler of this.notifications) {
+      try {
+        handler(method, message.params);
+      } catch {
+        // A UI/logging callback must never break the protocol reader.
+      }
+    }
+  }
+
+  private async handleServerRequest(id: JsonRpcId, method: string, params: unknown): Promise<void> {
+    if (!this.onServerRequest) {
+      await this.writeMessage({
+        id,
+        error: { code: -32601, message: `Unsupported server request: ${method}` },
+      }).catch(() => undefined);
+      return;
+    }
+
+    try {
+      const result = await this.onServerRequest(method, params);
+      await this.writeMessage({ id, result });
+    } catch (error) {
+      await this.writeMessage({
+        id,
+        error: {
+          code: -32000,
+          message: safeErrorMessage(error),
+        },
+      }).catch(() => undefined);
+    }
+  }
+
+  private async writeMessage(message: JsonObject): Promise<void> {
+    this.assertOpen();
+    const line = `${JSON.stringify(message)}\n`;
+    if (this.child.stdin.write(line)) return;
+    await new Promise<void>((resolve, reject) => {
+      const onDrain = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      const onClose = () => {
+        cleanup();
+        reject(
+          this.exitError ??
+            new CodexAppServerError("OpenAI Codex app-server closed while writing a request."),
+        );
+      };
+      const cleanup = () => {
+        this.child.stdin.off("drain", onDrain);
+        this.child.stdin.off("error", onError);
+        this.child.stdin.off("close", onClose);
+      };
+      this.child.stdin.once("drain", onDrain);
+      this.child.stdin.once("error", onError);
+      this.child.stdin.once("close", onClose);
+    });
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw this.exitError ?? new CodexAppServerError("OpenAI Codex app-server is closed.");
+    }
+  }
+
+  private fail(error: Error): void {
+    this.exitError = this.exitError ?? error;
+    this.rejectPending(this.exitError);
+  }
+
+  private failAndClose(error: Error): void {
+    this.fail(error);
+    void this.close();
+  }
+
+  private finalizeProcessExit(error: Error | null): void {
+    if (this.processExited) return;
+    this.processExited = true;
+    this.closed = true;
+    this.exitError = this.exitError ?? error;
+    const reason =
+      this.exitError ??
+      new CodexAppServerError("OpenAI Codex app-server closed before the request completed.");
+    this.rejectPending(reason);
+    for (const handler of this.exits) {
+      try {
+        handler(this.exitError);
+      } catch {
+        // Exit observers are advisory.
+      }
+    }
+    this.resolveExited();
+  }
+
+  private rejectPending(reason: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(reason);
+    }
+    this.pending.clear();
+  }
+}
+
+function signalChild(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back to the direct child if its process group already changed.
+    }
+  }
+  child.kill(signal);
+}
+
+function resolveCodexEntrypoint(): string {
+  const require = createRequire(import.meta.url);
+  return require.resolve("@openai/codex/bin/codex.js");
+}
+
+function asObject(value: unknown): JsonObject | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : null;
+}
+
+function rpcId(value: unknown): JsonRpcId | null {
+  return typeof value === "number" || typeof value === "string" ? value : null;
+}
+
+function appendCapped(current: string, next: string, cap: number): string {
+  const combined = current + next;
+  return combined.length <= cap ? combined : combined.slice(combined.length - cap);
+}
+
+function cleanDiagnostic(value: string): string {
+  return value.replace(ANSI_ESCAPE, "").replace(/\s+/g, " ").trim().slice(0, 1_000);
+}
+
+function safeErrorMessage(error: unknown): string {
+  return asError(error).message.replace(/\s+/g, " ").trim().slice(0, 1_000);
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/App/server/services/agent/codexRuntime.test.ts
+++ b/App/server/services/agent/codexRuntime.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertCodexThreadPosture } from "./codexRuntime.js";
+
+const expected = { cwd: "/tmp/genosyn-work", model: "gpt-5.6-terra" };
+const safeResponse = {
+  thread: {
+    id: "thread-id",
+    cwd: expected.cwd,
+    ephemeral: true,
+    parentThreadId: null,
+  },
+  model: expected.model,
+  modelProvider: "openai",
+  cwd: expected.cwd,
+  approvalPolicy: "never",
+  sandbox: { type: "readOnly", networkAccess: false },
+  runtimeWorkspaceRoots: [],
+  instructionSources: [],
+};
+
+test("subscription turns verify the app-server isolation posture", () => {
+  assert.equal(assertCodexThreadPosture(safeResponse, expected), "thread-id");
+  assert.throws(
+    () =>
+      assertCodexThreadPosture(
+        {
+          ...safeResponse,
+          sandbox: { type: "workspaceWrite", networkAccess: true },
+        },
+        expected,
+      ),
+    /did not honor Genosyn's requested thread isolation/,
+  );
+  assert.throws(
+    () =>
+      assertCodexThreadPosture(
+        {
+          ...safeResponse,
+          instructionSources: ["/workspace/AGENTS.md"],
+        },
+        expected,
+      ),
+    /did not honor Genosyn's requested thread isolation/,
+  );
+});

--- a/App/server/services/agent/codexRuntime.ts
+++ b/App/server/services/agent/codexRuntime.ts
@@ -1,0 +1,592 @@
+import type { AIModel } from "../../db/entities/AIModel.js";
+import {
+  CODEX_CONFIG_OVERRIDES,
+  prepareCodexRuntime,
+  withSubscriptionModelLock,
+} from "../codexSubscription.js";
+import { CodexAppServer, CodexAppServerError } from "./codexAppServer.js";
+import { toolResultCap } from "./contextBudget.js";
+import type { ToolRegistry } from "./tools/toolRegistry.js";
+import type { AgentMessage, AgentTool, StreamCallbacks, ToolResult, TurnUsage } from "./types.js";
+
+type JsonObject = Record<string, unknown>;
+
+const ALLOWED_CODEX_ITEM_TYPES = new Set([
+  "userMessage",
+  "agentMessage",
+  "plan",
+  "reasoning",
+  "dynamicToolCall",
+  "contextCompaction",
+]);
+const SUBSCRIPTION_TURN_DEADLINE_MS = 6 * 60 * 60 * 1_000;
+
+type DynamicToolCallParams = {
+  threadId: string;
+  turnId: string;
+  callId: string;
+  namespace: string | null;
+  tool: string;
+  arguments: unknown;
+};
+
+type DynamicToolCallResponse = {
+  contentItems: Array<
+    { type: "inputText"; text: string } | { type: "inputImage"; imageUrl: string }
+  >;
+  success: boolean;
+};
+
+export type CodexSubscriptionResult = {
+  finalText: string;
+  steps: number;
+};
+
+/**
+ * Execute one AI Employee turn through OpenAI's official Codex app-server.
+ *
+ * Only the resident portion of Genosyn's existing ToolRegistry is advertised.
+ * That resident set already includes `find_tools` and `call_tool`, whose bound
+ * closures can resolve the deferred catalogue exactly as the direct API loop
+ * does. No second permission or dispatch implementation is introduced here.
+ */
+export async function runCodexSubscriptionTurn(params: {
+  model: AIModel;
+  system: string;
+  messages: AgentMessage[];
+  registry: ToolRegistry;
+  maxSteps: number;
+  signal?: AbortSignal;
+  callbacks?: StreamCallbacks;
+}): Promise<CodexSubscriptionResult> {
+  return withSubscriptionModelLock(params.model.id, params.signal, async () => {
+    const lease = await prepareCodexRuntime(params.model.id);
+    const effectiveModel = lease.model;
+    let server: CodexAppServer | null = null;
+    let toolCalls = 0;
+    let threadId: string | null = null;
+    let turnId: string | null = null;
+    let disallowedItemType: string | null = null;
+    let finalText = "";
+    let lastUsageFingerprint = "";
+    let terminalError: Error | null = null;
+    let runawayViolation: string | null = null;
+    const streamedByItem = new Map<string, string>();
+    const completedMessages: Array<{ text: string; phase: string | null }> = [];
+    const completion = deferred<void>();
+
+    try {
+      server = await CodexAppServer.start({
+        cwd: lease.home.workspace,
+        env: lease.env,
+        configOverrides: [...CODEX_CONFIG_OVERRIDES],
+        onServerRequest: async (method, requestParams) => {
+          if (method !== "item/tool/call") {
+            throw new CodexAppServerError(
+              `Genosyn denied unsupported Codex server request: ${method}`,
+              "REQUEST_DENIED",
+            );
+          }
+          const call = parseDynamicToolCall(requestParams);
+          if (threadId && call.threadId !== threadId) {
+            throw new Error("Codex sent a tool call for the wrong thread.");
+          }
+          if (turnId && call.turnId !== turnId) {
+            throw new Error("Codex sent a tool call for the wrong turn.");
+          }
+          toolCalls += 1;
+          if (toolCalls > Math.max(1, params.maxSteps)) {
+            runawayViolation =
+              `Genosyn stopped this turn after ${params.maxSteps} tool calls ` +
+              "to prevent a runaway loop.";
+            interruptActiveTurn(server, threadId, turnId);
+            completion.resolve(undefined);
+            return toolFailure(runawayViolation);
+          }
+          return invokeRegistryTool(
+            params.registry,
+            call,
+            effectiveModel.contextWindow,
+            params.callbacks,
+          );
+        },
+      });
+
+      const stopNotifications = server.onNotification((method, raw) => {
+        const body = asObject(raw);
+        if (!body) return;
+        if (!matchesActiveTurn(body, threadId, turnId)) return;
+
+        if (method === "item/agentMessage/delta") {
+          const itemId = stringField(body, "itemId");
+          const delta = stringField(body, "delta");
+          if (!itemId || delta === null) return;
+          streamedByItem.set(itemId, (streamedByItem.get(itemId) ?? "") + delta);
+          safeCallback(() => params.callbacks?.onText?.(delta));
+          return;
+        }
+
+        if (method === "item/completed") {
+          const item = asObject(body.item);
+          const type = stringField(item, "type");
+          if (type === "agentMessage") {
+            const text = stringField(item, "text") ?? "";
+            const itemId = stringField(item, "id") ?? "";
+            const streamed = streamedByItem.get(itemId) ?? "";
+            if (text && text.startsWith(streamed) && text.length > streamed.length) {
+              const missing = text.slice(streamed.length);
+              safeCallback(() => params.callbacks?.onText?.(missing));
+            } else if (text && !streamed) {
+              safeCallback(() => params.callbacks?.onText?.(text));
+            }
+            if (text) {
+              completedMessages.push({
+                text,
+                phase: stringField(item, "phase"),
+              });
+            }
+            return;
+          }
+          if (!isAllowedCodexItemType(type)) {
+            disallowedItemType = type ?? "unknown";
+            interruptActiveTurn(server, threadId, turnId);
+            completion.resolve(undefined);
+          }
+          return;
+        }
+
+        if (method === "item/started") {
+          const item = asObject(body.item);
+          const type = stringField(item, "type");
+          if (!isAllowedCodexItemType(type)) {
+            disallowedItemType = type ?? "unknown";
+            interruptActiveTurn(server, threadId, turnId);
+            completion.resolve(undefined);
+          }
+          return;
+        }
+
+        if (method === "thread/tokenUsage/updated") {
+          const usage = asObject(body.tokenUsage);
+          const total = asObject(usage?.total);
+          const last = asObject(usage?.last);
+          const inputTokens = numberField(last, "inputTokens");
+          const outputTokens = numberField(last, "outputTokens");
+          if (inputTokens !== null && outputTokens !== null) {
+            const fingerprint = JSON.stringify(total ?? last);
+            if (fingerprint !== lastUsageFingerprint) {
+              lastUsageFingerprint = fingerprint;
+              const reported: TurnUsage = { inputTokens, outputTokens };
+              safeCallback(() => params.callbacks?.onUsage?.(reported));
+            }
+          }
+          return;
+        }
+
+        if (method === "error" && body.willRetry !== true) {
+          const detail = asObject(body.error);
+          terminalError = new CodexAppServerError(
+            stringField(detail, "message") || "OpenAI Codex reported a terminal error.",
+            stringField(detail, "codexErrorInfo"),
+            detail,
+          );
+          return;
+        }
+
+        if (method === "turn/completed") {
+          const turn = asObject(body.turn);
+          const status = stringField(turn, "status");
+          if (status === "completed") {
+            completion.resolve(undefined);
+            return;
+          }
+          if (status === "interrupted" && (disallowedItemType || runawayViolation)) {
+            completion.resolve(undefined);
+            return;
+          }
+          const error = asObject(turn?.error);
+          completion.reject(
+            terminalError ??
+              new CodexAppServerError(
+                stringField(error, "message") ||
+                  (status === "interrupted"
+                    ? "The OpenAI subscription turn was interrupted."
+                    : "The OpenAI subscription turn failed."),
+                status,
+                error,
+              ),
+          );
+        }
+      });
+
+      const started = await server.request<unknown>(
+        "thread/start",
+        {
+          model: effectiveModel.model,
+          modelProvider: "openai",
+          allowProviderModelFallback: false,
+          cwd: lease.home.workspace,
+          approvalPolicy: "never",
+          sandbox: "read-only",
+          baseInstructions: [
+            "You are the runtime for a Genosyn AI Employee.",
+            "Follow the developer instructions and continue the supplied conversation.",
+            "Use only the dynamic tools supplied by Genosyn. Native shell, file-editing, web, app, plugin, skill, memory, goal, and multi-agent tools are disabled.",
+            "A tool's result is authoritative. Never claim an external action succeeded unless its tool result says it did.",
+          ].join("\n"),
+          developerInstructions: params.system,
+          personality: "none",
+          ephemeral: true,
+          environments: [],
+          runtimeWorkspaceRoots: [],
+          selectedCapabilityRoots: [],
+          dynamicTools: params.registry.resident.map(dynamicToolSpec),
+          serviceName: "genosyn",
+          threadSource: "genosyn",
+        },
+        30_000,
+      );
+      threadId = assertCodexThreadPosture(started, {
+        cwd: lease.home.workspace,
+        model: effectiveModel.model,
+      });
+
+      if (params.signal?.aborted) throw abortError();
+      const conversation = splitConversation(params.messages);
+      if (conversation.history.length > 0) {
+        await server.request(
+          "thread/inject_items",
+          {
+            threadId,
+            items: conversation.history,
+          },
+          30_000,
+        );
+      }
+      const turnStarted = await server.request<{ turn: { id: string } }>(
+        "turn/start",
+        {
+          threadId,
+          input: [
+            {
+              type: "text",
+              text: conversation.current,
+              text_elements: [],
+            },
+          ],
+          approvalPolicy: "never",
+        },
+        30_000,
+      );
+      if (!turnStarted.turn?.id) {
+        throw new Error("OpenAI Codex did not return a turn id.");
+      }
+      turnId = turnStarted.turn.id;
+      if (disallowedItemType || runawayViolation) {
+        interruptActiveTurn(server, threadId, turnId);
+      }
+
+      const onAbort = () => {
+        interruptActiveTurn(server, threadId, turnId);
+        completion.reject(abortError());
+      };
+      const stopExit = server.onExit((error) => {
+        completion.reject(
+          error ??
+            new CodexAppServerError(
+              "OpenAI Codex app-server closed before the turn completed.",
+              "PROCESS_EXIT",
+            ),
+        );
+      });
+      const deadline = setTimeout(() => {
+        interruptActiveTurn(server, threadId, turnId);
+        completion.reject(
+          new CodexAppServerError(
+            "OpenAI Codex subscription turn exceeded its hard runtime limit.",
+            "TURN_DEADLINE",
+          ),
+        );
+      }, SUBSCRIPTION_TURN_DEADLINE_MS);
+      deadline.unref?.();
+      params.signal?.addEventListener("abort", onAbort, { once: true });
+      if (params.signal?.aborted) onAbort();
+      try {
+        await completion.promise;
+      } finally {
+        clearTimeout(deadline);
+        params.signal?.removeEventListener("abort", onAbort);
+        stopExit();
+        stopNotifications();
+      }
+
+      if (disallowedItemType) {
+        throw new Error(
+          `OpenAI Codex attempted the disallowed ${disallowedItemType} item. Genosyn stopped the turn before allowing native workspace access.`,
+        );
+      }
+      if (runawayViolation) throw new Error(runawayViolation);
+
+      finalText =
+        [...completedMessages]
+          .reverse()
+          .find((message) => message.phase === "final_answer" && message.text.trim().length > 0)
+          ?.text.trim() ??
+        [...completedMessages]
+          .reverse()
+          .find((message) => message.text.trim().length > 0)
+          ?.text.trim() ??
+        [...streamedByItem.values()]
+          .reverse()
+          .find((text) => text.trim().length > 0)
+          ?.trim() ??
+        "";
+      return {
+        finalText: finalText || "(no reply)",
+        steps: Math.max(1, toolCalls + 1),
+      };
+    } finally {
+      await server?.close().catch(() => undefined);
+      await lease.finish();
+    }
+  });
+}
+
+export function assertCodexThreadPosture(
+  value: unknown,
+  expected: { cwd: string; model: string },
+): string {
+  const response = asObject(value);
+  const thread = asObject(response?.thread);
+  const sandbox = asObject(response?.sandbox);
+  const runtimeRoots = response?.runtimeWorkspaceRoots;
+  const instructionSources = response?.instructionSources;
+  if (!thread || !sandbox) {
+    throw new Error("OpenAI Codex app-server did not honor Genosyn's requested thread isolation.");
+  }
+  const threadId = typeof thread.id === "string" && thread.id.length > 0 ? thread.id : null;
+  const valid =
+    threadId !== null &&
+    thread.ephemeral === true &&
+    thread.parentThreadId === null &&
+    response?.model === expected.model &&
+    response?.modelProvider === "openai" &&
+    response?.cwd === expected.cwd &&
+    thread.cwd === expected.cwd &&
+    response?.approvalPolicy === "never" &&
+    sandbox?.type === "readOnly" &&
+    sandbox.networkAccess === false &&
+    Array.isArray(runtimeRoots) &&
+    runtimeRoots.length === 0 &&
+    Array.isArray(instructionSources) &&
+    instructionSources.length === 0;
+  if (!valid) {
+    throw new Error("OpenAI Codex app-server did not honor Genosyn's requested thread isolation.");
+  }
+  return threadId;
+}
+
+function dynamicToolSpec(tool: AgentTool): JsonObject {
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(tool.name)) {
+    throw new Error(`Genosyn tool name is not valid for OpenAI Codex: ${tool.name}`);
+  }
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    deferLoading: false,
+  };
+}
+
+async function invokeRegistryTool(
+  registry: ToolRegistry,
+  call: DynamicToolCallParams,
+  contextWindow: number | null,
+  callbacks?: StreamCallbacks,
+): Promise<DynamicToolCallResponse> {
+  if (call.namespace !== null) {
+    return toolFailure(`Unknown Genosyn tool namespace: ${call.namespace}`);
+  }
+  const tool = registry.resolve(call.tool);
+  if (!tool) return toolFailure(`Unknown Genosyn tool: ${call.tool}`);
+  const input = asObject(call.arguments);
+  if (!input) return toolFailure(`Tool ${call.tool} requires a JSON object.`);
+
+  let described = { name: tool.name, input };
+  try {
+    described = tool.describeCall?.(input) ?? described;
+  } catch {
+    // Logging metadata must not prevent the actual tool call.
+  }
+  safeCallback(() => callbacks?.onToolUse?.(described.name, described.input));
+
+  let result: ToolResult;
+  try {
+    result = await tool.run(input);
+  } catch (error) {
+    result = {
+      content: error instanceof Error ? error.message : String(error),
+      isError: true,
+    };
+  }
+  const content = clip(result.content, toolResultCap(contextWindow));
+  const reportedResult = { ...result, content };
+  safeCallback(() => callbacks?.onToolResult?.(described.name, reportedResult));
+
+  const contentItems: DynamicToolCallResponse["contentItems"] = [
+    {
+      type: "inputText",
+      text: content || (result.isError ? "Tool call failed." : "(no output)"),
+    },
+  ];
+  for (const image of result.images ?? []) {
+    if (!/^image\/[a-z0-9.+-]+$/i.test(image.mimeType)) continue;
+    contentItems.push({
+      type: "inputImage",
+      imageUrl: `data:${image.mimeType};base64,${image.data}`,
+    });
+  }
+  return { contentItems, success: !result.isError };
+}
+
+function toolFailure(message: string): DynamicToolCallResponse {
+  return {
+    contentItems: [{ type: "inputText", text: message }],
+    success: false,
+  };
+}
+
+function parseDynamicToolCall(value: unknown): DynamicToolCallParams {
+  const body = asObject(value);
+  const threadId = stringField(body, "threadId");
+  const turnId = stringField(body, "turnId");
+  const callId = stringField(body, "callId");
+  const tool = stringField(body, "tool");
+  const namespace = body?.namespace === null ? null : stringField(body, "namespace");
+  if (!threadId || !turnId || !callId || !tool || namespace === undefined) {
+    throw new Error("OpenAI Codex sent an invalid dynamic tool call.");
+  }
+  return {
+    threadId,
+    turnId,
+    callId,
+    namespace,
+    tool,
+    arguments: body?.arguments,
+  };
+}
+
+function splitConversation(messages: AgentMessage[]): {
+  history: JsonObject[];
+  current: string;
+} {
+  if (messages.length === 0) {
+    throw new Error("The OpenAI subscription turn has no user message.");
+  }
+  const latest = messages.at(-1);
+  if (!latest || latest.role !== "user") {
+    throw new Error("The OpenAI subscription conversation must end with a user message.");
+  }
+
+  const history = messages.slice(0, -1).map((message) => ({
+    type: "message",
+    role: message.role,
+    content: [
+      {
+        type: message.role === "assistant" ? "output_text" : "input_text",
+        text: messageText(message),
+      },
+    ],
+  }));
+  return {
+    history,
+    current: messageText(latest),
+  };
+}
+
+function messageText(message: AgentMessage): string {
+  return message.content
+    .map((block) => {
+      if (block.type === "text") return block.text;
+      if (block.type === "tool_use") {
+        return `[Prior tool call: ${block.name} ${JSON.stringify(block.input)}]`;
+      }
+      return `[Prior tool result${block.isError ? " (error)" : ""}: ${block.content}]`;
+    })
+    .join("\n");
+}
+
+function isAllowedCodexItemType(type: string | null | undefined): boolean {
+  return typeof type === "string" && ALLOWED_CODEX_ITEM_TYPES.has(type);
+}
+
+function asObject(value: unknown): JsonObject | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : null;
+}
+
+function stringField(record: JsonObject | null | undefined, key: string): string | null {
+  const value = record?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function numberField(record: JsonObject | null | undefined, key: string): number | null {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function safeCallback(callback: () => void): void {
+  try {
+    callback();
+  } catch {
+    // Stream/transcript observers are never allowed to break the turn.
+  }
+}
+
+function matchesActiveTurn(
+  body: JsonObject,
+  threadId: string | null,
+  turnId: string | null,
+): boolean {
+  const eventThreadId = stringField(body, "threadId");
+  const eventTurnId = stringField(body, "turnId");
+  if (threadId && eventThreadId && eventThreadId !== threadId) return false;
+  if (turnId && eventTurnId && eventTurnId !== turnId) return false;
+  return true;
+}
+
+function interruptActiveTurn(
+  server: CodexAppServer | null,
+  threadId: string | null,
+  turnId: string | null,
+): void {
+  if (!server || !threadId || !turnId) return;
+  void server.request("turn/interrupt", { threadId, turnId }, 10_000).catch(() => undefined);
+}
+
+function clip(value: string, cap: number): string {
+  if (value.length <= cap) return value;
+  return value.slice(0, cap) + `\n… [truncated ${value.length - cap} chars]`;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((ok, fail) => {
+    resolve = ok;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function abortError(): Error {
+  const error = new Error("The OpenAI subscription turn was aborted.");
+  error.name = "AbortError";
+  return error;
+}

--- a/App/server/services/agent/contextWindow.ts
+++ b/App/server/services/agent/contextWindow.ts
@@ -55,7 +55,10 @@ export async function probeContextWindow(model: AIModel): Promise<number | null>
  * there's no sense showing a Refresh button that is guaranteed to find nothing.
  */
 export function canProbeContextWindow(model: AIModel): boolean {
-  return model.authMode === "customEndpoint" || model.provider === "anthropic";
+  return (
+    model.authMode === "customEndpoint" ||
+    (model.authMode === "apikey" && model.provider === "anthropic")
+  );
 }
 
 /**

--- a/App/server/services/agent/modelClients/index.ts
+++ b/App/server/services/agent/modelClients/index.ts
@@ -16,6 +16,10 @@ import { createOpenAIResponsesClient } from "./openaiResponses.js";
  *  - openai    + apikey       → OpenAI Responses API with the stored key
  *  - custom    + customEndpoint → OpenAI-compatible client at the stored baseURL
  *
+ * OpenAI `subscription` rows intentionally do not resolve here. They use the
+ * official Codex app-server adapter in `codexRuntime.ts`, which consumes the
+ * same ToolRegistry without pretending a ChatGPT plan is an API key.
+ *
  * The two OpenAI-shaped providers deliberately land on different clients. The
  * `openai` provider needs `/v1/responses`, because Chat Completions rejects
  * function tools for a reasoning model (see `openaiResponses.ts`) — and an
@@ -26,6 +30,14 @@ import { createOpenAIResponsesClient } from "./openaiResponses.js";
 export async function createModelClient(
   model: AIModel,
 ): Promise<{ client: ModelClient } | { error: string }> {
+  if (model.authMode === "subscription") {
+    return {
+      error:
+        model.provider === "openai"
+          ? "OpenAI subscription models must run through the Codex subscription runtime."
+          : `${model.provider} does not support subscription authentication.`,
+    };
+  }
   if (model.authMode === "customEndpoint") {
     if (model.provider !== "custom") {
       return { error: `${model.provider} does not use a custom endpoint — use an API key.` };

--- a/App/server/services/agent/modelError.test.ts
+++ b/App/server/services/agent/modelError.test.ts
@@ -4,10 +4,7 @@ import { describe, test } from "node:test";
 import type { AIModel, Provider } from "../../db/entities/AIModel.js";
 import { formatModelError } from "./modelError.js";
 
-function model(
-  provider: Provider,
-  overrides: Partial<AIModel> = {},
-): AIModel {
+function model(provider: Provider, overrides: Partial<AIModel> = {}): AIModel {
   return {
     provider,
     model: provider === "custom" ? "qwen/local" : "model-id",
@@ -44,6 +41,17 @@ describe("formatModelError classification", () => {
     );
   });
 
+  test("gives subscription-specific authentication recovery without API-key advice", () => {
+    const out = formatModelError(model("openai", { authMode: "subscription" }), {
+      status: 401,
+      message: "token expired",
+    });
+    assert.match(out, /Endpoint: OpenAI Codex subscription/);
+    assert.match(out, /Reconnect the ChatGPT subscription/);
+    assert.match(out, /Codex access/);
+    assert.doesNotMatch(out, /Replace the saved API key/);
+  });
+
   test("recognizes timeouts by status, name, and message", () => {
     assert.match(
       formatModelError(model("openai"), { statusCode: 504, message: "gateway" }),
@@ -62,6 +70,23 @@ describe("formatModelError classification", () => {
     });
     assert.match(out, /rejected an over-long prompt/);
     assert.match(out, /Set the model’s context window accurately/);
+  });
+
+  test("does not offer unavailable context controls or Genosyn retries for subscriptions", () => {
+    const subscription = model("openai", { authMode: "subscription" });
+    const context = formatModelError(subscription, {
+      status: 400,
+      message: "Maximum context length exceeded",
+    });
+    assert.match(context, /Codex manages the subscription model’s context budget/);
+    assert.doesNotMatch(context, /Set the model’s context window/);
+
+    const provider = formatModelError(subscription, {
+      status: 503,
+      message: "service unavailable",
+    });
+    assert.match(provider, /Codex app-server manages retries/);
+    assert.doesNotMatch(provider, /Genosyn retries transient failures/);
   });
 
   test("finds a network code through a bounded cause chain", () => {
@@ -117,10 +142,9 @@ describe("formatModelError output safety", () => {
   });
 
   test("collapses line breaks and truncates hostile model metadata", () => {
-    const out = formatModelError(
-      model("openai", { model: `gpt\n${"x".repeat(300)}` }),
-      { message: `first\nsecond ${"y".repeat(1_500)}` },
-    );
+    const out = formatModelError(model("openai", { model: `gpt\n${"x".repeat(300)}` }), {
+      message: `first\nsecond ${"y".repeat(1_500)}`,
+    });
     assert.doesNotMatch(out, /gpt\n/);
     assert.ok(out.includes("…"));
     assert.ok(out.split("\n").find((line) => line.startsWith("Details: "))!.length <= 1_010);

--- a/App/server/services/agent/modelError.ts
+++ b/App/server/services/agent/modelError.ts
@@ -24,7 +24,7 @@ export function formatModelError(model: AIModel, error: unknown): string {
   }
   if (meta.requestId) lines.push(`Request ID: ${meta.requestId}`);
 
-  lines.push("", "What to check:", ...guidance(category, model.provider));
+  lines.push("", "What to check:", ...guidance(category, model));
   lines.push("", "Open Settings → Model for this employee, then retry.");
   return lines.join("\n");
 }
@@ -69,10 +69,7 @@ function errorMetadata(error: unknown): ErrorMetadata {
 }
 
 /** Node's fetch errors commonly nest the useful ECONNREFUSED/ENOTFOUND code. */
-function stringInCauseChain(
-  record: Record<string, unknown> | null,
-  key: string,
-): string | null {
+function stringInCauseChain(record: Record<string, unknown> | null, key: string): string | null {
   let current = asRecord(record?.cause);
   for (let depth = 0; current && depth < 4; depth += 1) {
     const found = stringField(current, key);
@@ -145,7 +142,8 @@ function heading(category: ErrorCategory): string {
   }
 }
 
-function guidance(category: ErrorCategory, provider: AIModel["provider"]): string[] {
+function guidance(category: ErrorCategory, model: AIModel): string[] {
+  const provider = model.provider;
   if (category === "network") {
     return provider === "custom"
       ? [
@@ -167,12 +165,24 @@ function guidance(category: ErrorCategory, provider: AIModel["provider"]): strin
     ];
   }
   if (category === "authentication") {
+    if (model.authMode === "subscription") {
+      return [
+        "• Reconnect the ChatGPT subscription from this employee’s Model settings.",
+        "• Confirm the ChatGPT account still has Codex access in its current plan or workspace.",
+      ];
+    }
     return [
       "• Replace the saved API key and confirm it is still active.",
       "• Confirm the key can access the configured model.",
     ];
   }
   if (category === "rate_limit") {
+    if (model.authMode === "subscription") {
+      return [
+        "• Check the ChatGPT plan’s current Codex usage and reset window.",
+        "• Wait for the limit to reset or switch the employee to another AI Model.",
+      ];
+    }
     return [
       "• Check the model account’s quota, billing status, and rate limits.",
       "• Wait for the limit to reset or switch the employee to another AI Model.",
@@ -185,17 +195,32 @@ function guidance(category: ErrorCategory, provider: AIModel["provider"]): strin
           "• Confirm the configured model id exactly matches one exposed by the server.",
         ]
       : [
-          "• Confirm the configured model id is valid and available to this API key.",
+          `• Confirm the configured model id is valid and available to this ${
+            model.authMode === "subscription" ? "ChatGPT account" : "API key"
+          }.`,
           "• Switch to a model the account can access if it was renamed or retired.",
         ];
   }
   if (category === "context") {
+    if (model.authMode === "subscription") {
+      return [
+        "• Codex manages the subscription model’s context budget; there is no manual window setting.",
+        "• Reduce unusually large Soul, Skill, attachment, or tool output content, or switch models.",
+      ];
+    }
     return [
       "• Set the model’s context window accurately so Genosyn can compact before the limit.",
       "• Reduce unusually large Soul, Skill, attachment, or tool output content.",
     ];
   }
   if (category === "provider") {
+    if (model.authMode === "subscription") {
+      return [
+        "• The Codex app-server manages retries for subscription-auth turns.",
+        "• Retry later after checking OpenAI’s service status or the Genosyn server logs.",
+        "• If the failure persists, switch the employee to another AI Model.",
+      ];
+    }
     return [
       "• Genosyn retries transient failures before any output; it never replays a partial response.",
       "• If no response had started, this failure outlasted the automatic retry window.",
@@ -212,7 +237,9 @@ function guidance(category: ErrorCategory, provider: AIModel["provider"]): strin
 /** Host-only endpoint preview. Never decrypt or render the stored full URL. */
 function endpointLabel(model: AIModel): string | null {
   if (model.provider === "anthropic") return "api.anthropic.com";
-  if (model.provider === "openai") return "api.openai.com";
+  if (model.provider === "openai") {
+    return model.authMode === "subscription" ? "OpenAI Codex subscription" : "api.openai.com";
+  }
   try {
     const cfg = JSON.parse(model.configJson || "{}") as Record<string, unknown>;
     const preview = typeof cfg.baseURLPreview === "string" ? cfg.baseURLPreview : "";

--- a/App/server/services/agent/runEmployee.ts
+++ b/App/server/services/agent/runEmployee.ts
@@ -7,17 +7,20 @@ import { formatModelError } from "./modelError.js";
 import {
   createParallelDelegationTool,
   MAX_DELEGATIONS_PER_TURN,
+  supportsParallelDelegation,
   type DelegatedBrief,
   type DelegationBudget,
 } from "./tools/parallelDelegation.js";
 import { createChatProgressTool } from "./tools/chatProgress.js";
+import { runCodexSubscriptionTurn } from "./codexRuntime.js";
 
 /**
  * Run one employee agent turn end-to-end — the entry point both the chat seam
  * and the routine runner call.
  *
- * This is the whole job the harness CLI used to do, in-process:
- *   1. build the model client from the employee's AIModel credentials;
+ * This is the whole runtime job:
+ *   1. build the direct model client, or the pinned official OpenAI Codex
+ *      subscription runtime, from the employee's AIModel credentials;
  *   2. assemble the tool list (coding + genosyn + browser + user MCP servers);
  *   3. run the tool-use loop, streaming text and tool activity via `callbacks`;
  *   4. tear the bridged MCP connections down.
@@ -89,9 +92,6 @@ function trimToProviderCap(
 }
 
 export async function runEmployeeAgent(params: EmployeeAgentParams): Promise<EmployeeAgentResult> {
-  const built = await createModelClient(params.model);
-  if ("error" in built) return { status: "error", error: built.error };
-
   const delegationDepth = params.delegationDepth ?? 0;
   const delegationBudget = params.delegationBudget ?? { remaining: MAX_DELEGATIONS_PER_TURN };
   const localTools: AgentTool[] = [...(params.extraTools ?? [])];
@@ -99,14 +99,23 @@ export async function runEmployeeAgent(params: EmployeeAgentParams): Promise<Emp
     if (params.callbacks?.onProgress) {
       localTools.push(createChatProgressTool(params.callbacks.onProgress));
     }
-    localTools.push(
-      createParallelDelegationTool({
-        budget: delegationBudget,
-        signal: params.signal,
-        runBrief: (brief) => runDelegatedBrief(params, brief, delegationBudget),
-      }),
-    );
+    if (supportsParallelDelegation(params.model.authMode)) {
+      localTools.push(
+        createParallelDelegationTool({
+          budget: delegationBudget,
+          signal: params.signal,
+          runBrief: (brief) => runDelegatedBrief(params, brief, delegationBudget),
+        }),
+      );
+    }
   }
+
+  if (params.model.authMode === "subscription") {
+    return runSubscriptionEmployeeAgent(params, localTools);
+  }
+
+  const built = await createModelClient(params.model);
+  if ("error" in built) return { status: "error", error: built.error };
 
   const gathered = await gatherEmployeeTools({
     employeeId: params.employeeId,
@@ -164,6 +173,67 @@ export async function runEmployeeAgent(params: EmployeeAgentParams): Promise<Emp
     };
   } finally {
     await gathered.close();
+  }
+}
+
+async function runSubscriptionEmployeeAgent(
+  params: EmployeeAgentParams,
+  localTools: AgentTool[],
+): Promise<EmployeeAgentResult> {
+  let gathered: Awaited<ReturnType<typeof gatherEmployeeTools>> | null = null;
+  try {
+    gathered = await gatherEmployeeTools({
+      employeeId: params.employeeId,
+      genosynToken: params.genosynToken,
+      cwd: params.cwd,
+      localTools,
+      toolEnv: params.toolEnv,
+      bashTimeoutMs: params.bashTimeoutMs,
+      skillToolset: params.skillToolset,
+      routineId: params.routineId,
+      conversationId: params.conversationId,
+      runId: params.runId,
+      signal: params.signal,
+      requireIsolatedBash: true,
+      onDeprecatedFamily: (family, target) => {
+        console.warn(
+          `[genosyn] employee=${params.employeeId} used the deprecated family tool "${family}" ` +
+            `(-> ${target}). Update the Skill or Soul that names it.`,
+        );
+      },
+    });
+
+    params.callbacks?.onToolsDeferred?.(gathered.registry.stats);
+    // Dynamic tools follow the Responses API naming/size contract. The normal
+    // working set is around twenty; retain the provider's published ceiling as
+    // a defensive backstop for unusually large Skill-requested resident sets.
+    gathered.registry.resident = trimToProviderCap(
+      gathered.registry.resident,
+      128,
+      params.callbacks,
+    );
+
+    const result = await runCodexSubscriptionTurn({
+      model: params.model,
+      system: params.system,
+      messages: params.messages,
+      registry: gathered.registry,
+      maxSteps: params.maxSteps,
+      signal: params.signal,
+      callbacks: params.callbacks,
+    });
+    return { status: "ok", finalText: result.finalText, steps: result.steps };
+  } catch (err) {
+    console.error(
+      `[agent:model] subscription request failed employee=${params.employeeId} model=${params.model.id}`,
+      err,
+    );
+    return {
+      status: "error",
+      error: formatModelError(params.model, err),
+    };
+  } finally {
+    await gathered?.close();
   }
 }
 

--- a/App/server/services/agent/systemPrompt.ts
+++ b/App/server/services/agent/systemPrompt.ts
@@ -39,6 +39,12 @@ export function composeEmployeeSystemPrompt(args: {
   /** The one line the two seams genuinely disagree on. */
   opening: string;
   surface: PromptSurface;
+  /** Subscription turns serialize on a model lock and cannot delegate. */
+  parallelDelegationAvailable: boolean;
+  /** Whether this turn receives any built-in coding tool. */
+  codingToolsAvailable: boolean;
+  /** Bubblewrap mode keeps every coding operation inside its namespace. */
+  isolatedCodingTools: boolean;
   /** Per-skill declared toolsets, keyed by skill id, for the Skill headings. */
   skillToolsets?: Map<string, string[]>;
 }): string {
@@ -56,7 +62,14 @@ export function composeEmployeeSystemPrompt(args: {
   const parts: string[] = [];
 
   parts.push(args.opening);
-  parts.push(toolsBriefing(args.surface));
+  parts.push(
+    toolsBriefing(
+      args.surface,
+      args.parallelDelegationAvailable,
+      args.codingToolsAvailable,
+      args.isolatedCodingTools,
+    ),
+  );
   parts.push("\n## Soul\n");
   parts.push(emp.soulBody);
   if (memoryContext) parts.push(memoryContext);
@@ -87,7 +100,13 @@ export function composeEmployeeSystemPrompt(args: {
  * for a teammate's ambiguous request. A routine's brief is written in advance
  * and there is nobody to ask.
  */
-export function toolsBriefing(surface: PromptSurface): string {
+export function toolsBriefing(
+  surface: PromptSurface,
+  parallelDelegationAvailable: boolean,
+  codingToolsAvailable = config.agent.codingTools.enabled &&
+    config.agent.codingTools.executionMode !== "disabled",
+  isolatedCodingTools = config.agent.codingTools.executionMode === "bubblewrap",
+): string {
   const isChat = surface === "chat";
   // When discovery is off (the revert flag), every tool is loaded and there is
   // no find_tools/call_tool to reach for — so promising them would send the
@@ -117,11 +136,23 @@ export function toolsBriefing(surface: PromptSurface): string {
     );
   }
 
+  lines.push(discovery ? "### Always loaded" : "### Your tools");
+
+  if (codingToolsAvailable && isolatedCodingTools) {
+    lines.push(
+      "- Coding: isolated `bash`, rooted at your working directory. Use shell commands for file " +
+        "reading and editing too; host-process file tools are intentionally unavailable across " +
+        "this bubblewrap deployment.",
+    );
+  } else if (codingToolsAvailable) {
+    lines.push(
+      "- Coding: `bash`, `read_file`, `write_file`, `edit_file`, `list_dir`, `glob`, `grep`, " +
+        "rooted at your working directory (which holds any granted git repos under `repos/` and " +
+        "`code-repos/`).",
+    );
+  }
+
   lines.push(
-    discovery ? "### Always loaded" : "### Your tools",
-    "- Coding: `bash`, `read_file`, `write_file`, `edit_file`, `list_dir`, `glob`, `grep`, " +
-      "rooted at your working directory (which holds any granted git repos under `repos/` and " +
-      "`code-repos/`).",
     '- Routines — scheduled recurring AI work. Genosyn calls these **Routines**, never "tasks". ' +
       "`create_routine` to schedule one; `update_routine` to rename, re-schedule, rewrite, or " +
       "pause/resume one in place — **never create a duplicate to change one** — and " +
@@ -131,20 +162,25 @@ export function toolsBriefing(surface: PromptSurface): string {
       "auto-injected into every prompt), and `memory` to curate durable facts that are also " +
       "auto-injected.",
     "- `send_chat_attachment` to send a generated file back as a download chip.",
-    "- Parallel delegation: `delegate_parallel_work` runs independent briefs concurrently as " +
-      "temporary copies of you, then returns their results for you to verify and synthesize. " +
-      "Prefer independent research, analysis, and API calls. Workers share your working " +
-      "directory, so partition file-writing briefs explicitly and never overlap git operations.",
-    "- Browser tools (when enabled) and any company-configured MCP server tools.",
-    "",
   );
+
+  if (parallelDelegationAvailable) {
+    lines.push(
+      "- Parallel delegation: `delegate_parallel_work` runs independent briefs concurrently as " +
+        "temporary copies of you, then returns their results for you to verify and synthesize. " +
+        "Prefer independent research, analysis, and API calls. Workers share your working " +
+        "directory, so partition file-writing briefs explicitly and never overlap git operations.",
+    );
+  }
+
+  lines.push("- Browser tools (when enabled) and any company-configured MCP server tools.", "");
 
   if (discovery) {
     lines.push(
       "### Reaching the rest",
       "- Email, finance, Bases, notes, resources, charts, dashboards, workspace channels, " +
         "handoffs and your company's integrations all live in the catalogue. Call `find_tools` " +
-        "with what you are trying to do — \"record a payment\", \"reply to that email\", \"read a " +
+        'with what you are trying to do — "record a payment", "reply to that email", "read a ' +
         'spreadsheet" — and it returns the exact tools and their arguments.',
       "- Grants still apply. If `find_tools` says you hold no grant for something, say so plainly " +
         "rather than working around it.",
@@ -159,7 +195,9 @@ export function toolsBriefing(surface: PromptSurface): string {
 
   lines.push(
     "- Mail: prefer creating a draft over sending" +
-      (isChat ? " unless explicitly told to send." : " unless the brief explicitly allows sending."),
+      (isChat
+        ? " unless explicitly told to send."
+        : " unless the brief explicitly allows sending."),
   );
 
   if (isChat) {
@@ -170,7 +208,7 @@ export function toolsBriefing(surface: PromptSurface): string {
         "load it, and work on that exact row. A tag does not bypass Grants or project membership; " +
         "if your tools deny access, say so instead of guessing.",
       "",
-      'When the teammate uploads a file, you\'ll see a header like `[Attachment id=<uuid> ' +
+      "When the teammate uploads a file, you'll see a header like `[Attachment id=<uuid> " +
         'filename="foo.pdf" size=… mime="…"]` at the top of their message. That `id=` is the ' +
         "`attachmentId` you pass to `read_pdf_fields` / `fill_pdf_form` / any tool that takes an " +
         "`attachmentId` — copy it verbatim.",

--- a/App/server/services/agent/tools/coding.ts
+++ b/App/server/services/agent/tools/coding.ts
@@ -4,6 +4,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import type { AgentTool, ToolResult } from "../types.js";
 import { config } from "../../../../config.js";
+import { buildBubblewrapCommandArgs } from "../bubblewrap.js";
 
 /**
  * The built-in coding toolset — bash + file read/write/edit + glob/grep — that
@@ -146,7 +147,17 @@ function runBash(command: string, ctx: CodingToolContext, timeoutMs: number): Pr
     };
     const sandbox = config.agent.codingTools.executionMode;
     const executable = sandbox === "bubblewrap" ? config.agent.codingTools.bubblewrapPath : "bash";
-    const args = sandbox === "bubblewrap" ? bubblewrapArgs(command, ctx, env) : ["-lc", command];
+    const args =
+      sandbox === "bubblewrap"
+        ? buildBubblewrapCommandArgs({
+            workspaceRoot: ctx.cwd,
+            cwd: ctx.cwd,
+            executable: "bash",
+            args: ["-lc", command],
+            env,
+            unshareNetwork: !config.agent.codingTools.allowNetwork,
+          })
+        : ["-lc", command];
     const child = spawn(executable, args, {
       cwd: ctx.cwd,
       env,
@@ -207,58 +218,6 @@ function runBash(command: string, ctx: CodingToolContext, timeoutMs: number): Pr
       }
     });
   });
-}
-
-function bubblewrapArgs(
-  command: string,
-  ctx: CodingToolContext,
-  env: Record<string, string>,
-): string[] {
-  const args = [
-    "--die-with-parent",
-    "--new-session",
-    "--unshare-user",
-    "--unshare-pid",
-    "--unshare-ipc",
-    "--unshare-uts",
-    "--unshare-cgroup",
-    "--proc",
-    "/proc",
-    "--dev",
-    "/dev",
-    "--tmpfs",
-    "/tmp",
-    "--ro-bind",
-    "/bin",
-    "/bin",
-    "--ro-bind",
-    "/usr",
-    "/usr",
-    "--ro-bind-try",
-    "/lib",
-    "/lib",
-    "--ro-bind-try",
-    "/lib64",
-    "/lib64",
-    "--ro-bind-try",
-    "/etc/ssl",
-    "/etc/ssl",
-    "--ro-bind-try",
-    "/etc/ca-certificates",
-    "/etc/ca-certificates",
-    "--bind",
-    path.resolve(ctx.cwd),
-    "/workspace",
-    "--chdir",
-    "/workspace",
-    "--clearenv",
-  ];
-  if (!config.agent.codingTools.allowNetwork) args.push("--unshare-net");
-  for (const [name, value] of Object.entries(env)) {
-    args.push("--setenv", name, value);
-  }
-  args.push("--", "bash", "-lc", command);
-  return args;
 }
 
 // ---------- read ----------

--- a/App/server/services/agent/tools/credentialIsolation.test.ts
+++ b/App/server/services/agent/tools/credentialIsolation.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentTool } from "../types.js";
+import { filterCodingToolsForCredentialIsolation } from "./index.js";
+
+const tools = [{ name: "bash" }, { name: "read_file" }] as AgentTool[];
+
+test("bubblewrap deployments expose coding only through sandboxed bash for every turn", () => {
+  assert.deepEqual(
+    filterCodingToolsForCredentialIsolation(tools, true, "host").map((tool) => tool.name),
+    [],
+  );
+  assert.deepEqual(
+    filterCodingToolsForCredentialIsolation(tools, true, "bubblewrap").map((tool) => tool.name),
+    ["bash"],
+  );
+  assert.deepEqual(
+    filterCodingToolsForCredentialIsolation(tools, false, "host").map((tool) => tool.name),
+    ["bash", "read_file"],
+  );
+  assert.deepEqual(
+    filterCodingToolsForCredentialIsolation(tools, false, "bubblewrap").map((tool) => tool.name),
+    ["bash"],
+  );
+});

--- a/App/server/services/agent/tools/index.ts
+++ b/App/server/services/agent/tools/index.ts
@@ -83,6 +83,12 @@ export async function gatherEmployeeTools(params: {
   conversationId?: string;
   runId?: string;
   signal?: AbortSignal;
+  /**
+   * Defense in depth for a subscription turn: omit bash unless bubblewrap
+   * gives it private /tmp and PID namespaces. The install-level subscription
+   * gate separately rejects enabled host-mode coding tools.
+   */
+  requireIsolatedBash?: boolean;
   /** Called when a Soul, Skill or brief reached for a retired family name. */
   onDeprecatedFamily?: (family: string, target: string) => void;
 }): Promise<{ registry: ToolRegistry; browser: BrowserConfig; close: () => Promise<void> }> {
@@ -106,7 +112,12 @@ export async function gatherEmployeeTools(params: {
 
   const codingEnabled =
     config.agent.codingTools.enabled && config.agent.codingTools.executionMode !== "disabled";
-  const coding = codingEnabled ? codingTools(codingCtx) : [];
+  const coding = codingEnabled
+    ? filterCodingToolsForCredentialIsolation(
+        codingTools(codingCtx),
+        Boolean(params.requireIsolatedBash),
+      )
+    : [];
 
   const tools: AgentTool[] = [...(params.localTools ?? []), ...coding, ...genosyn.tools];
   const bridged: BridgedServer[] = [];
@@ -230,6 +241,26 @@ export async function gatherEmployeeTools(params: {
     browser,
     close,
   };
+}
+
+export function filterCodingToolsForCredentialIsolation(
+  tools: AgentTool[],
+  required: boolean,
+  executionMode = config.agent.codingTools.executionMode,
+): AgentTool[] {
+  // The path-based file tools run in the App process. Their validate-then-open
+  // sequence cannot provide an atomic symlink boundary, so a concurrent
+  // sandboxed shell could race another turn's file tool into Codex's host-side
+  // credential temp directory. Bubblewrap mode therefore keeps *every* turn's
+  // coding operations inside the namespace, not only the subscription turn.
+  if (executionMode === "bubblewrap") {
+    return tools.filter((tool) => tool.name === "bash");
+  }
+  // A subscription row cannot run outside bubblewrap. Keep this secondary
+  // fail-closed branch even though the install-level availability gate rejects
+  // the turn before the Codex credential is materialized.
+  if (required) return [];
+  return tools;
 }
 
 /**

--- a/App/server/services/agent/tools/mcpBridge.test.ts
+++ b/App/server/services/agent/tools/mcpBridge.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mcpChildEnvironment } from "./mcpBridge.js";
+
+test("stdio MCP children inherit only runtime essentials and explicit server env", () => {
+  process.env.GENOSYN_TEST_PARENT_SECRET = "do-not-inherit";
+  try {
+    const env = mcpChildEnvironment({ MCP_SERVER_SETTING: "explicit" });
+    assert.equal(env.GENOSYN_TEST_PARENT_SECRET, undefined);
+    assert.equal(env.MCP_SERVER_SETTING, "explicit");
+    assert.equal(env.PATH, process.env.PATH);
+  } finally {
+    delete process.env.GENOSYN_TEST_PARENT_SECRET;
+  }
+});

--- a/App/server/services/agent/tools/mcpBridge.ts
+++ b/App/server/services/agent/tools/mcpBridge.ts
@@ -49,10 +49,7 @@ export type BridgedServer = {
  */
 export type McpToolGuard = {
   patterns: string[];
-  onGuarded: (
-    toolName: string,
-    input: Record<string, unknown>,
-  ) => Promise<ToolResult>;
+  onGuarded: (toolName: string, input: Record<string, unknown>) => Promise<ToolResult>;
 };
 
 /** Does a native tool name match any of the guard's glob patterns? */
@@ -60,9 +57,7 @@ export function matchesGuardPattern(name: string, patterns: string[]): boolean {
   for (const pattern of patterns) {
     const p = pattern.trim();
     if (!p) continue;
-    const re = new RegExp(
-      "^" + p.split("*").map(escapeRegex).join(".*") + "$",
-    );
+    const re = new RegExp("^" + p.split("*").map(escapeRegex).join(".*") + "$");
     if (re.test(name)) return true;
   }
   return false;
@@ -105,7 +100,7 @@ export async function connectMcpServer(
         args: spec.args,
         // MCP's stdio transport uses a restricted default env; merge the parent
         // env so the child (e.g. the browser server) sees GENOSYN_* + PATH.
-        env: mergeEnv(spec.env),
+        env: mcpChildEnvironment(spec.env),
         ...(spec.cwd ? { cwd: spec.cwd } : {}),
       });
       await client.connect(transport);
@@ -144,7 +139,7 @@ export async function connectMcpServer(
       name: exposedToolName(namePrefix, t.name),
       description: guarded
         ? `${t.description ?? `${label} tool`} (Guarded: this call queues a human Approval and runs after approve.)`
-        : t.description ?? `${label} tool`,
+        : (t.description ?? `${label} tool`),
       inputSchema: (t.inputSchema as Record<string, unknown>) ?? {
         type: "object",
         properties: {},
@@ -238,10 +233,30 @@ function sanitizeChars(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
-function mergeEnv(extra: Record<string, string>): Record<string, string> {
+export function mcpChildEnvironment(extra: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(process.env)) {
-    if (typeof v === "string") out[k] = v;
+  const inherited = [
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "NODE_EXTRA_CA_CERTS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH",
+  ];
+  for (const key of inherited) {
+    const value = process.env[key];
+    if (typeof value === "string") out[key] = value;
   }
   Object.assign(out, extra);
   return out;

--- a/App/server/services/agent/tools/mcpSources.test.ts
+++ b/App/server/services/agent/tools/mcpSources.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { userStdioMcpAvailableFor } from "./mcpSources.js";
+
+test("user stdio MCP is omitted anywhere subscription credentials can be active", () => {
+  assert.equal(
+    userStdioMcpAvailableFor({
+      multiTenant: false,
+      codingToolsExecutionMode: "bubblewrap",
+    }),
+    false,
+  );
+  assert.equal(
+    userStdioMcpAvailableFor({
+      multiTenant: true,
+      codingToolsExecutionMode: "host",
+    }),
+    false,
+  );
+  assert.equal(
+    userStdioMcpAvailableFor({
+      multiTenant: false,
+      codingToolsExecutionMode: "host",
+    }),
+    true,
+  );
+});

--- a/App/server/services/agent/tools/mcpSources.ts
+++ b/App/server/services/agent/tools/mcpSources.ts
@@ -15,9 +15,11 @@ import type { McpServerSpec, McpToolGuard } from "./mcpBridge.js";
  * company-configured stdio/HTTP servers. The in-process `genosyn` tools live in
  * ./genosyn.ts; the built-in coding tools in ./coding.ts.
  *
- * This is the surviving remnant of the old `services/mcp.ts`: we no longer
- * materialize per-CLI config files (there is no CLI), but we still need to know
- * which servers to connect to and mint the browser live-view session.
+ * This is the surviving remnant of the old `services/mcp.ts`: we do not
+ * materialize provider-owned MCP config files. Even the narrow OpenAI
+ * subscription app-server path receives this same App-owned registry through
+ * dynamic tools. We still need to know which servers to connect to and mint
+ * the browser live-view session.
  */
 
 /** Absolute path to the built-in `browser` MCP stdio binary (dev + prod). */
@@ -153,6 +155,14 @@ export function specForMcpServerRow(s: McpServer): McpServerSpec | null {
     return { transport: "http", url: s.url };
   }
   if (s.transport === "stdio" && s.command) {
+    if (
+      !userStdioMcpAvailableFor({
+        multiTenant: config.security.multiTenant,
+        codingToolsExecutionMode: config.agent.codingTools.executionMode,
+      })
+    ) {
+      return null;
+    }
     return {
       transport: "stdio",
       command: s.command,
@@ -161,6 +171,17 @@ export function specForMcpServerRow(s: McpServer): McpServerSpec | null {
     };
   }
   return null;
+}
+
+export function userStdioMcpAvailableFor(options: {
+  multiTenant: boolean;
+  codingToolsExecutionMode: "host" | "bubblewrap" | "disabled";
+}): boolean {
+  // An arbitrary same-UID child can inspect sibling /proc entries and private
+  // temp directories. Bubblewrap is the install-wide signal that credentials
+  // require process isolation, so user stdio servers stay off for every turn
+  // in that mode—not only the subscription turn that holds the credential.
+  return !options.multiTenant && options.codingToolsExecutionMode !== "bubblewrap";
 }
 
 export async function loadUserServerSpecs(
@@ -178,7 +199,6 @@ export async function loadUserServerSpecs(
     if (RESERVED_SERVER_NAMES.has(s.name)) continue;
     const spec = specForMcpServerRow(s);
     if (!spec) continue;
-    if (config.security.multiTenant && spec.transport === "stdio") continue;
     if (spec.transport === "http") {
       try {
         await assertSafeOutboundUrl(spec.url);

--- a/App/server/services/agent/tools/parallelDelegation.test.ts
+++ b/App/server/services/agent/tools/parallelDelegation.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toolsBriefing } from "../systemPrompt.js";
+import { supportsParallelDelegation } from "./parallelDelegation.js";
+
+test("subscription turns do not advertise delegation that would wait on their model lock", () => {
+  assert.equal(supportsParallelDelegation("subscription"), false);
+  assert.equal(supportsParallelDelegation("apikey"), true);
+  assert.equal(supportsParallelDelegation("customEndpoint"), true);
+});
+
+test("the employee briefing promises only tools the runtime offers", () => {
+  assert.doesNotMatch(toolsBriefing("chat", false), /delegate_parallel_work/);
+  assert.match(toolsBriefing("chat", true), /delegate_parallel_work/);
+  assert.doesNotMatch(toolsBriefing("chat", false, false), /`bash`/);
+  assert.match(toolsBriefing("chat", false, true, true), /isolated `bash`/);
+  assert.doesNotMatch(toolsBriefing("chat", false, true, true), /`read_file`/);
+  assert.match(toolsBriefing("chat", false, true, true), /bubblewrap deployment/);
+});

--- a/App/server/services/agent/tools/parallelDelegation.ts
+++ b/App/server/services/agent/tools/parallelDelegation.ts
@@ -11,6 +11,17 @@ const MAX_RESULT_LENGTH = 12_000;
 
 export type DelegationBudget = { remaining: number };
 
+/**
+ * Managed ChatGPT credentials can rotate, so subscription turns serialize on
+ * one model lock. A parent cannot wait on a delegated copy that is waiting for
+ * that same lock.
+ */
+export function supportsParallelDelegation(
+  authMode: "apikey" | "subscription" | "customEndpoint",
+): boolean {
+  return authMode !== "subscription";
+}
+
 export type DelegatedBrief = {
   label: string;
   instruction: string;
@@ -59,8 +70,7 @@ export function createParallelDelegationTool(params: {
                 type: "string",
                 minLength: 1,
                 maxLength: MAX_INSTRUCTION_LENGTH,
-                description:
-                  "Complete brief with scope, inputs, constraints, and expected output.",
+                description: "Complete brief with scope, inputs, constraints, and expected output.",
               },
             },
             required: ["label", "instruction"],

--- a/App/server/services/agent/types.ts
+++ b/App/server/services/agent/types.ts
@@ -1,13 +1,12 @@
 /**
  * Provider-agnostic types for the in-process agent runtime.
  *
- * This is the seam that replaced the CLI harnesses. Instead of spawning
- * `claude` / `codex` / `opencode` / `goose` / `openclaw` and letting them drive
- * the tool-use loop, we talk to the model API directly (Anthropic Messages,
- * OpenAI Chat Completions, or an OpenAI-compatible custom endpoint) and run the
- * loop ourselves — handing the model the same tools a harness would: the
- * built-in coding toolset (bash + file editing) plus every MCP tool the
- * employee has (genosyn, browser, company-configured servers).
+ * This is the seam that replaced generic CLI harnesses. API-key and custom
+ * models use the direct provider loop; the narrow OpenAI subscription adapter
+ * renders the same messages, callbacks, and ToolRegistry through the official
+ * Codex app-server dynamic-tool protocol. Either way the employee receives
+ * Genosyn's built-in coding toolset plus its granted genosyn, browser, and
+ * company-configured MCP tools.
  *
  * The message + tool shapes here are a small common denominator; each model
  * client converts to/from its own wire format.

--- a/App/server/services/chat.ts
+++ b/App/server/services/chat.ts
@@ -28,6 +28,9 @@ import {
   releaseWorkloadLease,
 } from "./workloadLeases.js";
 import { createGenosynHelpSource } from "./agent/tools/genosynHelp.js";
+import { supportsParallelDelegation } from "./agent/tools/parallelDelegation.js";
+import { shouldMaterializeRepositoriesForTurn } from "./codexSubscription.js";
+import { CODING_TOOL_NAMES } from "./agent/tools/coding.js";
 
 /**
  * Chat seam.
@@ -219,8 +222,24 @@ export async function streamChatWithEmployee(
 
   let mcpToken: string | null = null;
   try {
+    const parallelDelegationAvailable = supportsParallelDelegation(model.authMode);
+    const unavailableCodingTools =
+      !config.agent.codingTools.enabled || config.agent.codingTools.executionMode === "disabled"
+        ? [...CODING_TOOL_NAMES]
+        : config.agent.codingTools.executionMode === "bubblewrap"
+          ? CODING_TOOL_NAMES.filter((name) => name !== "bash")
+          : model.authMode === "subscription"
+            ? [...CODING_TOOL_NAMES]
+            : [];
+    const unavailableSkillTools = [
+      ...(parallelDelegationAvailable ? [] : ["delegate_parallel_work"]),
+      ...unavailableCodingTools,
+    ];
+    const repositoryMaterializationAllowed = shouldMaterializeRepositoriesForTurn(model.authMode);
     const memoryContext = await composeMemoryContext(emp.id);
-    const codeReposContext = await composeCodeReposContext(emp.id);
+    const codeReposContext = repositoryMaterializationAllowed
+      ? await composeCodeReposContext(emp.id)
+      : "";
     const financeContext = await composeFinanceContext(emp.id);
     const [revenueContext, marketingContext] = await Promise.all([
       composeRevenueContext(emp.id),
@@ -237,13 +256,16 @@ export async function streamChatWithEmployee(
       revenueContext,
       marketingContext,
       surface: "chat",
+      parallelDelegationAvailable,
+      codingToolsAvailable: unavailableCodingTools.length < CODING_TOOL_NAMES.length,
+      isolatedCodingTools: config.agent.codingTools.executionMode === "bubblewrap",
       opening:
         options.surface === "help"
           ? `You are ${emp.name}, ${emp.role} at ${co.name}. A teammate selected you in Genosyn Help to answer a question about Genosyn. Reply in your own voice, guided by your Soul and Skills, while treating the Help briefing and shipped source as authoritative.`
           : `You are ${emp.name}, ${emp.role} at ${co.name}. A teammate is chatting with you ` +
             `directly. Reply in your own voice, guided by your Soul, Memory, and Skills below. ` +
             `Keep replies focused and grounded — ask clarifying questions when needed.`,
-      skillToolsets: skillToolsetMap(skills),
+      skillToolsets: skillToolsetMap(skills, unavailableSkillTools),
     });
     if (helpSource) system += `\n${helpSource.prompt}`;
     if (options.extraSystem) system += `\n${options.extraSystem}`;
@@ -268,16 +290,18 @@ export async function streamChatWithEmployee(
       }
     }
 
-    // Materialize granted repos into the employee's cwd so the coding tools find
-    // a working tree. Non-fatal — chat still proceeds if a repo fails to sync.
-    const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
-    Object.assign(toolEnv, repoSync.extraEnv);
-    const codeRepoSync = await materializeCodeReposForEmployee({
-      employeeId: emp.id,
-      cwd,
-      githubRepoCredentials: repoSync.githubRepoCredentials,
-    });
-    Object.assign(toolEnv, codeRepoSync.extraEnv);
+    if (repositoryMaterializationAllowed) {
+      // Materialize granted repos into the employee's cwd so the coding tools
+      // find a working tree. Non-fatal — chat still proceeds if a repo fails.
+      const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
+      Object.assign(toolEnv, repoSync.extraEnv);
+      const codeRepoSync = await materializeCodeReposForEmployee({
+        employeeId: emp.id,
+        cwd,
+        githubRepoCredentials: repoSync.githubRepoCredentials,
+      });
+      Object.assign(toolEnv, codeRepoSync.extraEnv);
+    }
 
     mcpToken = issueMcpToken(emp.id, co.id);
     const controller = new AbortController();
@@ -300,7 +324,10 @@ export async function streamChatWithEmployee(
         genosynToken: mcpToken,
         bashTimeoutMs: 5 * 60 * 1000,
         maxSteps: CHAT_MAX_STEPS,
-        skillToolset: [...residentNamesForSkills(skills), ...(options.extraToolset ?? [])],
+        skillToolset: [
+          ...residentNamesForSkills(skills, unavailableSkillTools),
+          ...(options.extraToolset ?? []),
+        ].filter((name) => !unavailableSkillTools.includes(name)),
         extraTools: helpSource?.tools,
         conversationId: options.conversationId,
         signal: controller.signal,

--- a/App/server/services/codeRepos.ts
+++ b/App/server/services/codeRepos.ts
@@ -1,5 +1,3 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
@@ -16,8 +14,13 @@ import {
 import type { CodeRepoAccessLevel } from "../db/entities/EmployeeCodeRepositoryGrant.js";
 import { encryptSecret, decryptSecret } from "../lib/secret.js";
 import { toSlug } from "../lib/slug.js";
-import { clearEnvCredentialHelper, configureEnvCredentialHelper } from "./gitCredentialHelper.js";
+import {
+  clearEnvCredentialHelper,
+  configureEnvCredentialHelper,
+  inlineEnvCredentialHelper,
+} from "./gitCredentialHelper.js";
 import type { GithubRepoCredential } from "./repoSync.js";
+import { runWorkspaceGit } from "./workspaceGit.js";
 
 /**
  * Code Repository seam — the provider-agnostic cousin of `repoSync.ts`.
@@ -43,8 +46,6 @@ import type { GithubRepoCredential } from "./repoSync.js";
  * — git needs a private-key *file*, so the key is written under the employee's
  * data dir (gitignored) with mode 0600 and pinned via `core.sshCommand`.
  */
-
-const exec = promisify(execFile);
 
 // ───────────────────────────── slugs ────────────────────────────────────
 
@@ -144,41 +145,19 @@ function envKeyFor(repoId: string): string {
 }
 
 async function runGit(
+  workspaceRoot: string,
   cwd: string,
   args: string[],
   extraEnv: Record<string, string> = {},
+  credentialHelper?: string,
 ): Promise<{ stdout: string }> {
-  try {
-    const { stdout } = await exec("git", args, {
-      cwd,
-      env: {
-        ...process.env,
-        // No TTY → fail fast on missing creds instead of hanging the runner.
-        GIT_TERMINAL_PROMPT: "0",
-        GIT_ASKPASS: "/bin/echo",
-        ...extraEnv,
-      },
-      maxBuffer: 16 * 1024 * 1024,
-    });
-    return { stdout };
-  } catch (err) {
-    if ((err as { code?: string }).code === "ENOENT") {
-      throw new Error(
-        `git is not installed on the Genosyn server, so "git ${args[0]}" could not run. Install git (the official Genosyn Docker image bundles it) and try again.`,
-      );
-    }
-    const e = err as { stderr?: string; stdout?: string; message?: string };
-    const tail = (e.stderr || e.stdout || e.message || "").toString().trim();
-    throw new Error(`git ${args[0]} failed: ${tail.split("\n").slice(-3).join(" | ")}`);
-  }
-}
-
-/** Insert `user:token@` into an `https://…` URL. Returns null for non-HTTPS. */
-function injectHttpsCreds(gitUrl: string, username: string, token: string): string | null {
-  const m = gitUrl.match(/^https:\/\/(.*)$/i);
-  if (!m) return null;
-  const enc = encodeURIComponent;
-  return `https://${enc(username)}:${enc(token)}@${m[1]}`;
+  return runWorkspaceGit({
+    workspaceRoot,
+    cwd,
+    args,
+    extraEnv,
+    credentialHelper,
+  });
 }
 
 function httpsUsernameOf(repo: CodeRepository): string {
@@ -194,6 +173,15 @@ function sshKeyDir(cwd: string): string {
   return path.join(cwd, "code-repos", ".ssh");
 }
 
+function workspaceVisiblePath(workspaceRoot: string, hostPath: string): string {
+  if (config.agent.codingTools.executionMode !== "bubblewrap") return hostPath;
+  const relative = path.relative(path.resolve(workspaceRoot), path.resolve(hostPath));
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error("SSH key path escapes the employee workspace.");
+  }
+  return relative ? `/workspace/${relative.split(path.sep).join("/")}` : "/workspace";
+}
+
 /**
  * Build the `ssh` command git should use for a given key file: identities
  * pinned to our key only, host keys auto-accepted on first contact (no
@@ -207,11 +195,16 @@ function sshCommandFor(keyPath: string): string {
 }
 
 async function configureCredentialHelper(
+  workspaceRoot: string,
   repoPath: string,
   username: string,
   envKey: string,
 ): Promise<void> {
-  await configureEnvCredentialHelper((args) => runGit(repoPath, args), username, envKey);
+  await configureEnvCredentialHelper(
+    (args) => runGit(workspaceRoot, repoPath, args),
+    username,
+    envKey,
+  );
 }
 
 // In-process mutex per (employeeId × repoId) so two concurrent spawns can't
@@ -355,7 +348,7 @@ async function syncOneRepo(
     fs.writeFileSync(keyPath, sshKey.endsWith("\n") ? sshKey : sshKey + "\n", {
       mode: 0o600,
     });
-    sshCommand = sshCommandFor(keyPath);
+    sshCommand = sshCommandFor(workspaceVisiblePath(cwd, keyPath));
     cloneEnv = { GIT_SSH_COMMAND: sshCommand };
   }
   if (repo.authMode === "https" && token) {
@@ -365,67 +358,91 @@ async function syncOneRepo(
     result.extraEnv[envKey] = linkedGithubCredential.token;
   }
   const credentialEnv = token ? { [envKey]: token } : {};
+  const credentialHelper = token ? inlineEnvCredentialHelper(httpsUsername, envKey) : undefined;
 
   if (!isCheckout) {
     fs.mkdirSync(path.dirname(repoPath), { recursive: true });
     if (token) {
-      // Initial clone: temporarily inline the token in the URL, then strip it
-      // immediately so it never persists in `.git/config`. From then on git
-      // pulls the token from the credential helper / env var.
-      const tokenUrl = injectHttpsCreds(repo.gitUrl, httpsUsername, token);
-      if (!tokenUrl) {
+      if (!/^https:\/\//i.test(repo.gitUrl)) {
         throw new Error("HTTPS credentials require an https:// clone URL.");
       }
-      await runGit(path.dirname(repoPath), ["clone", "--quiet", tokenUrl, repo.slug]);
-      await runGit(repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
+      await runGit(
+        cwd,
+        path.dirname(repoPath),
+        ["clone", "--quiet", repo.gitUrl, repo.slug],
+        credentialEnv,
+        credentialHelper,
+      );
+      await runGit(cwd, repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
     } else {
       // SSH or public: clone the URL as-is (SSH key supplied via env).
-      await runGit(path.dirname(repoPath), ["clone", "--quiet", repo.gitUrl, repo.slug], cloneEnv);
+      await runGit(
+        cwd,
+        path.dirname(repoPath),
+        ["clone", "--quiet", repo.gitUrl, repo.slug],
+        cloneEnv,
+      );
     }
   } else {
     // Install/refresh the helper before fetch so a pre-existing private
     // checkout can authenticate even if it predates Genosyn's helper wiring.
     if (token) {
-      await configureCredentialHelper(repoPath, httpsUsername, envKey);
+      await configureCredentialHelper(cwd, repoPath, httpsUsername, envKey);
     } else {
-      await clearCredentialHelper(repoPath);
+      await clearCredentialHelper(cwd, repoPath);
     }
-    // Existing checkout: refresh refs but never touch the working tree.
-    await runGit(repoPath, ["fetch", "--all", "--prune", "--quiet"], {
-      ...cloneEnv,
-      ...credentialEnv,
-    });
-    await runGit(repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
+    await runGit(cwd, repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
+    // Existing checkout: refresh refs from only the trusted configured URL.
+    // Never visit remotes an AI Employee added to the writable local config.
+    await runGit(
+      cwd,
+      repoPath,
+      [
+        "fetch",
+        "--no-recurse-submodules",
+        "--prune",
+        "--quiet",
+        repo.gitUrl,
+        "+refs/heads/*:refs/remotes/origin/*",
+      ],
+      {
+        ...cloneEnv,
+        ...credentialEnv,
+      },
+      credentialHelper,
+    );
   }
 
   // Pin per-repo wiring every spawn (idempotent — settings may have changed
   // between spawns, e.g. a grant downgraded from write to read).
   if (sshCommand) {
-    await runGit(repoPath, ["config", "--local", "core.sshCommand", sshCommand]);
+    await runGit(cwd, repoPath, ["config", "--local", "core.sshCommand", sshCommand]);
   } else {
     // Drop any stale sshCommand if the repo flipped away from SSH.
-    await runGit(repoPath, ["config", "--local", "--unset", "core.sshCommand"]).catch(() => {});
+    await runGit(cwd, repoPath, ["config", "--local", "--unset", "core.sshCommand"]).catch(
+      () => {},
+    );
   }
   if (token) {
-    await configureCredentialHelper(repoPath, httpsUsername, envKey);
+    await configureCredentialHelper(cwd, repoPath, httpsUsername, envKey);
   } else {
-    await clearCredentialHelper(repoPath);
+    await clearCredentialHelper(cwd, repoPath);
   }
 
   // Read-only grants get their push URL disabled so an accidental `git push`
   // fails fast with a message naming the missing grant, rather than silently
   // succeeding on a token that happens to carry write scope.
   if (accessLevel === "write") {
-    await runGit(repoPath, ["remote", "set-url", "--push", "origin", repo.gitUrl]);
+    await runGit(cwd, repoPath, ["remote", "set-url", "--push", "origin", repo.gitUrl]);
   } else {
-    await runGit(repoPath, ["remote", "set-url", "--push", "origin", NO_PUSH_URL]);
+    await runGit(cwd, repoPath, ["remote", "set-url", "--push", "origin", NO_PUSH_URL]);
   }
 
   // Git identity for commits the agent makes.
   const committerName = (repo.committerName ?? "").trim() || employee.name;
   const committerEmail = (repo.committerEmail ?? "").trim() || `${employee.slug}@genosyn.local`;
-  await runGit(repoPath, ["config", "--local", "user.name", committerName]);
-  await runGit(repoPath, ["config", "--local", "user.email", committerEmail]);
+  await runGit(cwd, repoPath, ["config", "--local", "user.name", committerName]);
+  await runGit(cwd, repoPath, ["config", "--local", "user.email", committerEmail]);
 
   result.repos.push({
     codeRepositoryId: repo.id,
@@ -475,8 +492,8 @@ export function findGithubRepoCredential(
   return connectionIds.size === 1 ? (credentials[0] ?? null) : null;
 }
 
-async function clearCredentialHelper(repoPath: string): Promise<void> {
-  await clearEnvCredentialHelper((args) => runGit(repoPath, args));
+async function clearCredentialHelper(workspaceRoot: string, repoPath: string): Promise<void> {
+  await clearEnvCredentialHelper((args) => runGit(workspaceRoot, repoPath, args));
 }
 
 // ──────────────────────── test connection ───────────────────────────────
@@ -497,8 +514,8 @@ export type TestConnectionResult = {
 export async function testCodeRepoConnection(repo: CodeRepository): Promise<TestConnectionResult> {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-repo-"));
   try {
-    let url = repo.gitUrl;
     const env: Record<string, string> = {};
+    let credentialHelper: string | undefined;
 
     if (repo.authMode === "https") {
       const token = tryDecrypt(repo.encryptedToken);
@@ -508,14 +525,15 @@ export async function testCodeRepoConnection(repo: CodeRepository): Promise<Test
           message: "No HTTPS token is set. Add one and try again.",
         };
       }
-      const tokenUrl = injectHttpsCreds(url, httpsUsernameOf(repo), token);
-      if (!tokenUrl) {
+      if (!/^https:\/\//i.test(repo.gitUrl)) {
         return {
           ok: false,
           message: "Auth mode is HTTPS but the clone URL isn't an https:// URL.",
         };
       }
-      url = tokenUrl;
+      const envKey = "GENOSYN_REPO_TOKEN_CONNECTION_TEST";
+      env[envKey] = token;
+      credentialHelper = inlineEnvCredentialHelper(httpsUsernameOf(repo), envKey);
     } else if (repo.authMode === "ssh") {
       const key = tryDecrypt(repo.encryptedSshKey);
       if (!key) {
@@ -525,10 +543,16 @@ export async function testCodeRepoConnection(repo: CodeRepository): Promise<Test
       fs.writeFileSync(keyPath, key.endsWith("\n") ? key : key + "\n", {
         mode: 0o600,
       });
-      env.GIT_SSH_COMMAND = sshCommandFor(keyPath);
+      env.GIT_SSH_COMMAND = sshCommandFor(workspaceVisiblePath(tmp, keyPath));
     }
 
-    const { stdout } = await runGit(tmp, ["ls-remote", "--symref", url, "HEAD"], env);
+    const { stdout } = await runGit(
+      tmp,
+      tmp,
+      ["ls-remote", "--symref", repo.gitUrl, "HEAD"],
+      env,
+      credentialHelper,
+    );
     const m = stdout.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/);
     return {
       ok: true,

--- a/App/server/services/codexSubscription.test.ts
+++ b/App/server/services/codexSubscription.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AIModel } from "../db/entities/AIModel.js";
+import { decryptSecret } from "../lib/secret.js";
+import {
+  configWithSubscriptionAccessToken,
+  hasSubscriptionCredential,
+  isManagedChatgptAccount,
+  parseDeviceVerificationUrl,
+  shouldMaterializeRepositoriesForTurnFor,
+  subscriptionCredentialKind,
+  subscriptionUnavailableReasonFor,
+} from "./codexSubscription.js";
+
+test("device sign-in accepts only absolute HTTPS verification URLs", () => {
+  assert.equal(
+    parseDeviceVerificationUrl("https://auth.openai.com/codex/device"),
+    "https://auth.openai.com/codex/device",
+  );
+  assert.equal(parseDeviceVerificationUrl("javascript:alert(1)"), null);
+  assert.equal(parseDeviceVerificationUrl("http://auth.openai.com/codex/device"), null);
+  assert.equal(parseDeviceVerificationUrl("/codex/device"), null);
+});
+
+test("repository materialization is isolated or omitted when subscription auth can run", () => {
+  assert.equal(
+    shouldMaterializeRepositoriesForTurnFor({
+      authMode: "subscription",
+      codingToolsEnabled: true,
+      codingToolsExecutionMode: "bubblewrap",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldMaterializeRepositoriesForTurnFor({
+      authMode: "subscription",
+      codingToolsEnabled: true,
+      codingToolsExecutionMode: "host",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldMaterializeRepositoriesForTurnFor({
+      authMode: "apikey",
+      codingToolsEnabled: false,
+      codingToolsExecutionMode: "host",
+    }),
+    false,
+  );
+});
+
+function model(configJson = "{}"): AIModel {
+  return {
+    id: "model-subscription-test",
+    provider: "openai",
+    authMode: "subscription",
+    configJson,
+  } as AIModel;
+}
+
+test("Codex access tokens are encrypted and replace managed session credentials", () => {
+  const original = model(
+    JSON.stringify({
+      codexAuthEncrypted: "old-managed-session",
+      subscriptionCredentialKind: "chatgptSession",
+      harmlessSetting: true,
+    }),
+  );
+  const token = "codex-access-token-value-for-test";
+  const updated = configWithSubscriptionAccessToken(original, token);
+  const parsed = JSON.parse(updated) as Record<string, unknown>;
+
+  assert.equal(updated.includes(token), false);
+  assert.equal(parsed.codexAuthEncrypted, undefined);
+  assert.equal(parsed.subscriptionCredentialKind, "accessToken");
+  assert.equal(parsed.harmlessSetting, true);
+  assert.equal(decryptSecret(String(parsed.codexAccessTokenEncrypted)), token);
+
+  const connected = model(updated);
+  assert.equal(subscriptionCredentialKind(connected), "accessToken");
+  assert.equal(hasSubscriptionCredential(connected), true);
+});
+
+test("subscription credential detection fails closed on previews and malformed config", () => {
+  assert.equal(
+    subscriptionCredentialKind(model('{"subscriptionCredentialKind":"chatgptSession"}')),
+    null,
+  );
+  assert.equal(subscriptionCredentialKind(model("{")), null);
+  assert.equal(hasSubscriptionCredential(model('{"codexAuthEncrypted":" "}')), false);
+});
+
+test("managed login success follows the ChatGPT account discriminator", () => {
+  assert.equal(
+    isManagedChatgptAccount({
+      account: { type: "chatgpt", email: "member@example.com" },
+      requiresOpenaiAuth: true,
+    }),
+    true,
+  );
+  assert.equal(isManagedChatgptAccount({ account: null, requiresOpenaiAuth: true }), false);
+  assert.equal(
+    isManagedChatgptAccount({
+      account: { type: "apiKey" },
+      requiresOpenaiAuth: true,
+    }),
+    false,
+  );
+});
+
+test("subscription auth rejects shared and same-UID host-shell deployments", () => {
+  assert.match(
+    subscriptionUnavailableReasonFor({
+      multiTenant: true,
+      codingToolsExecutionMode: "disabled",
+      bubblewrapAvailable: false,
+    }) ?? "",
+    /self-hosted/,
+  );
+  assert.match(
+    subscriptionUnavailableReasonFor({
+      multiTenant: false,
+      codingToolsExecutionMode: "host",
+      bubblewrapAvailable: true,
+    }) ?? "",
+    /bubblewrap isolation/,
+  );
+  assert.equal(
+    subscriptionUnavailableReasonFor({
+      multiTenant: false,
+      codingToolsExecutionMode: "bubblewrap",
+      bubblewrapAvailable: true,
+    }),
+    null,
+  );
+  assert.match(
+    subscriptionUnavailableReasonFor({
+      multiTenant: false,
+      codingToolsExecutionMode: "bubblewrap",
+      bubblewrapAvailable: false,
+    }) ?? "",
+    /working bubblewrap/,
+  );
+});

--- a/App/server/services/codexSubscription.ts
+++ b/App/server/services/codexSubscription.ts
@@ -1,0 +1,874 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { config } from "../../config.js";
+import { AppDataSource } from "../db/datasource.js";
+import { AIModel } from "../db/entities/AIModel.js";
+import { Membership } from "../db/entities/Membership.js";
+import { decryptSecret, encryptSecret } from "../lib/secret.js";
+import { CodexAppServer } from "./agent/codexAppServer.js";
+import { bubblewrapProbeError } from "./runtimeSecurity.js";
+
+const AUTH_FILE_MAX_BYTES = 2 * 1024 * 1024;
+const DEVICE_LOGIN_TIMEOUT_MS = 15 * 60 * 1_000;
+const TERMINAL_SESSION_TTL_MS = 15 * 60 * 1_000;
+const STALE_TEMP_MAX_AGE_MS = 8 * 60 * 60 * 1_000;
+const MAX_ACTIVE_DEVICE_SESSIONS = 8;
+const AUTH_TEMP_PREFIX = "genosyn-codex-auth-";
+const WORK_TEMP_PREFIX = "genosyn-codex-work-";
+const REMOVE_RETRY_DELAYS_MS = [0, 50, 250] as const;
+
+export type SubscriptionCredentialKind = "chatgptSession" | "accessToken";
+export type SubscriptionDeviceStatus = "running" | "succeeded" | "failed" | "cancelled";
+
+export class SubscriptionCredentialConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubscriptionCredentialConflictError";
+  }
+}
+
+export type PublicSubscriptionDeviceSession = {
+  id: string;
+  status: SubscriptionDeviceStatus;
+  output: string | null;
+  loginUrl: string | null;
+  userCode: string | null;
+  error: string | null;
+};
+
+type DeviceSession = PublicSubscriptionDeviceSession & {
+  modelId: string;
+  companyId: string;
+  actorUserId: string;
+  expectedConfigJson: string;
+  loginId: string | null;
+  home: IsolatedCodexHome;
+  server: CodexAppServer;
+  timeout: ReturnType<typeof setTimeout>;
+  settling: boolean;
+  finishStarted: boolean;
+  finished: Promise<void>;
+  resolveFinished: () => void;
+};
+
+type IsolatedCodexHome = {
+  authRoot: string;
+  workspace: string;
+};
+
+export type CodexRuntimeLease = {
+  /** Fresh row loaded after this model's refresh-token lock was acquired. */
+  model: AIModel;
+  home: IsolatedCodexHome;
+  env: NodeJS.ProcessEnv;
+  credentialKind: SubscriptionCredentialKind;
+  finish: () => Promise<void>;
+};
+
+const deviceSessions = new Map<string, DeviceSession>();
+const deviceStarts = new Map<string, Promise<PublicSubscriptionDeviceSession>>();
+const modelLockTails = new Map<string, Promise<void>>();
+
+void sweepStaleCodexHomes();
+
+/**
+ * Locked-down app-server config used for both login and AI Employee turns.
+ *
+ * Codex receives only an empty scratch cwd. Genosyn's existing dynamic tools
+ * remain the sole path to employee files, browser sessions, Connections and
+ * other granted resources, so the product's own sandbox and approval policy
+ * stay authoritative.
+ */
+export const CODEX_CONFIG_OVERRIDES = [
+  'cli_auth_credentials_store="file"',
+  'mcp_oauth_credentials_store="file"',
+  'web_search="disabled"',
+  "tools.web_search=false",
+  "project_doc_max_bytes=0",
+  "project_doc_fallback_filenames=[]",
+  'history.persistence="none"',
+  "agents.enabled=false",
+  "features.shell_tool=false",
+  "features.unified_exec=false",
+  "features.apps=false",
+  "features.goals=false",
+  "features.hooks=false",
+  "features.memories=false",
+  "features.multi_agent=false",
+  "features.plugins=false",
+  "features.remote_plugin=false",
+  "features.skill_search=false",
+  "features.skill_mcp_dependency_install=false",
+  "features.browser_use=false",
+  "features.browser_use_external=false",
+  "features.browser_use_full_cdp_access=false",
+  "features.computer_use=false",
+  "features.in_app_browser=false",
+  "features.image_generation=false",
+  "features.code_mode_host=false",
+  "features.workspace_dependencies=false",
+  "features.tool_suggest=false",
+  "features.auth_elicitation=false",
+  "features.tool_call_mcp_elicitation=false",
+  "analytics.enabled=false",
+  'otel.exporter="none"',
+  'otel.metrics_exporter="none"',
+  'otel.trace_exporter="none"',
+  'approval_policy="never"',
+  'sandbox_mode="read-only"',
+  'shell_environment_policy.inherit="none"',
+  "shell_environment_policy.ignore_default_excludes=false",
+  "shell_environment_policy.include_only=[]",
+  "allow_login_shell=false",
+] as const;
+
+export function subscriptionUnavailableReasonFor(options: {
+  multiTenant: boolean;
+  codingToolsExecutionMode: "host" | "bubblewrap" | "disabled";
+  bubblewrapAvailable: boolean;
+}): string | null {
+  if (options.multiTenant) {
+    return "ChatGPT subscription sign-in is limited to trusted self-hosted Genosyn installs.";
+  }
+  if (options.codingToolsExecutionMode !== "bubblewrap") {
+    return 'ChatGPT subscription auth requires Linux bubblewrap isolation. Set config.agent.codingTools.executionMode to "bubblewrap".';
+  }
+  if (!options.bubblewrapAvailable) {
+    return "ChatGPT subscription auth requires a working bubblewrap executable and user namespaces.";
+  }
+  return null;
+}
+
+export function subscriptionUnavailableReason(): string | null {
+  // Preserve the cheap configuration checks on the normal host-mode path.
+  // The full namespace probe is synchronous and may take up to five seconds on
+  // a restrictive container, so run it only after the operator has explicitly
+  // selected bubblewrap.
+  const executionMode = config.agent.codingTools.executionMode;
+  if (config.security.multiTenant || executionMode !== "bubblewrap") {
+    return subscriptionUnavailableReasonFor({
+      multiTenant: config.security.multiTenant,
+      codingToolsExecutionMode: executionMode,
+      bubblewrapAvailable: false,
+    });
+  }
+  return subscriptionUnavailableReasonFor({
+    multiTenant: false,
+    codingToolsExecutionMode: executionMode,
+    bubblewrapAvailable: bubblewrapProbeError() === null,
+  });
+}
+
+/**
+ * Repository checkouts are writable by the AI Employee, including `.git/config`.
+ * Never hand one of those configs to a host-side git process immediately before
+ * materializing a subscription credential: git config can name executable
+ * credential helpers, SSH commands, remote helpers, and other hooks into the
+ * App UID. Subscription turns keep repository work inside the coding sandbox.
+ */
+export function shouldMaterializeRepositoriesForTurnFor(options: {
+  authMode: AIModel["authMode"];
+  codingToolsEnabled: boolean;
+  codingToolsExecutionMode: "host" | "bubblewrap" | "disabled";
+}): boolean {
+  if (!options.codingToolsEnabled || options.codingToolsExecutionMode === "disabled") return false;
+  if (options.authMode === "subscription") {
+    return options.codingToolsExecutionMode === "bubblewrap";
+  }
+  return true;
+}
+
+export function shouldMaterializeRepositoriesForTurn(authMode: AIModel["authMode"]): boolean {
+  return shouldMaterializeRepositoriesForTurnFor({
+    authMode,
+    codingToolsEnabled: config.agent.codingTools.enabled,
+    codingToolsExecutionMode: config.agent.codingTools.executionMode,
+  });
+}
+
+export function subscriptionCredentialKind(model: AIModel): SubscriptionCredentialKind | null {
+  const cfg = parseModelConfig(model.configJson);
+  if (nonEmptyString(cfg.codexAuthEncrypted)) return "chatgptSession";
+  if (nonEmptyString(cfg.codexAccessTokenEncrypted)) return "accessToken";
+  return null;
+}
+
+export function hasSubscriptionCredential(model: AIModel): boolean {
+  return subscriptionCredentialKind(model) !== null;
+}
+
+export function configWithSubscriptionAccessToken(model: AIModel, accessToken: string): string {
+  const cfg = parseModelConfig(model.configJson);
+  delete cfg.codexAuthEncrypted;
+  cfg.codexAccessTokenEncrypted = encryptSecret(accessToken, subscriptionScope(model.id));
+  cfg.subscriptionCredentialKind = "accessToken";
+  return JSON.stringify(cfg);
+}
+
+export async function saveSubscriptionAccessToken(
+  modelId: string,
+  accessToken: string,
+): Promise<AIModel> {
+  assertSubscriptionAllowed();
+  await cancelSubscriptionDeviceLoginsForModel(modelId);
+  const model = await loadSubscriptionModel(modelId);
+  const nextConfig = configWithSubscriptionAccessToken(model, accessToken);
+  const repo = AppDataSource.getRepository(AIModel);
+  const updated = await repo.update(
+    {
+      id: model.id,
+      provider: "openai",
+      authMode: "subscription",
+      configJson: model.configJson,
+    },
+    {
+      configJson: nextConfig,
+      connectedAt: new Date(),
+    },
+  );
+  if (updated.affected !== 1) {
+    throw new SubscriptionCredentialConflictError(
+      "This AI Model changed while the access token was being saved. Try again.",
+    );
+  }
+  const saved = await repo.findOneBy({ id: model.id });
+  if (!saved) throw new Error("AI Model not found after saving its access token.");
+  return saved;
+}
+
+export async function startSubscriptionDeviceLogin(
+  modelId: string,
+  authorization: { companyId: string; actorUserId: string },
+): Promise<PublicSubscriptionDeviceSession> {
+  const existingStart = deviceStarts.get(modelId);
+  if (existingStart) return existingStart;
+  const running = [...deviceSessions.values()].find(
+    (session) => session.modelId === modelId && session.status === "running",
+  );
+  if (running) return publicSession(running);
+  const activeModels = new Set([
+    ...deviceStarts.keys(),
+    ...[...deviceSessions.values()]
+      .filter((session) => session.status === "running")
+      .map((session) => session.modelId),
+  ]);
+  if (activeModels.size >= MAX_ACTIVE_DEVICE_SESSIONS) {
+    throw new Error(
+      `This Genosyn process already has ${MAX_ACTIVE_DEVICE_SESSIONS} active ChatGPT sign-ins. Cancel or finish one before starting another.`,
+    );
+  }
+
+  const start = startSubscriptionDeviceLoginInner(modelId, authorization);
+  deviceStarts.set(modelId, start);
+  try {
+    return await start;
+  } finally {
+    if (deviceStarts.get(modelId) === start) deviceStarts.delete(modelId);
+  }
+}
+
+async function startSubscriptionDeviceLoginInner(
+  modelId: string,
+  authorization: { companyId: string; actorUserId: string },
+): Promise<PublicSubscriptionDeviceSession> {
+  assertSubscriptionAllowed();
+  const model = await loadSubscriptionModel(modelId);
+  const running = [...deviceSessions.values()].find(
+    (session) => session.modelId === model.id && session.status === "running",
+  );
+  if (running) return publicSession(running);
+
+  const home = await createIsolatedCodexHome();
+  let server: CodexAppServer | null = null;
+  try {
+    server = await CodexAppServer.start({
+      cwd: home.workspace,
+      env: codexEnvironment(home.authRoot),
+      configOverrides: [...CODEX_CONFIG_OVERRIDES],
+    });
+
+    const id = crypto.randomUUID();
+    let resolveFinished!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const session: DeviceSession = {
+      id,
+      modelId: model.id,
+      companyId: authorization.companyId,
+      actorUserId: authorization.actorUserId,
+      expectedConfigJson: model.configJson,
+      status: "running" as const,
+      output: "Waiting for ChatGPT device authorization.",
+      loginUrl: null,
+      userCode: null,
+      error: null,
+      loginId: null,
+      home,
+      server,
+      settling: false,
+      finishStarted: false,
+      finished,
+      resolveFinished,
+      timeout: setTimeout(() => undefined, DEVICE_LOGIN_TIMEOUT_MS),
+    };
+    clearTimeout(session.timeout);
+
+    const earlyCompletion: { value: Record<string, unknown> | null } = {
+      value: null,
+    };
+    const stopNotifications = server.onNotification((method, params) => {
+      if (method !== "account/login/completed") return;
+      const body = asObject(params);
+      if (!body) return;
+      if (!session.loginId) {
+        earlyCompletion.value = body;
+        return;
+      }
+      if (body.loginId !== session.loginId) return;
+      stopNotifications();
+      void settleDeviceSession(
+        session,
+        body.success === true ? "succeeded" : "failed",
+        typeof body.error === "string" ? body.error : null,
+      );
+    });
+    server.onExit((error) => {
+      if (session.status !== "running") return;
+      void settleDeviceSession(
+        session,
+        "failed",
+        error?.message || "OpenAI Codex closed before sign-in completed.",
+      );
+    });
+
+    const login = await server.request<{
+      type: string;
+      loginId?: string;
+      verificationUrl?: string;
+      userCode?: string;
+    }>("account/login/start", { type: "chatgptDeviceCode" }, 60_000);
+    const verificationUrl = parseDeviceVerificationUrl(login.verificationUrl);
+    if (
+      login.type !== "chatgptDeviceCode" ||
+      !nonEmptyString(login.loginId) ||
+      !verificationUrl ||
+      !nonEmptyString(login.userCode)
+    ) {
+      throw new Error("OpenAI Codex returned an invalid device sign-in response.");
+    }
+
+    session.loginId = login.loginId;
+    session.loginUrl = verificationUrl;
+    session.userCode = login.userCode;
+    session.timeout = setTimeout(() => {
+      void settleDeviceSession(
+        session,
+        "failed",
+        "ChatGPT sign-in expired. Start a new sign-in to try again.",
+      );
+    }, DEVICE_LOGIN_TIMEOUT_MS);
+    session.timeout.unref?.();
+    deviceSessions.set(id, session);
+    if (earlyCompletion.value?.loginId === session.loginId) {
+      stopNotifications();
+      void settleDeviceSession(
+        session,
+        earlyCompletion.value.success === true ? "succeeded" : "failed",
+        typeof earlyCompletion.value.error === "string" ? earlyCompletion.value.error : null,
+      );
+    }
+    return publicSession(session);
+  } catch (error) {
+    if (server) await server.close().catch(() => undefined);
+    await removeIsolatedCodexHome(home);
+    throw error;
+  }
+}
+
+export function parseDeviceVerificationUrl(value: unknown): string | null {
+  if (!nonEmptyString(value)) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function getSubscriptionDeviceLogin(
+  modelId: string,
+  sessionId: string,
+): PublicSubscriptionDeviceSession | null {
+  const session = deviceSessions.get(sessionId);
+  return session && session.modelId === modelId ? publicSession(session) : null;
+}
+
+export async function cancelSubscriptionDeviceLogin(
+  modelId: string,
+  sessionId: string,
+): Promise<PublicSubscriptionDeviceSession | null> {
+  const session = deviceSessions.get(sessionId);
+  if (!session || session.modelId !== modelId) return null;
+  if (session.status !== "running") return publicSession(session);
+  if (session.settling) {
+    await session.finished;
+    return publicSession(session);
+  }
+
+  session.status = "cancelled";
+  if (session.loginId) {
+    await session.server
+      .request("account/login/cancel", { loginId: session.loginId }, 10_000)
+      .catch(() => undefined);
+  }
+  await finishDeviceSession(session);
+  return publicSession(session);
+}
+
+export async function cancelSubscriptionDeviceLoginsForModel(modelId: string): Promise<void> {
+  await deviceStarts.get(modelId)?.catch(() => undefined);
+  const matching = [...deviceSessions.values()].filter(
+    (session) => session.modelId === modelId && session.status === "running",
+  );
+  await Promise.all(matching.map((session) => cancelSubscriptionDeviceLogin(modelId, session.id)));
+}
+
+/**
+ * Materialize the model's encrypted credential into a private, short-lived
+ * Codex home. Managed ChatGPT auth may refresh while a turn runs; `finish`
+ * merges the refreshed JSON back into the same model row only if an admin did
+ * not replace the credential in the meantime.
+ */
+export async function prepareCodexRuntime(modelId: string): Promise<CodexRuntimeLease> {
+  assertSubscriptionAllowed();
+  const model = await loadSubscriptionModel(modelId);
+
+  const home = await createIsolatedCodexHome();
+  const cfg = parseModelConfig(model.configJson);
+  const authEncrypted = stringValue(cfg.codexAuthEncrypted);
+  const accessTokenEncrypted = stringValue(cfg.codexAccessTokenEncrypted);
+
+  try {
+    if (authEncrypted) {
+      const authJson = decryptSecret(authEncrypted);
+      validateManagedAuthJson(authJson);
+      await fs.writeFile(path.join(home.authRoot, "auth.json"), authJson, {
+        encoding: "utf8",
+        mode: 0o600,
+        flag: "wx",
+      });
+      return {
+        model,
+        home,
+        env: codexEnvironment(home.authRoot),
+        credentialKind: "chatgptSession",
+        finish: async () => {
+          try {
+            const refreshed = await readManagedAuthJson(home.authRoot);
+            if (refreshed !== authJson) {
+              await persistRefreshedManagedAuth(model.id, authEncrypted, refreshed);
+            }
+          } finally {
+            await removeIsolatedCodexHome(home);
+          }
+        },
+      };
+    }
+
+    if (accessTokenEncrypted) {
+      const accessToken = decryptSecret(accessTokenEncrypted);
+      if (!accessToken.trim()) throw new Error("The stored OpenAI access token is empty.");
+      return {
+        model,
+        home,
+        env: codexEnvironment(home.authRoot, accessToken),
+        credentialKind: "accessToken",
+        finish: () => removeIsolatedCodexHome(home),
+      };
+    }
+
+    throw new Error(
+      "No ChatGPT subscription credential is connected. Open Settings → Model and sign in.",
+    );
+  } catch (error) {
+    await removeIsolatedCodexHome(home);
+    throw error;
+  }
+}
+
+/**
+ * Managed ChatGPT refresh tokens rotate. Serialize turns using the same model
+ * so two copied temporary auth files can never race and invalidate each other.
+ */
+export async function withSubscriptionModelLock<T>(
+  modelId: string,
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = modelLockTails.get(modelId) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.catch(() => undefined).then(() => current);
+  modelLockTails.set(modelId, tail);
+
+  try {
+    await waitForLock(previous, signal);
+    if (signal?.aborted) throw abortError();
+    return await run();
+  } finally {
+    release();
+    void tail.finally(() => {
+      if (modelLockTails.get(modelId) === tail) modelLockTails.delete(modelId);
+    });
+  }
+}
+
+async function settleDeviceSession(
+  session: DeviceSession,
+  status: "succeeded" | "failed",
+  error: string | null,
+): Promise<void> {
+  if (session.status !== "running" || session.settling) return;
+  session.settling = true;
+  try {
+    if (status === "succeeded") {
+      const account = await session.server.request<unknown>(
+        "account/read",
+        { refreshToken: false },
+        30_000,
+      );
+      if (!isManagedChatgptAccount(account)) {
+        throw new Error("OpenAI Codex did not confirm the managed ChatGPT account.");
+      }
+      const authJson = await readManagedAuthJson(session.home.authRoot);
+      const membership = await AppDataSource.getRepository(Membership).findOneBy({
+        companyId: session.companyId,
+        userId: session.actorUserId,
+      });
+      if (!membership || (membership.role !== "admin" && membership.role !== "owner")) {
+        throw new Error("The Member who started sign-in is no longer an admin of this company.");
+      }
+      const cfg = parseModelConfig(session.expectedConfigJson);
+      delete cfg.codexAccessTokenEncrypted;
+      cfg.codexAuthEncrypted = encryptSecret(authJson, subscriptionScope(session.modelId));
+      cfg.subscriptionCredentialKind = "chatgptSession";
+      const updated = await AppDataSource.getRepository(AIModel).update(
+        {
+          id: session.modelId,
+          provider: "openai",
+          authMode: "subscription",
+          configJson: session.expectedConfigJson,
+        },
+        {
+          configJson: JSON.stringify(cfg),
+          connectedAt: new Date(),
+        },
+      );
+      if (updated.affected !== 1) {
+        throw new Error(
+          "This AI Model changed while sign-in was in progress. Start sign-in again.",
+        );
+      }
+      session.status = "succeeded";
+      session.output = "ChatGPT subscription connected.";
+      session.error = null;
+    } else {
+      session.status = "failed";
+      session.output = null;
+      session.error = safePublicError(error || "ChatGPT sign-in failed.");
+    }
+  } catch (persistError) {
+    session.status = "failed";
+    session.output = null;
+    session.error = safePublicError(
+      persistError instanceof Error ? persistError.message : String(persistError),
+    );
+  } finally {
+    await finishDeviceSession(session);
+  }
+}
+
+async function finishDeviceSession(session: DeviceSession): Promise<void> {
+  if (session.finishStarted) {
+    await session.finished;
+    return;
+  }
+  session.finishStarted = true;
+  try {
+    clearTimeout(session.timeout);
+    await session.server.close().catch(() => undefined);
+    await removeIsolatedCodexHome(session.home);
+    const expiry = setTimeout(() => deviceSessions.delete(session.id), TERMINAL_SESSION_TTL_MS);
+    expiry.unref?.();
+  } finally {
+    session.resolveFinished();
+  }
+}
+
+async function persistRefreshedManagedAuth(
+  modelId: string,
+  expectedCiphertext: string,
+  authJson: string,
+): Promise<void> {
+  validateManagedAuthJson(authJson);
+  const repo = AppDataSource.getRepository(AIModel);
+  const fresh = await repo.findOneBy({ id: modelId });
+  if (!fresh || fresh.provider !== "openai" || fresh.authMode !== "subscription") return;
+  const cfg = parseModelConfig(fresh.configJson);
+  if (cfg.codexAuthEncrypted !== expectedCiphertext || cfg.codexAccessTokenEncrypted) return;
+  cfg.codexAuthEncrypted = encryptSecret(authJson, subscriptionScope(modelId));
+  cfg.subscriptionCredentialKind = "chatgptSession";
+  await repo.update(
+    {
+      id: modelId,
+      provider: "openai",
+      authMode: "subscription",
+      configJson: fresh.configJson,
+    },
+    {
+      configJson: JSON.stringify(cfg),
+      connectedAt: fresh.connectedAt ?? new Date(),
+    },
+  );
+}
+
+async function loadSubscriptionModel(modelId: string): Promise<AIModel> {
+  const model = await AppDataSource.getRepository(AIModel).findOneBy({ id: modelId });
+  if (!model) throw new Error("AI Model not found.");
+  if (model.provider !== "openai" || model.authMode !== "subscription") {
+    throw new Error("Only OpenAI AI Models in subscription mode can sign in with ChatGPT.");
+  }
+  return model;
+}
+
+function assertSubscriptionAllowed(): void {
+  const unavailable = subscriptionUnavailableReason();
+  if (unavailable) throw new Error(unavailable);
+}
+
+async function createIsolatedCodexHome(): Promise<IsolatedCodexHome> {
+  const authRoot = await fs.mkdtemp(path.join(os.tmpdir(), AUTH_TEMP_PREFIX));
+  await fs.chmod(authRoot, 0o700);
+  try {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), WORK_TEMP_PREFIX));
+    await fs.chmod(workspace, 0o700);
+    return { authRoot, workspace };
+  } catch (error) {
+    await removePathWithRetry(authRoot);
+    throw error;
+  }
+}
+
+async function removeIsolatedCodexHome(home: IsolatedCodexHome): Promise<void> {
+  const results = await Promise.allSettled([
+    removePathWithRetry(home.authRoot),
+    removePathWithRetry(home.workspace),
+  ]);
+  for (const [index, result] of results.entries()) {
+    if (result.status === "fulfilled") continue;
+    const target = index === 0 ? "authentication" : "workspace";
+    console.warn(
+      `[genosyn] could not remove temporary Codex ${target} directory: ${safePublicError(
+        result.reason instanceof Error ? result.reason.message : String(result.reason),
+      )}`,
+    );
+  }
+}
+
+async function removePathWithRetry(target: string): Promise<void> {
+  let lastError: unknown;
+  for (const delayMs of REMOVE_RETRY_DELAYS_MS) {
+    if (delayMs > 0) await delay(delayMs);
+    try {
+      await fs.rm(target, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+async function sweepStaleCodexHomes(): Promise<void> {
+  const tempRoot = os.tmpdir();
+  const cutoff = Date.now() - STALE_TEMP_MAX_AGE_MS;
+  try {
+    const entries = await fs.readdir(tempRoot, { withFileTypes: true });
+    await Promise.all(
+      entries
+        .filter(
+          (entry) =>
+            entry.isDirectory() &&
+            (entry.name.startsWith(AUTH_TEMP_PREFIX) || entry.name.startsWith(WORK_TEMP_PREFIX)),
+        )
+        .map(async (entry) => {
+          const target = path.join(tempRoot, entry.name);
+          const stat = await fs.stat(target).catch(() => null);
+          if (stat && stat.mtimeMs < cutoff) await removePathWithRetry(target);
+        }),
+    );
+  } catch (error) {
+    console.warn(
+      `[genosyn] could not sweep stale temporary Codex directories: ${safePublicError(
+        error instanceof Error ? error.message : String(error),
+      )}`,
+    );
+  }
+}
+
+function codexEnvironment(root: string, accessToken?: string): NodeJS.ProcessEnv {
+  const inherited = [
+    "PATH",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "NODE_EXTRA_CA_CERTS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of inherited) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  env.HOME = root;
+  env.XDG_CONFIG_HOME = root;
+  env.CODEX_HOME = root;
+  env.NO_COLOR = "1";
+  if (accessToken) env.CODEX_ACCESS_TOKEN = accessToken;
+  return env;
+}
+
+async function readManagedAuthJson(root: string): Promise<string> {
+  const file = path.join(root, "auth.json");
+  const stat = await fs.stat(file);
+  if (!stat.isFile() || stat.size <= 0 || stat.size > AUTH_FILE_MAX_BYTES) {
+    throw new Error("OpenAI Codex wrote an invalid authentication file.");
+  }
+  const value = await fs.readFile(file, "utf8");
+  validateManagedAuthJson(value);
+  return value;
+}
+
+function validateManagedAuthJson(value: string): void {
+  if (Buffer.byteLength(value, "utf8") > AUTH_FILE_MAX_BYTES) {
+    throw new Error("OpenAI Codex authentication data is too large.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("OpenAI Codex authentication data is not valid JSON.");
+  }
+  const auth = asObject(parsed);
+  const tokens = asObject(auth?.tokens);
+  if (
+    auth?.auth_mode !== "chatgpt" ||
+    !nonEmptyString(tokens?.access_token) ||
+    !nonEmptyString(tokens?.id_token) ||
+    !nonEmptyString(tokens?.refresh_token)
+  ) {
+    throw new Error("OpenAI Codex did not return a complete managed ChatGPT session.");
+  }
+}
+
+/**
+ * `requiresOpenaiAuth` describes the active provider, not login success, and
+ * remains true for an authenticated ChatGPT account. The account discriminator
+ * is the authoritative success signal.
+ */
+export function isManagedChatgptAccount(value: unknown): boolean {
+  const response = asObject(value);
+  const account = asObject(response?.account);
+  return account?.type === "chatgpt";
+}
+
+function parseModelConfig(value: string): Record<string, unknown> {
+  try {
+    return asObject(JSON.parse(value || "{}")) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function subscriptionScope(modelId: string): string {
+  return `model:${modelId}:openai-subscription`;
+}
+
+function publicSession(session: DeviceSession): PublicSubscriptionDeviceSession {
+  return {
+    id: session.id,
+    status: session.status,
+    output: session.output,
+    loginUrl: session.loginUrl,
+    userCode: session.userCode,
+    error: session.error,
+  };
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function stringValue(value: unknown): string | null {
+  return nonEmptyString(value) ? value : null;
+}
+
+function safePublicError(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 1_000);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForLock(previous: Promise<void>, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    await previous;
+    return;
+  }
+  if (signal.aborted) throw abortError();
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(abortError());
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    previous.then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function abortError(): Error {
+  const error = new Error("The OpenAI subscription turn was aborted.");
+  error.name = "AbortError";
+  return error;
+}

--- a/App/server/services/providers.test.ts
+++ b/App/server/services/providers.test.ts
@@ -16,6 +16,7 @@ test("provider catalogue exposes exactly the supported model APIs", () => {
   ][]) {
     assert.ok(spec.label.length > 0, `${provider} needs a label`);
     assert.equal(spec.supportsApiKey, provider !== "custom");
+    assert.equal(spec.supportsSubscription, provider === "openai");
     assert.equal(spec.supportsCustomEndpoint, provider === "custom");
     assert.equal(spec.apiKeyEnv === null, provider === "custom");
   }
@@ -36,15 +37,33 @@ test("custom models require a non-blank encrypted base URL but not an API key", 
   );
   assert.equal(
     isModelConnected(
-      model(
-        "customEndpoint",
-        '{"baseURLEncrypted":"v2:ciphertext","apiKeyEncrypted":""}',
-      ),
+      model("customEndpoint", '{"baseURLEncrypted":"v2:ciphertext","apiKeyEncrypted":""}'),
     ),
     true,
   );
   assert.equal(isModelConnected(model("customEndpoint", '{"baseURLEncrypted":"\\t"}')), false);
   assert.equal(isModelConnected(model("customEndpoint", '{"modelId":"local-model"}')), false);
+});
+
+test("subscription models accept either managed ChatGPT auth or a Codex access token", () => {
+  assert.equal(
+    isModelConnected(model("subscription", '{"codexAuthEncrypted":"v2:ciphertext"}')),
+    true,
+  );
+  assert.equal(
+    isModelConnected(model("subscription", '{"codexAccessTokenEncrypted":"v2:ciphertext"}')),
+    true,
+  );
+  assert.equal(
+    isModelConnected(
+      model("subscription", '{"codexAuthEncrypted":" ","codexAccessTokenEncrypted":""}'),
+    ),
+    false,
+  );
+  assert.equal(
+    isModelConnected(model("subscription", '{"subscriptionCredentialKind":"chatgptSession"}')),
+    false,
+  );
 });
 
 test("malformed or non-object model configuration is disconnected", () => {

--- a/App/server/services/providers.ts
+++ b/App/server/services/providers.ts
@@ -1,11 +1,11 @@
 import type { AIModel, Provider } from "../db/entities/AIModel.js";
 
 /**
- * Per-provider facts for the three model APIs an employee can run on now that
- * the CLI harnesses are gone. There is no CLI to install, no subscription to
- * sign into, and no on-disk credential dir — a provider is just an API we call
- * in-process, and its "spec" is the handful of facts the UI and the credential
- * resolver need.
+ * Per-provider facts for the model backends an employee can run. API-key and
+ * custom-endpoint models are called directly in-process. OpenAI additionally
+ * supports the official Codex app-server subscription runtime on trusted
+ * self-hosted installs; this narrow integration is not a return to arbitrary
+ * provider CLI harnesses.
  *
  *   - anthropic → Anthropic Messages API (Claude), API key
  *   - openai    → OpenAI Chat Completions API (GPT), API key
@@ -21,6 +21,8 @@ export type ProviderSpec = {
   apiKeyEnv: string | null;
   /** Does this provider connect with a plain API key? */
   supportsApiKey: boolean;
+  /** Does this provider have a sanctioned consumer-subscription runtime? */
+  supportsSubscription: boolean;
   /** Does this provider connect via a custom OpenAI-compatible endpoint? */
   supportsCustomEndpoint: boolean;
 };
@@ -31,6 +33,7 @@ export const PROVIDERS: Record<Provider, ProviderSpec> = {
     defaultModel: "claude-opus-4-6",
     apiKeyEnv: "ANTHROPIC_API_KEY",
     supportsApiKey: true,
+    supportsSubscription: false,
     supportsCustomEndpoint: false,
   },
   openai: {
@@ -38,6 +41,7 @@ export const PROVIDERS: Record<Provider, ProviderSpec> = {
     defaultModel: "gpt-4o",
     apiKeyEnv: "OPENAI_API_KEY",
     supportsApiKey: true,
+    supportsSubscription: true,
     supportsCustomEndpoint: false,
   },
   custom: {
@@ -45,6 +49,7 @@ export const PROVIDERS: Record<Provider, ProviderSpec> = {
     defaultModel: "",
     apiKeyEnv: null,
     supportsApiKey: false,
+    supportsSubscription: false,
     supportsCustomEndpoint: true,
   },
 };
@@ -52,6 +57,8 @@ export const PROVIDERS: Record<Provider, ProviderSpec> = {
 /**
  * A Model is "connected" if a usable credential is present:
  *  - apikey:         an encrypted API key is on file
+ *  - subscription:   an encrypted managed ChatGPT session or supported
+ *                    Codex access token is on file
  *  - customEndpoint: an encrypted base URL is on file (the key is optional —
  *                    most local servers don't enforce one)
  */
@@ -65,14 +72,20 @@ export function isModelConnected(m: AIModel): boolean {
   }
   if (m.authMode === "apikey") {
     return (
-      typeof cfg.apiKeyEncrypted === "string" &&
-      (cfg.apiKeyEncrypted as string).trim().length > 0
+      typeof cfg.apiKeyEncrypted === "string" && (cfg.apiKeyEncrypted as string).trim().length > 0
+    );
+  }
+  if (m.authMode === "subscription") {
+    return (
+      (typeof cfg.codexAuthEncrypted === "string" &&
+        (cfg.codexAuthEncrypted as string).trim().length > 0) ||
+      (typeof cfg.codexAccessTokenEncrypted === "string" &&
+        (cfg.codexAccessTokenEncrypted as string).trim().length > 0)
     );
   }
   if (m.authMode === "customEndpoint") {
     return (
-      typeof cfg.baseURLEncrypted === "string" &&
-      (cfg.baseURLEncrypted as string).trim().length > 0
+      typeof cfg.baseURLEncrypted === "string" && (cfg.baseURLEncrypted as string).trim().length > 0
     );
   }
   return false;

--- a/App/server/services/repoSync.ts
+++ b/App/server/services/repoSync.ts
@@ -1,5 +1,3 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import path from "node:path";
 import fs from "node:fs";
 import { AppDataSource } from "../db/datasource.js";
@@ -11,7 +9,8 @@ import {
   loadEmployeeConnections,
 } from "./integrations.js";
 import { readGithubRepos, resolveGithubCredentials } from "../integrations/providers/github.js";
-import { configureEnvCredentialHelper } from "./gitCredentialHelper.js";
+import { configureEnvCredentialHelper, inlineEnvCredentialHelper } from "./gitCredentialHelper.js";
+import { runWorkspaceGit } from "./workspaceGit.js";
 
 /**
  * Repo sync seam — materializes git checkouts of every allowlisted repo on
@@ -45,8 +44,6 @@ import { configureEnvCredentialHelper } from "./gitCredentialHelper.js";
  * the turn so `git push` Just Works, then the env var disappears with the
  * turn and does not leak to other employees.
  */
-
-const exec = promisify(execFile);
 
 export type SyncedRepo = {
   connectionId: string;
@@ -202,6 +199,7 @@ async function syncConnection(
     try {
       const repoPath = path.join(cwd, "repos", repo.owner, repo.name);
       await syncOneRepo({
+        workspaceRoot: cwd,
         repoPath,
         owner: repo.owner,
         name: repo.name,
@@ -226,6 +224,7 @@ async function syncConnection(
 }
 
 async function syncOneRepo(args: {
+  workspaceRoot: string;
   repoPath: string;
   owner: string;
   name: string;
@@ -236,60 +235,65 @@ async function syncOneRepo(args: {
   const cleanRemote = `https://github.com/${args.owner}/${args.name}.git`;
   const isCheckout = fs.existsSync(path.join(args.repoPath, ".git"));
   const credentialEnv = { [args.envKey]: args.token };
+  const credentialHelper = inlineEnvCredentialHelper("x-access-token", args.envKey);
 
   if (!isCheckout) {
     fs.mkdirSync(path.dirname(args.repoPath), { recursive: true });
-    // Initial clone: temporarily inline the token in the URL. We strip it
-    // immediately afterward via `remote set-url`, and from this point on
-    // git pulls the token from the credential helper instead.
-    const tokenUrl = `https://x-access-token:${args.token}@github.com/${args.owner}/${args.name}.git`;
-    await runGit(path.dirname(args.repoPath), ["clone", "--quiet", tokenUrl, args.name]);
-    await runGit(args.repoPath, ["remote", "set-url", "origin", cleanRemote]);
-    await configureCredentialHelper(args.repoPath, args.envKey);
+    await runWorkspaceGit({
+      workspaceRoot: args.workspaceRoot,
+      cwd: path.dirname(args.repoPath),
+      args: ["clone", "--quiet", cleanRemote, args.name],
+      extraEnv: credentialEnv,
+      credentialHelper,
+    });
+    await runWorkspaceGit({
+      workspaceRoot: args.workspaceRoot,
+      cwd: args.repoPath,
+      args: ["remote", "set-url", "origin", cleanRemote],
+    });
+    await configureCredentialHelper(args.workspaceRoot, args.repoPath, args.envKey);
   } else {
     // Older/manual checkouts may not have a helper yet. Install it before the
     // first authenticated fetch, and make its turn token available to this
     // server-side git process as well as the later employee bash process.
-    await configureCredentialHelper(args.repoPath, args.envKey);
-    // Existing checkout: fetch fresh refs but never touch the agent's
-    // working tree or current branch. The agent decides when to merge.
-    await runGit(args.repoPath, ["fetch", "--all", "--prune", "--quiet"], credentialEnv);
-    // Make sure the remote URL doesn't carry a stale token from a previous
-    // version of this code or a manual `git remote add`.
-    await runGit(args.repoPath, ["remote", "set-url", "origin", cleanRemote]);
-  }
-}
-
-async function configureCredentialHelper(repoPath: string, envKey: string): Promise<void> {
-  await configureEnvCredentialHelper((args) => runGit(repoPath, args), "x-access-token", envKey);
-}
-
-async function runGit(
-  cwd: string,
-  args: string[],
-  extraEnv: Record<string, string> = {},
-): Promise<void> {
-  try {
-    await exec("git", args, {
-      cwd,
-      // Disable interactive auth prompts. With no TTY git will fail fast on
-      // missing creds rather than hanging the runner.
-      env: {
-        ...process.env,
-        GIT_TERMINAL_PROMPT: "0",
-        GIT_ASKPASS: "/bin/echo",
-        ...extraEnv,
-      },
-      maxBuffer: 16 * 1024 * 1024,
+    await configureCredentialHelper(args.workspaceRoot, args.repoPath, args.envKey);
+    await runWorkspaceGit({
+      workspaceRoot: args.workspaceRoot,
+      cwd: args.repoPath,
+      args: ["remote", "set-url", "origin", cleanRemote],
     });
-  } catch (err) {
-    if ((err as { code?: string }).code === "ENOENT") {
-      throw new Error(
-        `git is not installed on the Genosyn server, so "git ${args[0]}" could not run. Install git (the official Genosyn Docker image bundles it) and try again.`,
-      );
-    }
-    const e = err as { stderr?: string; stdout?: string; message?: string };
-    const tail = (e.stderr || e.stdout || e.message || "").toString().trim();
-    throw new Error(`git ${args[0]} failed: ${tail.split("\n").slice(-3).join(" | ")}`);
+    // Fetch only the trusted configured URL. Attacker-added remotes in the
+    // writable local config are never visited.
+    await runWorkspaceGit({
+      workspaceRoot: args.workspaceRoot,
+      cwd: args.repoPath,
+      args: [
+        "fetch",
+        "--no-recurse-submodules",
+        "--prune",
+        "--quiet",
+        cleanRemote,
+        "+refs/heads/*:refs/remotes/origin/*",
+      ],
+      extraEnv: credentialEnv,
+      credentialHelper,
+    });
   }
+}
+
+async function configureCredentialHelper(
+  workspaceRoot: string,
+  repoPath: string,
+  envKey: string,
+): Promise<void> {
+  await configureEnvCredentialHelper(
+    (gitArgs) =>
+      runWorkspaceGit({
+        workspaceRoot,
+        cwd: repoPath,
+        args: gitArgs,
+      }),
+    "x-access-token",
+    envKey,
+  );
 }

--- a/App/server/services/runner.ts
+++ b/App/server/services/runner.ts
@@ -25,6 +25,9 @@ import { composeEmployeeSystemPrompt } from "./agent/systemPrompt.js";
 import { residentNamesForSkills, skillToolsetMap } from "./skillToolset.js";
 import { acquireWorkloadLease, releaseWorkloadLease } from "./workloadLeases.js";
 import { DurableRunLog, RUN_LOG_MAX_BYTES } from "./runLog.js";
+import { supportsParallelDelegation } from "./agent/tools/parallelDelegation.js";
+import { shouldMaterializeRepositoriesForTurn } from "./codexSubscription.js";
+import { CODING_TOOL_NAMES } from "./agent/tools/coding.js";
 
 export { RUN_LOG_MAX_BYTES } from "./runLog.js";
 
@@ -156,10 +159,7 @@ export async function startRoutineRun(
     persist: async (content) => {
       // Never let a late checkpoint overwrite a terminal row recovered or
       // finalized elsewhere. Only the transcript column changes.
-      await runRepo.update(
-        { id: saved.id, status: "running" },
-        { logContent: content },
-      );
+      await runRepo.update({ id: saved.id, status: "running" }, { logContent: content });
     },
     onCheckpointError: (error) => {
       // A later checkpoint or the final Run save will try again. The Routine
@@ -218,8 +218,24 @@ export async function startRoutineRun(
         return saved;
       }
 
+      const parallelDelegationAvailable = supportsParallelDelegation(model.authMode);
+      const unavailableCodingTools =
+        !config.agent.codingTools.enabled || config.agent.codingTools.executionMode === "disabled"
+          ? [...CODING_TOOL_NAMES]
+          : config.agent.codingTools.executionMode === "bubblewrap"
+            ? CODING_TOOL_NAMES.filter((name) => name !== "bash")
+            : model.authMode === "subscription"
+              ? [...CODING_TOOL_NAMES]
+              : [];
+      const unavailableSkillTools = [
+        ...(parallelDelegationAvailable ? [] : ["delegate_parallel_work"]),
+        ...unavailableCodingTools,
+      ];
+      const repositoryMaterializationAllowed = shouldMaterializeRepositoriesForTurn(model.authMode);
       const memoryContext = await composeMemoryContext(emp.id);
-      const codeReposContext = await composeCodeReposContext(emp.id);
+      const codeReposContext = repositoryMaterializationAllowed
+        ? await composeCodeReposContext(emp.id)
+        : "";
       const financeContext = await composeFinanceContext(emp.id);
       const [revenueContext, marketingContext] = await Promise.all([
         composeRevenueContext(emp.id),
@@ -235,10 +251,13 @@ export async function startRoutineRun(
         revenueContext,
         marketingContext,
         surface: "routine",
+        parallelDelegationAvailable,
+        codingToolsAvailable: unavailableCodingTools.length < CODING_TOOL_NAMES.length,
+        isolatedCodingTools: config.agent.codingTools.executionMode === "bubblewrap",
         opening:
           `You are ${emp.name}, ${emp.role} at ${co.name}. The following documents are yours — ` +
           `your Soul, your Memory, and your Skills.`,
-        skillToolsets: skillToolsetMap(skills),
+        skillToolsets: skillToolsetMap(skills, unavailableSkillTools),
       });
       const userMessage = composeRoutineMessage(routine, missedSlots);
 
@@ -257,25 +276,29 @@ export async function startRoutineRun(
         }
       }
 
-      // Materialize granted GitHub Connection repos + provider-agnostic Code
-      // Repositories into the employee's cwd. Errors are non-fatal.
-      const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
-      Object.assign(toolEnv, repoSync.extraEnv);
-      for (const r of repoSync.repos) {
-        log.line(`[repos] synced ${r.owner}/${r.name}@${r.defaultBranch}`);
-      }
-      for (const e of repoSync.errors) log.line(`[repos] ${e.scope}: ${e.message}`);
+      if (repositoryMaterializationAllowed) {
+        // Materialize granted GitHub Connection repos + provider-agnostic Code
+        // Repositories into the employee's cwd. Errors are non-fatal.
+        const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
+        Object.assign(toolEnv, repoSync.extraEnv);
+        for (const r of repoSync.repos) {
+          log.line(`[repos] synced ${r.owner}/${r.name}@${r.defaultBranch}`);
+        }
+        for (const e of repoSync.errors) log.line(`[repos] ${e.scope}: ${e.message}`);
 
-      const codeRepoSync = await materializeCodeReposForEmployee({
-        employeeId: emp.id,
-        cwd,
-        githubRepoCredentials: repoSync.githubRepoCredentials,
-      });
-      Object.assign(toolEnv, codeRepoSync.extraEnv);
-      for (const r of codeRepoSync.repos) {
-        log.line(`[code-repos] synced ${r.slug}@${r.defaultBranch} (${r.accessLevel})`);
+        const codeRepoSync = await materializeCodeReposForEmployee({
+          employeeId: emp.id,
+          cwd,
+          githubRepoCredentials: repoSync.githubRepoCredentials,
+        });
+        Object.assign(toolEnv, codeRepoSync.extraEnv);
+        for (const r of codeRepoSync.repos) {
+          log.line(`[code-repos] synced ${r.slug}@${r.defaultBranch} (${r.accessLevel})`);
+        }
+        for (const e of codeRepoSync.errors) log.line(`[code-repos] ${e.scope}: ${e.message}`);
+      } else {
+        log.line("[repos] automatic repository sync is disabled for this Run");
       }
-      for (const e of codeRepoSync.errors) log.line(`[code-repos] ${e.scope}: ${e.message}`);
 
       log.line("");
 
@@ -304,7 +327,7 @@ export async function startRoutineRun(
           genosynToken: mcpToken,
           bashTimeoutMs: Math.min(timeoutMs, 5 * 60 * 1000),
           maxSteps: RUN_MAX_STEPS,
-          skillToolset: residentNamesForSkills(skills),
+          skillToolset: residentNamesForSkills(skills, unavailableSkillTools),
           routineId: routine.id,
           runId: saved.id,
           signal: controller.signal,
@@ -465,7 +488,9 @@ function toolDeferLine(d: ToolDeferralInfo): string {
     return `[tools] ${d.resident} tools, all loaded up-front (discovery off or catalogue small).`;
   }
   const skills =
-    d.fromSkills.length > 0 ? ` (${d.fromSkills.length} from Skills: ${d.fromSkills.join(", ")})` : "";
+    d.fromSkills.length > 0
+      ? ` (${d.fromSkills.length} from Skills: ${d.fromSkills.join(", ")})`
+      : "";
   return (
     `[tools] ${d.resident} loaded${skills}, ${d.deferred} in the catalogue behind find_tools ` +
     `— ${d.domains.join(", ")}.`

--- a/App/server/services/runtimeSecurity.ts
+++ b/App/server/services/runtimeSecurity.ts
@@ -1,11 +1,11 @@
 import { config } from "../../config.js";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { getEffectiveGlobalSmtp } from "./globalEmailTransport.js";
-import {
-  getPublicUrl,
-  isPublicUrlConfigured,
-} from "./publicUrl.js";
+import { getPublicUrl, isPublicUrlConfigured } from "./publicUrl.js";
+import { buildBubblewrapCommandArgs } from "./agent/bubblewrap.js";
 
 const PLACEHOLDERS = new Set(["change-me-in-production", "change-me-in-production-too"]);
 
@@ -13,34 +13,43 @@ function strongSecret(value: string): boolean {
   return value.length >= 32 && !PLACEHOLDERS.has(value);
 }
 
-function bubblewrapProbeError(): string | null {
-  const result = spawnSync(
-    config.agent.codingTools.bubblewrapPath,
-    [
-      "--die-with-parent",
-      "--new-session",
-      "--unshare-user",
-      "--unshare-pid",
-      "--unshare-ipc",
-      "--unshare-uts",
-      "--unshare-cgroup",
-      "--proc",
-      "/proc",
-      "--dev",
-      "/dev",
-      "--ro-bind",
-      "/bin",
-      "/bin",
-      "--ro-bind",
-      "/usr",
-      "/usr",
-      "--",
-      "/bin/true",
-    ],
-    { encoding: "utf8", timeout: 5_000 },
-  );
-  if (!result.error && result.status === 0) return null;
-  return (result.stderr || result.error?.message || `exit status ${result.status}`).trim();
+let bubblewrapProbeCache: { path: string; error: string | null } | null = null;
+
+export function bubblewrapProbeError(): string | null {
+  if (bubblewrapProbeCache?.path === config.agent.codingTools.bubblewrapPath) {
+    return bubblewrapProbeCache.error;
+  }
+  const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-bwrap-probe-"));
+  try {
+    const result = spawnSync(
+      config.agent.codingTools.bubblewrapPath,
+      buildBubblewrapCommandArgs({
+        workspaceRoot: probeRoot,
+        cwd: probeRoot,
+        executable: "/bin/true",
+        args: [],
+        env: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          HOME: "/workspace",
+          LANG: "C.UTF-8",
+        },
+        unshareNetwork: true,
+      }),
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+        env: { PATH: "/usr/local/bin:/usr/bin:/bin" },
+      },
+    );
+    const error =
+      !result.error && result.status === 0
+        ? null
+        : (result.stderr || result.error?.message || `exit status ${result.status}`).trim();
+    bubblewrapProbeCache = { path: config.agent.codingTools.bubblewrapPath, error };
+    return error;
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true });
+  }
 }
 
 export function secureSessionCookies(): boolean {

--- a/App/server/services/skillToolset.test.ts
+++ b/App/server/services/skillToolset.test.ts
@@ -6,7 +6,10 @@ import {
   serializeToolset,
   validateToolset,
   MAX_TOOLSET_ENTRIES,
+  residentNamesForSkills,
+  skillToolsetMap,
 } from "./skillToolset.js";
+import type { Skill } from "../db/entities/Skill.js";
 
 describe("parseToolset", () => {
   test("reads a stored list", () => {
@@ -102,4 +105,15 @@ describe("validateToolset", () => {
     assert.equal(validateToolset("send_invoice" as unknown).ok, false);
     assert.equal(validateToolset([123] as unknown).ok, false);
   });
+});
+
+test("runtime toolsets omit a declared tool that is unavailable for the turn", () => {
+  const skill = {
+    id: "skill-1",
+    toolsetJson: JSON.stringify(["delegate_parallel_work", "read_file", "send_invoice"]),
+  } as Skill;
+  const unavailable = ["delegate_parallel_work", "read_file"];
+
+  assert.deepEqual(residentNamesForSkills([skill], unavailable), ["send_invoice"]);
+  assert.deepEqual(skillToolsetMap([skill], unavailable).get(skill.id), ["send_invoice"]);
 });

--- a/App/server/services/skillToolset.ts
+++ b/App/server/services/skillToolset.ts
@@ -91,9 +91,7 @@ function isNearStatic(name: string, known: Set<string>): boolean {
   return false;
 }
 
-export type ToolsetValidation =
-  | { ok: true; names: string[] }
-  | { ok: false; error: string };
+export type ToolsetValidation = { ok: true; names: string[] } | { ok: false; error: string };
 
 export function validateToolset(names: unknown): ToolsetValidation {
   if (!Array.isArray(names)) {
@@ -139,22 +137,30 @@ export function validateToolset(names: unknown): ToolsetValidation {
   return { ok: true, names: cleaned };
 }
 
-/** The union of every active Skill's declared tools, deduped. */
-export function residentNamesForSkills(skills: Skill[]): string[] {
+/** The union of every active Skill's runtime-available declared tools, deduped. */
+export function residentNamesForSkills(
+  skills: Skill[],
+  unavailableNames: Iterable<string> = [],
+): string[] {
+  const unavailable = new Set(unavailableNames);
   const out: string[] = [];
   for (const s of skills) {
     for (const n of parseToolset(s.toolsetJson)) {
-      if (!out.includes(n)) out.push(n);
+      if (!unavailable.has(n) && !out.includes(n)) out.push(n);
     }
   }
   return out;
 }
 
-/** Per-skill toolsets, for rendering under each `## Skill:` heading. */
-export function skillToolsetMap(skills: Skill[]): Map<string, string[]> {
+/** Runtime-available per-skill toolsets, rendered under each Skill heading. */
+export function skillToolsetMap(
+  skills: Skill[],
+  unavailableNames: Iterable<string> = [],
+): Map<string, string[]> {
+  const unavailable = new Set(unavailableNames);
   const map = new Map<string, string[]>();
   for (const s of skills) {
-    const names = parseToolset(s.toolsetJson);
+    const names = parseToolset(s.toolsetJson).filter((name) => !unavailable.has(name));
     if (names.length > 0) map.set(s.id, names);
   }
   return map;

--- a/App/server/services/workspaceGit.test.ts
+++ b/App/server/services/workspaceGit.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildWorkspaceGitInvocation } from "./workspaceGit.js";
+
+test("bubblewrapped Git receives private namespaces and an explicit environment", () => {
+  const invocation = buildWorkspaceGitInvocation(
+    {
+      workspaceRoot: "/srv/employee",
+      cwd: "/srv/employee/code-repos/app",
+      args: ["fetch", "https://github.com/example/app.git"],
+      extraEnv: { GENOSYN_REPO_TOKEN_123: "repo-token" },
+      credentialHelper: "!trusted-helper",
+    },
+    "bubblewrap",
+    "/usr/bin/bwrap",
+  );
+
+  assert.equal(invocation.executable, "/usr/bin/bwrap");
+  assert.equal(invocation.isolated, true);
+  assert.deepEqual(invocation.env, { PATH: "/usr/local/bin:/usr/bin:/bin" });
+  assert.ok(invocation.args.includes("--unshare-pid"));
+  assert.ok(invocation.args.includes("--clearenv"));
+  assert.ok(invocation.args.includes("/tmp"));
+  assert.ok(invocation.args.includes("/workspace"));
+  assert.ok(invocation.args.includes("/etc/passwd"));
+  assert.ok(invocation.args.includes("/etc/group"));
+  assert.ok(invocation.args.includes("GENOSYN_REPO_TOKEN_123"));
+  assert.ok(invocation.args.includes("protocol.ext.allow"));
+  assert.ok(invocation.args.includes("credential.helper"));
+  assert.deepEqual(invocation.args.slice(-3), [
+    "git",
+    "fetch",
+    "https://github.com/example/app.git",
+  ]);
+});
+
+test("workspace Git never inherits arbitrary App or Codex environment variables", () => {
+  const invocation = buildWorkspaceGitInvocation(
+    {
+      workspaceRoot: "/srv/employee",
+      cwd: "/srv/employee",
+      args: ["status"],
+    },
+    "host",
+  );
+
+  assert.equal(invocation.isolated, false);
+  assert.equal("CODEX_ACCESS_TOKEN" in invocation.env, false);
+  assert.equal("DATABASE_URL" in invocation.env, false);
+  assert.equal(invocation.env.GIT_CONFIG_GLOBAL, "/dev/null");
+  assert.equal(invocation.env.GIT_SSH_COMMAND, "/bin/false");
+});
+
+test("workspace Git rejects unsafe environment entries and disabled execution", () => {
+  assert.throws(
+    () =>
+      buildWorkspaceGitInvocation(
+        {
+          workspaceRoot: "/srv/employee",
+          cwd: "/srv/employee",
+          args: ["status"],
+          extraEnv: { CODEX_ACCESS_TOKEN: "must-not-pass" },
+        },
+        "bubblewrap",
+      ),
+    /not allowed/,
+  );
+  assert.throws(
+    () =>
+      buildWorkspaceGitInvocation(
+        {
+          workspaceRoot: "/srv/employee",
+          cwd: "/srv/employee",
+          args: ["status"],
+        },
+        "disabled",
+      ),
+    /disabled/,
+  );
+});

--- a/App/server/services/workspaceGit.ts
+++ b/App/server/services/workspaceGit.ts
@@ -1,0 +1,138 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { config } from "../../config.js";
+import { buildBubblewrapCommandArgs } from "./agent/bubblewrap.js";
+
+const exec = promisify(execFile);
+const GIT_TIMEOUT_MS = 5 * 60 * 1_000;
+const SAFE_PATH = "/usr/local/bin:/usr/bin:/bin";
+const TOKEN_ENV = /^GENOSYN_(?:GH|REPO)_TOKEN_[A-Z0-9_]+$/;
+
+export type WorkspaceGitOptions = {
+  /** Employee workspace (or a server-owned test temp dir) mounted at `/workspace`. */
+  workspaceRoot: string;
+  cwd: string;
+  args: string[];
+  extraEnv?: Record<string, string>;
+  /** Trusted command-scoped helper; repository-local helpers are ignored. */
+  credentialHelper?: string;
+};
+
+export type GitInvocation = {
+  executable: string;
+  args: string[];
+  env: Record<string, string>;
+  isolated: boolean;
+};
+
+/**
+ * Construct a Git child with no App environment inheritance. In bubblewrap
+ * mode the checkout is the only writable host path, while PID, proc and tmp
+ * are private. Command-scoped config also blocks executable local config.
+ */
+export function buildWorkspaceGitInvocation(
+  options: WorkspaceGitOptions,
+  executionMode = config.agent.codingTools.executionMode,
+  bubblewrapPath = config.agent.codingTools.bubblewrapPath,
+): GitInvocation {
+  if (executionMode === "disabled") {
+    throw new Error("Repository synchronization is disabled with coding tools.");
+  }
+
+  const extraEnv = validateExtraEnv(options.extraEnv ?? {});
+  const gitConfig: Array<[string, string]> = [
+    ["core.hooksPath", "/dev/null"],
+    ["core.fsmonitor", "false"],
+    ["protocol.ext.allow", "never"],
+    ["protocol.file.allow", "never"],
+    ["credential.interactive", "never"],
+    ["credential.helper", ""],
+  ];
+  if (options.credentialHelper) {
+    if (options.credentialHelper.includes("\0")) {
+      throw new Error("Invalid Git credential helper.");
+    }
+    gitConfig.push(["credential.helper", options.credentialHelper]);
+  }
+
+  const childEnv: Record<string, string> = {
+    PATH: SAFE_PATH,
+    HOME: executionMode === "bubblewrap" ? "/workspace" : options.workspaceRoot,
+    LANG: "C.UTF-8",
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "/bin/false",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    // A repository-local core.sshCommand must never execute. Legitimate SSH
+    // repositories replace this with a trusted command in `extraEnv`.
+    GIT_SSH_COMMAND: "/bin/false",
+    ...extraEnv,
+    GIT_CONFIG_COUNT: String(gitConfig.length),
+  };
+  gitConfig.forEach(([key, value], index) => {
+    childEnv[`GIT_CONFIG_KEY_${index}`] = key;
+    childEnv[`GIT_CONFIG_VALUE_${index}`] = value;
+  });
+
+  if (executionMode !== "bubblewrap") {
+    return {
+      executable: "git",
+      args: options.args,
+      env: childEnv,
+      isolated: false,
+    };
+  }
+
+  return {
+    executable: bubblewrapPath,
+    args: buildBubblewrapCommandArgs({
+      workspaceRoot: options.workspaceRoot,
+      cwd: options.cwd,
+      executable: "git",
+      args: options.args,
+      env: childEnv,
+      // Git itself needs the network, but a hostile local config remains
+      // confined to this namespace and receives no App/Codex environment.
+      unshareNetwork: false,
+    }),
+    // The bwrap launcher itself receives no App secrets either.
+    env: { PATH: SAFE_PATH },
+    isolated: true,
+  };
+}
+
+export async function runWorkspaceGit(options: WorkspaceGitOptions): Promise<{ stdout: string }> {
+  const invocation = buildWorkspaceGitInvocation(options);
+  try {
+    const { stdout } = await exec(invocation.executable, invocation.args, {
+      cwd: options.cwd,
+      env: invocation.env,
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { stdout };
+  } catch (error) {
+    const command = options.args[0] ?? "(unknown)";
+    if ((error as { code?: string }).code === "ENOENT") {
+      const dependency = invocation.isolated ? "bubblewrap" : "git";
+      throw new Error(
+        `${dependency} is not installed on the Genosyn server, so "git ${command}" could not run.`,
+      );
+    }
+    const detail = error as { stderr?: string; stdout?: string; message?: string };
+    const tail = (detail.stderr || detail.stdout || detail.message || "").toString().trim();
+    throw new Error(`git ${command} failed: ${tail.split("\n").slice(-3).join(" | ")}`);
+  }
+}
+
+function validateExtraEnv(extraEnv: Record<string, string>): Record<string, string> {
+  const clean: Record<string, string> = {};
+  for (const [name, value] of Object.entries(extraEnv)) {
+    if (name !== "GIT_SSH_COMMAND" && !TOKEN_ENV.test(name)) {
+      throw new Error(`Git environment variable is not allowed: ${name}`);
+    }
+    if (value.includes("\0")) throw new Error(`Invalid Git environment value: ${name}`);
+    clean[name] = value;
+  }
+  return clean;
+}

--- a/Home/client/docs/nav.ts
+++ b/Home/client/docs/nav.ts
@@ -73,7 +73,7 @@ export const DOCS_NAV: DocsSection[] = [
       {
         path: "/docs/models",
         title: "AI Models",
-        blurb: "Connect Anthropic, OpenAI, or a custom OpenAI-compatible endpoint.",
+        blurb: "Connect API keys, a custom endpoint, or a self-hosted OpenAI subscription.",
       },
       {
         path: "/docs/tool-discovery",

--- a/Home/client/docs/pages/Employees.tsx
+++ b/Home/client/docs/pages/Employees.tsx
@@ -125,8 +125,9 @@ export function Employees() {
           constitution. Rewrite it to fit your team.
         </LI>
         <LI>
-          <Strong>Attach a model.</Strong> Pick a provider, add an API key or custom endpoint, and
-          the runner takes over from there.
+          <Strong>Attach a model.</Strong> Pick a provider and authentication method. Anthropic
+          takes an API key; OpenAI takes an API key or, on self-hosted Genosyn, eligible ChatGPT
+          subscription access; Custom takes an OpenAI-compatible endpoint.
         </LI>
         <LI>
           <Strong>Add skills + routines.</Strong> Skills describe what they know; Routines describe
@@ -145,14 +146,24 @@ export function Employees() {
 └── ...   # files the employee's coding tools read and write`}
       </pre>
       <P>
-        The runner starts an in-process agent loop with this directory as <Code>cwd</Code> for the
+        The runner starts the selected agent runtime with this directory as <Code>cwd</Code> for the
         built-in coding tools (<Code>bash</Code>, <Code>read_file</Code>, <Code>write_file</Code>,{" "}
         <Code>edit_file</Code>, <Code>glob</Code>, <Code>grep</Code>), and captures the agent
-        transcript into a Run log. A Routine does not make its AI employee unavailable: Members can
-        keep chatting with that employee and start independent Routines in parallel, up to the
-        company workload limit. Concurrent work shares this directory, so give overlapping Runs
-        distinct output files and avoid simultaneous edits to the same git working tree. Model
-        credentials stay encrypted in the database, never on disk.
+        transcript into a Run log. API-key and custom models use Genosyn&apos;s in-process loop;
+        OpenAI subscription models use the official Codex app-server. A Routine does not make its AI
+        employee unavailable: Members can keep chatting with that employee and start independent
+        Routines in parallel, up to the company workload limit. Concurrent work shares this
+        directory, so give overlapping Runs distinct output files and avoid simultaneous edits to
+        the same git working tree. Model credentials stay encrypted in the database. They never
+        enter the employee working directory. For an OpenAI subscription login or Run, Genosyn gives
+        the official app-server a locked temporary <Code>CODEX_HOME</Code>. Managed ChatGPT sessions
+        are materialized there; access tokens enter only the child process environment. Genosyn
+        removes the directory afterward. Subscription auth is unavailable while coding tools use
+        host mode, because a concurrent AI Employee&apos;s same-user shell could inspect that
+        sibling process. Use working Linux bubblewrap mode. In that mode every AI Model turn uses
+        sandboxed <Code>bash</Code> for file work, and repository synchronization stays inside the
+        same namespace; Genosyn omits its host-process file helpers install-wide so concurrent turns
+        cannot race them across the boundary.
       </P>
 
       <H3 id="org-chart">Org chart</H3>
@@ -174,14 +185,14 @@ export function Employees() {
           with a live, labelled progress bar and update it at meaningful milestones. The fill keeps
           moving between milestone updates so you can distinguish active work from a stalled
           connection without inflating the reported percentage. As soon as the reply begins, the
-          progress bar gives way to the response. Long turns can run for up to six hours. If the live
-          connection drops, you reload the page, or the Genosyn server restarts, Genosyn follows the
-          persisted turn automatically instead of marking it failed. After a server restart, a short
-          renewable database lease lets one replacement worker resume the request safely from its
-          saved context and latest milestone; it checks current state before continuing so completed
-          side effects are not repeated. The final reply reappears in the same thread. You can keep
-          writing while the employee works — follow-ups queue and send in order. Chat stays
-          available while that employee&apos;s Routines run.
+          progress bar gives way to the response. Long turns can run for up to six hours. If the
+          live connection drops, you reload the page, or the Genosyn server restarts, Genosyn
+          follows the persisted turn automatically instead of marking it failed. After a server
+          restart, a short renewable database lease lets one replacement worker resume the request
+          safely from its saved context and latest milestone; it checks current state before
+          continuing so completed side effects are not repeated. The final reply reappears in the
+          same thread. You can keep writing while the employee works — follow-ups queue and send in
+          order. Chat stays available while that employee&apos;s Routines run.
         </LI>
         <LI>
           <Strong>Workspace.</Strong> File editor scoped to the employee&apos;s directory — read
@@ -209,9 +220,10 @@ export function Employees() {
 
       <Callout kind="info" title="Models are employee-owned, on purpose.">
         Each employee owns their own provider credentials, stored encrypted (AES-256-GCM) in the
-        database — even when they register several models, every key belongs to that one employee.
-        There&apos;s no shared company-wide API key. Firing an employee deletes all of their
-        encrypted credential rows; you don&apos;t have to rotate anything for the rest of the team.
+        database — even when they register several models, every API key, endpoint credential, or
+        OpenAI subscription credential belongs to that one employee. There&apos;s no shared
+        company-wide model credential. Firing an employee deletes all of their encrypted credential
+        rows; you don&apos;t have to rotate anything for the rest of the team.
       </Callout>
     </>
   );

--- a/Home/client/docs/pages/Introduction.tsx
+++ b/Home/client/docs/pages/Introduction.tsx
@@ -1,17 +1,6 @@
 import { ArrowRight, BookHeart, CalendarClock, Sparkles } from "lucide-react";
 import { Link } from "@/lib/router";
-import {
-  Callout,
-  Code,
-  DocLink,
-  ExtLink,
-  H2,
-  P,
-  PageHeader,
-  Strong,
-  UL,
-  LI,
-} from "@/docs/Prose";
+import { Callout, Code, DocLink, ExtLink, H2, P, PageHeader, Strong, UL, LI } from "@/docs/Prose";
 import { GITHUB_URL } from "@/lib/constants";
 
 export function Introduction() {
@@ -23,9 +12,8 @@ export function Introduction() {
         lead={
           <>
             Genosyn is an open-source, self-hostable platform for hiring{" "}
-            <Strong>AI employees</Strong>. Each one has a written soul, a set of
-            skills, and routines on a schedule. They wake up, do their job, and
-            report what they shipped.
+            <Strong>AI employees</Strong>. Each one has a written soul, a set of skills, and
+            routines on a schedule. They wake up, do their job, and report what they shipped.
           </>
         }
       />
@@ -52,82 +40,76 @@ export function Introduction() {
       <P>
         A <Strong>Company</Strong> in Genosyn has human{" "}
         <DocLink to="/docs/vocabulary">Members</DocLink> and{" "}
-        <DocLink to="/docs/employees">AI Employees</DocLink>. Each AI employee
-        is a persistent persona — they have a name, a role, an{" "}
-        <DocLink to="/docs/models">AI Model</DocLink>, and a body of work that
-        accumulates over time. The whole employee fits in three editable text
+        <DocLink to="/docs/employees">AI Employees</DocLink>. Each AI employee is a persistent
+        persona — they have a name, a role, an <DocLink to="/docs/models">AI Model</DocLink>, and a
+        body of work that accumulates over time. The whole employee fits in three editable text
         fields: a <DocLink to="/docs/soul">Soul</DocLink>, a list of{" "}
         <DocLink to="/docs/skills">Skills</DocLink>, and a calendar of{" "}
         <DocLink to="/docs/routines">Routines</DocLink>.
       </P>
       <P>
-        Everything is plain markdown stored on the database row. You can read
-        it, diff it, copy it, share it — there is no opaque &ldquo;agent
-        configuration&rdquo; in another system. The runtime is{" "}
-        <Code>node-cron</Code> running an in-process agent inside the
-        employee&apos;s sandboxed directory, with credentials scoped to that
-        employee only.
+        Everything is plain markdown stored on the database row. You can read it, diff it, copy it,
+        share it — there is no opaque &ldquo;agent configuration&rdquo; in another system. The
+        scheduler is <Code>node-cron</Code>, which invokes the selected agent runtime with tools
+        rooted in the employee&apos;s sandboxed directory and credentials scoped to that employee
+        only.
       </P>
 
       <H2 id="who-its-for">Who it&apos;s for</H2>
       <UL>
         <LI>
-          <Strong>Solo founders</Strong> who want a finance employee, a brand
-          writer, and an on-call SRE without hiring three humans.
+          <Strong>Solo founders</Strong> who want a finance employee, a brand writer, and an on-call
+          SRE without hiring three humans.
         </LI>
         <LI>
-          <Strong>Small teams</Strong> tired of one-off LLM chatbots and want
-          AI work that runs reliably, on time, with a paper trail.
+          <Strong>Small teams</Strong> tired of one-off LLM chatbots and want AI work that runs
+          reliably, on time, with a paper trail.
         </LI>
         <LI>
-          <Strong>Anyone</Strong> who prefers their tools open source,
-          self-hosted, and BYOK — bring your own Anthropic / OpenAI API keys
-          (or a custom OpenAI-compatible endpoint).
+          <Strong>Anyone</Strong> who prefers their tools open source, self-hosted, and
+          bring-your-own-model: use Anthropic / OpenAI API keys, a custom OpenAI-compatible
+          endpoint, or eligible ChatGPT subscription access for OpenAI on a source-managed Linux
+          install with bubblewrap isolation.
         </LI>
       </UL>
 
       <H2 id="design-principles">Design principles</H2>
       <UL>
         <LI>
-          <Strong>Markdown everywhere.</Strong> Soul, Skills, and Routines are
-          markdown. No proprietary DSL, no node graph you can&apos;t read out
-          loud.
+          <Strong>Markdown everywhere.</Strong> Soul, Skills, and Routines are markdown. No
+          proprietary DSL, no node graph you can&apos;t read out loud.
         </LI>
         <LI>
-          <Strong>One Docker image.</Strong> Backend, frontend, cron, MCP
-          servers — all in a single container. No microservice sprawl.
+          <Strong>One Docker image.</Strong> Backend, frontend, cron, MCP servers — all in a single
+          container. No microservice sprawl.
         </LI>
         <LI>
-          <Strong>The database is the source of truth.</Strong> Model
-          credentials are encrypted at rest in the database; everything else
-          lives in SQLite (or Postgres, your call) too.
+          <Strong>The database is the source of truth.</Strong> Model credentials are encrypted at
+          rest in the database; everything else lives in SQLite (or Postgres, your call) too.
         </LI>
         <LI>
-          <Strong>BYO model.</Strong> Genosyn doesn&apos;t resell AI. You
-          bring your own Anthropic / OpenAI API keys (or a custom
-          OpenAI-compatible endpoint) and point each employee at the model you
-          choose.
+          <Strong>BYO model.</Strong> Genosyn doesn&apos;t resell AI. You bring an Anthropic /
+          OpenAI API key, a custom OpenAI-compatible endpoint, or eligible ChatGPT subscription
+          access for OpenAI on a source-managed Linux install with bubblewrap isolation, then point
+          each employee at the model you choose. Claude subscription credentials are not supported;
+          see <DocLink to="/docs/models">AI Models</DocLink>.
         </LI>
         <LI>
-          <Strong>Fast feedback.</Strong> Everyday actions update the screen
-          immediately while the server finishes in the background. Progress
-          follows you between pages; if a request fails, Genosyn surfaces the
-          error and restores the affected item or draft.
+          <Strong>Fast feedback.</Strong> Everyday actions update the screen immediately while the
+          server finishes in the background. Progress follows you between pages; if a request fails,
+          Genosyn surfaces the error and restores the affected item or draft.
         </LI>
         <LI>
-          <Strong>Room to work.</Strong> Operational pages expand to the full
-          main pane, so tables, dashboards, and queues make useful use of large
-          monitors while reading and writing surfaces retain focused line
-          lengths.
+          <Strong>Room to work.</Strong> Operational pages expand to the full main pane, so tables,
+          dashboards, and queues make useful use of large monitors while reading and writing
+          surfaces retain focused line lengths.
         </LI>
         <LI>
-          <Strong>Live by default.</Strong> Because your AI employees work on
-          their own schedule, the screens stay live: a routine finishing, an
-          employee moving a todo or leaving a comment, an invoice going out, a
-          base record being written — the list or page you&apos;re looking at
-          refreshes itself over a single WebSocket, no reload required. It works
-          the same across browser tabs and, in shared-SaaS mode, across
-          replicas.
+          <Strong>Live by default.</Strong> Because your AI employees work on their own schedule,
+          the screens stay live: a routine finishing, an employee moving a todo or leaving a
+          comment, an invoice going out, a base record being written — the list or page you&apos;re
+          looking at refreshes itself over a single WebSocket, no reload required. It works the same
+          across browser tabs and, in shared-SaaS mode, across replicas.
         </LI>
       </UL>
 
@@ -136,54 +118,47 @@ export function Introduction() {
         If you&apos;ve never run Genosyn before, the fastest path is{" "}
         <DocLink to="/docs/install">Install</DocLink> →{" "}
         <DocLink to="/docs/employees">create your first AI employee</DocLink> →{" "}
-        <DocLink to="/docs/routines">schedule a routine</DocLink>. That whole
-        loop takes about ten minutes if Docker is already running.
+        <DocLink to="/docs/routines">schedule a routine</DocLink>. That whole loop takes about ten
+        minutes if Docker is already running.
       </P>
       <P>
-        Once you&apos;re signed in, every session starts on{" "}
-        <Strong>Home</Strong> — unread mentions and DMs, todos assigned to
-        you, reviews and approvals waiting on your decision, today&apos;s AI
-        activity, and shortcuts to every section. When something needs you,
-        it&apos;s the first thing you see.
+        Once you&apos;re signed in, every session starts on <Strong>Home</Strong> — unread mentions
+        and DMs, todos assigned to you, reviews and approvals waiting on your decision, today&apos;s
+        AI activity, and shortcuts to every section. When something needs you, it&apos;s the first
+        thing you see.
       </P>
       <P>
-        To get anywhere else, press <Code>⌘K</Code> (<Code>Ctrl K</Code> on
-        Windows and Linux). That opens the command palette: every section in
-        one searchable list, with Essentials first — type a few letters, press{" "}
-        <Code>↵</Code>, done. It answers to the words you already know, so
-        &ldquo;cron&rdquo; finds{" "}
-        <DocLink to="/docs/routines">Routines</DocLink> and
-        &ldquo;slack&rdquo; finds Workspace. The section pill in the top nav
-        opens the same palette if you&apos;d rather click.
+        To get anywhere else, press <Code>⌘K</Code> (<Code>Ctrl K</Code> on Windows and Linux). That
+        opens the command palette: every section in one searchable list, with Essentials first —
+        type a few letters, press <Code>↵</Code>, done. It answers to the words you already know, so
+        &ldquo;cron&rdquo; finds <DocLink to="/docs/routines">Routines</DocLink> and
+        &ldquo;slack&rdquo; finds Workspace. The section pill in the top nav opens the same palette
+        if you&apos;d rather click.
       </P>
       <P>
-        For pages you use every day, press <Code>G</Code> and then the page&apos;s
-        letter: <Code>G H</Code> opens Home, <Code>G E</Code> opens AI
-        Employees, and <Code>G R</Code> opens Routines. Pressing <Code>G</Code>
-        shows the complete destination map, so you never have to guess. Press{" "}
-        <Code>?</Code> anywhere outside an editor to open the full shortcut
-        guide. Genosyn pauses global shortcuts while you type, and ordinary{" "}
-        <Code>Tab</Code> navigation has clear, context-appropriate focus styling
-        plus a skip-to-main link.
+        For pages you use every day, press <Code>G</Code> and then the page&apos;s letter:{" "}
+        <Code>G H</Code> opens Home, <Code>G E</Code> opens AI Employees, and <Code>G R</Code> opens
+        Routines. Pressing <Code>G</Code>
+        shows the complete destination map, so you never have to guess. Press <Code>?</Code>{" "}
+        anywhere outside an editor to open the full shortcut guide. Genosyn pauses global shortcuts
+        while you type, and ordinary <Code>Tab</Code> navigation has clear, context-appropriate
+        focus styling plus a skip-to-main link.
       </P>
       <P>
-        The palette searches your company&apos;s content too, not just the
-        section list. Type two or more characters and matching AI employees,
-        skills, routines, notebooks, notes, bases, channels, projects, todos,
-        customers, charts, dashboards, repositories, and pipelines appear
+        The palette searches your company&apos;s content too, not just the section list. Type two or
+        more characters and matching AI employees, skills, routines, notebooks, notes, bases,
+        channels, projects, todos, customers, charts, dashboards, repositories, and pipelines appear
         grouped beneath the sections. It matches <em>names</em> — plus a few fields you&apos;d
-        naturally reach for, like a customer&apos;s email, a channel&apos;s
-        topic, or an employee&apos;s role — never document bodies. Press{" "}
-        <Code>↵</Code> to open a result; a todo takes you to its
-        project&apos;s board, ticket number in hand. Results respect what you
-        can see: restricted projects and private channels you aren&apos;t in
-        stay out of the list.
+        naturally reach for, like a customer&apos;s email, a channel&apos;s topic, or an
+        employee&apos;s role — never document bodies. Press <Code>↵</Code> to open a result; a todo
+        takes you to its project&apos;s board, ticket number in hand. Results respect what you can
+        see: restricted projects and private channels you aren&apos;t in stay out of the list.
       </P>
 
       <Callout kind="tip" title="Open source, no strings.">
         Genosyn ships under MIT. The source lives at{" "}
-        <ExtLink href={GITHUB_URL}>github.com/genosyn/genosyn</ExtLink>. File
-        issues, send PRs, fork it — that&apos;s what it&apos;s there for.
+        <ExtLink href={GITHUB_URL}>github.com/genosyn/genosyn</ExtLink>. File issues, send PRs, fork
+        it — that&apos;s what it&apos;s there for.
       </Callout>
 
       <div className="mt-12">
@@ -199,15 +174,7 @@ export function Introduction() {
   );
 }
 
-function Primitive({
-  icon,
-  tag,
-  body,
-}: {
-  icon: React.ReactNode;
-  tag: string;
-  body: string;
-}) {
+function Primitive({ icon, tag, body }: { icon: React.ReactNode; tag: string; body: string }) {
   return (
     <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-card">
       <div className="flex items-center gap-2">

--- a/Home/client/docs/pages/Models.tsx
+++ b/Home/client/docs/pages/Models.tsx
@@ -1,4 +1,17 @@
-import { Callout, Code, DocLink, H2, H3, LI, P, PageHeader, Strong, UL } from "@/docs/Prose";
+import {
+  Callout,
+  Code,
+  DocLink,
+  ExtLink,
+  H2,
+  H3,
+  LI,
+  OL,
+  P,
+  PageHeader,
+  Strong,
+  UL,
+} from "@/docs/Prose";
 
 export function Models() {
   return (
@@ -9,19 +22,40 @@ export function Models() {
         lead={
           <>
             Every AI Employee can register one or more <Strong>AI Models</Strong> — their brains —
-            and keep exactly one <Strong>active</Strong> at a time. A model is a direct connection
-            to a model API: pick a provider kind, paste a key (or point at your own endpoint), and
-            the runner drives that model through an in-process agent loop. Switch the active model
-            any time without losing the others&apos; credentials.
+            and keep exactly one <Strong>active</Strong> at a time. Connect Anthropic or OpenAI with
+            an API key, point at your own OpenAI-compatible endpoint, or use eligible ChatGPT
+            subscription access for OpenAI on a source-managed Linux server with bubblewrap
+            isolation. Switch the active model any time without losing the others&apos; credentials.
           </>
         }
       />
 
+      <H2 id="connect-model">Connect an AI Model</H2>
+      <OL>
+        <LI>
+          Open an AI Employee, then go to <Strong>Settings → Model</Strong>.
+        </LI>
+        <LI>
+          Select <Strong>Add model</Strong> and choose Anthropic, OpenAI, or Custom.
+        </LI>
+        <LI>
+          Choose the model and authentication method. For Custom, enter the endpoint and model id in
+          the same form. Then select <Strong>Add model</Strong>.
+        </LI>
+        <LI>
+          On the new card, paste the Anthropic / OpenAI API key, or select{" "}
+          <Strong>Sign in with ChatGPT</Strong> for an OpenAI subscription. The newest model becomes
+          active automatically; use <Strong>Make active</Strong> when you want to switch back to
+          another.
+        </LI>
+      </OL>
+
       <H2 id="supported-providers">Provider kinds</H2>
       <P>
-        A model talks straight to a model API from inside Genosyn — there&apos;s no CLI to install,
-        no subscription sign-in, and nothing written to disk. Three provider kinds cover every
-        setup:
+        Three provider kinds cover every setup. API-key and custom-endpoint models talk straight to
+        the model API from Genosyn&apos;s in-process agent loop. OpenAI subscription models use
+        OpenAI&apos;s official Codex app-server; there is still no generic provider CLI to install
+        or maintain.
       </P>
 
       <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -34,8 +68,8 @@ export function Models() {
         <ProviderCard
           name="OpenAI (GPT)"
           vendor="OpenAI"
-          creds="Paste an API key."
-          connects="GPT models."
+          creds="API key, or source-managed Linux ChatGPT subscription access."
+          connects="Models available to the selected OpenAI access method."
         />
         <ProviderCard
           name="Custom"
@@ -59,31 +93,125 @@ export function Models() {
 
       <H2 id="credentials">Credentials</H2>
       <P>
-        Everything a model needs is entered in the app. There&apos;s no OAuth sign-in and no
-        per-provider config file to manage — just the fields the kind requires:
+        Everything a model needs is entered in the app. There is no persistent per-provider config
+        directory to manage:
       </P>
       <UL>
         <LI>
-          <Strong>Anthropic and OpenAI.</Strong> Paste an API key. That&apos;s the whole setup — the
-          runner picks the default model for the kind, or you can name a specific model string.
+          <Strong>Anthropic.</Strong> Paste an Anthropic Console API key. The runner picks the
+          default Claude model, or you can name a specific model string.
+        </LI>
+        <LI>
+          <Strong>OpenAI API key.</Strong> Paste an OpenAI Platform API key for direct, usage-based
+          access through Genosyn&apos;s in-process model loop.
+        </LI>
+        <LI>
+          <Strong>OpenAI subscription.</Strong> On a source-managed Linux Genosyn deployment with
+          bubblewrap isolation, complete ChatGPT device sign-in or paste a Codex access token from
+          an eligible Business or Enterprise workspace. Genosyn runs this model through the pinned{" "}
+          <Code>@openai/codex</Code> app-server.
         </LI>
         <LI>
           <Strong>Custom.</Strong> Paste a base URL and a model id, plus an optional API key if your
           endpoint requires one. The loop then points every request at that endpoint.
         </LI>
       </UL>
-      <Callout kind="info" title="Encrypted at rest.">
-        Keys and endpoints are AES-256-GCM encrypted and stored in the database — never on disk.
-        They&apos;re decrypted in memory only when the agent loop makes a request. Removing a model
-        (or firing the employee) deletes the encrypted row, so access dies with it.
+
+      <H3 id="openai-subscription">Use an OpenAI subscription</H3>
+      <P>
+        Subscription access is available only on a source-managed Linux deployment whose bubblewrap
+        isolation check passes. In the add-model form, choose <Strong>OpenAI (GPT)</Strong>, set{" "}
+        <Strong>Authentication</Strong> to <Strong>ChatGPT subscription</Strong>, choose the model,
+        then select <Strong>Add model</Strong>. The model card offers two official Codex
+        authentication paths:
+      </P>
+      <UL>
+        <LI>
+          <Strong>ChatGPT device sign-in.</Strong> Select <Strong>Sign in with ChatGPT</Strong>,
+          then <Strong>Open ChatGPT sign-in</Strong>. Sign in to the ChatGPT account and workspace
+          you want to use and enter the displayed one-time code. Device sign-in must be enabled in
+          your ChatGPT security settings or by your workspace admin.
+        </LI>
+        <LI>
+          <Strong>Codex access token.</Strong> Open{" "}
+          <Strong>Advanced: Business or Enterprise access token</Strong> and paste a token created
+          by a permitted member of that workspace. Workspace admins control whether members can
+          create these tokens and use Codex Local.
+        </LI>
+      </UL>
+      <P>
+        This uses the Codex access and limits attached to the selected ChatGPT workspace; it does
+        not turn a ChatGPT subscription into a general OpenAI Platform API key. OpenAI documents the{" "}
+        <ExtLink href="https://learn.chatgpt.com/docs/auth#login-on-headless-devices">
+          device-code flow
+        </ExtLink>
+        {", the "}
+        <ExtLink href="https://learn.chatgpt.com/docs/enterprise/access-tokens">
+          Business and Enterprise access-token flow
+        </ExtLink>
+        {", and the "}
+        <ExtLink href="https://developers.openai.com/codex/app-server/">
+          official Codex app-server
+        </ExtLink>
+        .
+      </P>
+      <Callout kind="warn" title="Unavailable in shared SaaS mode">
+        When <Code>config.security.multiTenant</Code> is on, Genosyn rejects subscription model
+        creation, sign-in, and Runs. Use an OpenAI API key in shared SaaS. Subscription credentials
+        represent a person or workspace identity and may run code, so Genosyn keeps this path inside
+        the trust boundary of a self-hosted deployment.
+      </Callout>
+      <Callout kind="info" title="Subscription auth needs coding-tool isolation">
+        Genosyn requires working Linux bubblewrap for subscription auth. A same-user host shell from
+        any concurrent AI Employee could inspect the temporary Codex credential. Set{" "}
+        <Code>config.agent.codingTools.executionMode</Code> to <Code>bubblewrap</Code>; host and
+        disabled modes are rejected. API-key models are unchanged.
+      </Callout>
+      <Callout kind="info" title="Coding and repository sync share one boundary">
+        Every model turn in a bubblewrap deployment exposes only sandboxed <Code>bash</Code> from
+        the coding family. The host-process file tools are omitted install-wide, so an overlapping
+        API-key or custom-model turn cannot race a workspace symlink into a subscription credential.
+        Automatic repository clone, fetch, and credential setup run through the same private PID and
+        temporary-filesystem boundary with a cleared environment and only the configured remote.
+      </Callout>
+      <Callout kind="warn" title="Run one App replica">
+        Device sessions and managed ChatGPT refresh locks currently live in one Genosyn process. Use
+        this authentication mode with a single-App-process self-hosted topology. If you horizontally
+        scale App replicas, use OpenAI API keys instead.
+      </Callout>
+
+      <H3 id="anthropic-subscriptions">Why Claude subscriptions are not offered</H3>
+      <P>
+        Genosyn does not ask for or accept Claude.ai or Claude Code subscription credentials.
+        Anthropic&apos;s{" "}
+        <ExtLink href="https://support.claude.com/en/articles/13189465-log-in-to-your-claude-account">
+          account authentication guidance
+        </ExtLink>{" "}
+        tells developers building third-party products to use an API key and prohibits routing
+        third-party traffic against subscription limits. Connect Anthropic with a Console API key
+        instead.
+      </P>
+
+      <Callout kind="info" title="Encrypted at rest, ephemeral when materialized.">
+        API keys, endpoints, and OpenAI subscription credentials are AES-256-GCM encrypted in the
+        database. Direct API credentials are decrypted in memory only when the agent loop makes a
+        request. Managed Codex authentication requires file-backed state, so a subscription login or
+        Run gets a new locked temporary <Code>CODEX_HOME</Code>; Genosyn materializes the credential
+        there, never in the employee workspace, and removes the directory afterward. The app-server
+        itself gets a separate empty scratch directory; Genosyn&apos;s granted tools remain the only
+        route to the employee workspace. Cleanup retries, and startup removes stale Genosyn Codex
+        directories left by a prior crash. Removing a model (or firing the employee) deletes the
+        encrypted row, so access dies with it.
       </Callout>
 
       <H2 id="context-window">Context window</H2>
       <P>
-        Every turn sends the employee&apos;s Soul, their Skills, and their working set of tools,
-        and each tool call adds its result on top. A long routine therefore grows until it reaches
-        whatever the model will accept — so Genosyn needs to know how much room there is. When a
-        model connects, it asks the provider and shows the answer on the model card.
+        Every turn sends the employee&apos;s Soul, their Skills, and their working set of tools, and
+        each tool call adds its result on top. A long routine therefore grows until it reaches
+        whatever the model will accept — so the direct agent loop needs to know how much room there
+        is. When an API-key or custom-endpoint model connects, Genosyn asks the provider and shows
+        the answer on the model card. For an OpenAI subscription model, the Codex app-server owns
+        context management, so its card does not show the manual context-window controls.
       </P>
       <P>
         Once it knows, a run <Strong>budgets</Strong> against it: when the next prompt wouldn&apos;t
@@ -109,10 +237,11 @@ export function Models() {
 
       <H2 id="built-in-tools">Built-in agent tools</H2>
       <P>
-        The runner and chat both run an in-process agent loop that hands the model tools directly.
-        No matter which provider kind you pick, every model gets the same <Strong>catalogue</Strong>
-        — but not all of it at once. An employee is shown a small working set every turn and looks
-        the rest up on demand; see{" "}
+        API-key and custom-endpoint models run through Genosyn&apos;s in-process agent loop; an
+        OpenAI subscription model runs through the official Codex app-server. The employee keeps the
+        same granted <Strong>catalogue</Strong> either way, except that subscription turns omit
+        parallel delegation because they serialize on the model&apos;s credential-refresh lock. An
+        employee is shown a small working set every turn and looks the rest up on demand; see{" "}
         <DocLink to="/docs/tool-discovery">How tools reach the model</DocLink>. The catalogue is:
       </P>
       <UL>
@@ -124,9 +253,9 @@ export function Models() {
         <LI>
           <Code>genosyn</Code> — the tools the employee calls to run Routines and Todos, write
           journal notes, save Memory, work with Bases, Notes, Resources, charts, mail, finance and
-          attachments, and reach <Strong>any registered Integration tool</Strong>. Always
-          available; the frequently-used ones are loaded up-front and the rest are a{" "}
-          <Code>find_tools</Code> call away.
+          attachments, and reach <Strong>any registered Integration tool</Strong>. Always available;
+          the frequently-used ones are loaded up-front and the rest are a <Code>find_tools</Code>{" "}
+          call away.
         </LI>
         <LI>
           <Code>find_tools</Code> and <Code>call_tool</Code> — how the employee searches the
@@ -137,8 +266,10 @@ export function Models() {
           <Code>browserEnabled</Code> is true on the employee. Skipped when off.
         </LI>
         <LI>
-          <Strong>Company MCP servers.</Strong> Any MCP servers your company has configured are
-          added to the loop alongside the built-ins.
+          <Strong>Company MCP servers.</Strong> HTTP MCP servers your company has configured are
+          added alongside the built-ins. User-configured stdio servers are omitted whenever
+          bubblewrap mode is active, across every model turn, because an arbitrary same-UID child
+          would break the subscription credential boundary.
         </LI>
       </UL>
 
@@ -149,8 +280,9 @@ export function Models() {
 
       <H3 id="tool-limit">How many tools an employee can hold</H3>
       <P>
-        OpenAI accepts at most <Strong>128 tools</Strong> on a request and rejects the whole turn if
-        you send more. Anthropic publishes no such limit, and a custom endpoint sets its own.
+        The direct OpenAI API path accepts at most <Strong>128 tools</Strong> on a request and
+        rejects the whole turn if you send more. Anthropic publishes no such limit, and a custom
+        endpoint sets its own.
       </P>
       <P>
         In practice this no longer binds. Only the working set goes on the request — around{" "}
@@ -168,10 +300,11 @@ export function Models() {
       <H2 id="multiple-models">Multiple models &amp; the active one</H2>
       <P>
         An employee can hold several models side by side — say an <Code>Anthropic</Code> key for
-        everyday work and an <Code>OpenAI</Code> key for a second opinion. Exactly one is{" "}
-        <Strong>active</Strong> at a time; the active model is the brain the loop runs for routines
-        and the chat seam answers with. The most recently added model becomes active automatically —
-        hit <Strong>Make active</Strong> on any other to switch, instantly and as often as you like.
+        everyday work and an <Code>OpenAI</Code> subscription model for a second opinion. Exactly
+        one is <Strong>active</Strong> at a time; the active model is the brain the runner uses for
+        Routines and the chat seam answers with. The most recently added model becomes active
+        automatically — hit <Strong>Make active</Strong> on any other to switch, instantly and as
+        often as you like.
       </P>
       <P>
         Open an employee, then <Strong>Settings → Model</Strong> to see the roster: each card shows
@@ -181,12 +314,14 @@ export function Models() {
 
       <H3 id="model-errors">When a chat or Run reports a model error</H3>
       <P>
-        Temporary model-service and network failures are retried automatically before Genosyn
-        reports an error. Each model turn gets up to <Strong>five attempts</Strong> with a short
-        exponential backoff; provider <Code>Retry-After</Code> guidance is respected up to 30
-        seconds, and cancelling the chat or Run cancels the wait. A turn is never replayed after
-        visible output has started, because doing so could duplicate a partial answer. Run
-        transcripts record each retry on a <Code>[model]</Code> line.
+        For API-key and custom-endpoint models, temporary model-service and network failures are
+        retried automatically before Genosyn reports an error. Each model turn gets up to{" "}
+        <Strong>five attempts</Strong> with a short exponential backoff; provider{" "}
+        <Code>Retry-After</Code> guidance is respected up to 30 seconds, and cancelling the chat or
+        Run cancels the wait. A turn is never replayed after visible output has started, because
+        doing so could duplicate a partial answer. Run transcripts record each retry on a{" "}
+        <Code>[model]</Code> line. The Codex app-server manages retries for subscription-auth turns,
+        so those turns do not use Genosyn&apos;s five-attempt loop or its retry transcript lines.
       </P>
       <P>
         The error names the active model, shows the safe host-only endpoint, preserves the

--- a/Home/client/docs/pages/Routines.tsx
+++ b/Home/client/docs/pages/Routines.tsx
@@ -192,12 +192,17 @@ Post it to the #morning channel.`}</Pre>
 
       <H2 id="parallel-delegation">Parallel delegation</H2>
       <P>
-        Chat turns and Routine runs include <Code>delegate_parallel_work</Code>. An AI employee can
-        split an objective into independent briefs, run up to four temporary copies of itself at
-        once, and receive their ordered results before it writes the final answer or takes follow-up
-        action. Each worker uses the same Soul, Skills, AI Model, Grants, secrets, and timeout as
-        its parent.
+        API-key and custom-endpoint Chat turns and Routine runs include{" "}
+        <Code>delegate_parallel_work</Code>. An AI employee can split an objective into independent
+        briefs, run up to four temporary copies of itself at once, and receive their ordered results
+        before it writes the final answer or takes follow-up action. Each worker uses the same Soul,
+        Skills, AI Model, Grants, secrets, and timeout as its parent.
       </P>
+      <Callout kind="info" title="Subscription turns run one at a time per AI Model">
+        OpenAI subscription turns do not include parallel delegation. Managed ChatGPT credentials
+        may rotate during a Run, so Genosyn serializes subscription work on that AI Model to keep
+        refreshes consistent.
+      </Callout>
       <Pre lang="markdown">{`Research our weekly launch brief in parallel:
 
 1. Summarize customer feedback from the support mailbox.

--- a/Home/client/docs/pages/SelfHosting.tsx
+++ b/Home/client/docs/pages/SelfHosting.tsx
@@ -71,7 +71,10 @@ export function SelfHosting() {
 
   agent: {
     codingTools: {
-      enabled: true, executionMode: "host",
+      enabled: true,
+      // Set bubblewrap deliberately on a Linux deployment after validating
+      // that its user-namespace policy permits the complete isolation probe.
+      executionMode: "host",
       bubblewrapPath: "/usr/bin/bwrap", allowNetwork: true,
     },
     browserEnabledInMultiTenant: false,
@@ -98,6 +101,15 @@ export function SelfHosting() {
         other independent Routines for the same employee. Increase it only when your AI Model quotas
         and host capacity can support the extra parallel requests.
       </P>
+      <Callout kind="info" title="Subscription auth needs an isolated Linux deployment.">
+        Existing installs keep <Code>executionMode: &quot;host&quot;</Code>. To use ChatGPT
+        subscription auth, run Genosyn from source on Linux, set the mode to{" "}
+        <Code>bubblewrap</Code>, and confirm the model card reports that the isolation check passed.
+        The standard Docker installer does not currently relax Docker&apos;s namespace policy, so
+        subscription auth remains unavailable in that container; API-key and custom-endpoint models
+        continue to work normally. Do not make the App container privileged or disable its security
+        profile just to bypass the check.
+      </Callout>
 
       <H2 id="public-url">Public URL</H2>
       <P>

--- a/Home/client/docs/pages/Vocabulary.tsx
+++ b/Home/client/docs/pages/Vocabulary.tsx
@@ -1,12 +1,4 @@
-import {
-  Callout,
-  Code,
-  DocLink,
-  H2,
-  KeyList,
-  PageHeader,
-  Strong,
-} from "@/docs/Prose";
+import { Callout, Code, DocLink, H2, KeyList, PageHeader, Strong } from "@/docs/Prose";
 
 export function Vocabulary() {
   return (
@@ -16,17 +8,15 @@ export function Vocabulary() {
         title="Vocabulary"
         lead={
           <>
-            Genosyn uses a deliberate vocabulary. These words show up in the
-            UI, the API, and the database — using the right one keeps the
-            mental model crisp.
+            Genosyn uses a deliberate vocabulary. These words show up in the UI, the API, and the
+            database — using the right one keeps the mental model crisp.
           </>
         }
       />
 
-      <Callout kind="info" title="Don't say &quot;task.&quot;">
-        <Strong>Task</Strong> is reserved for the future human-style project
-        and todo manager. Scheduled AI work is a{" "}
-        <DocLink to="/docs/routines">Routine</DocLink>, never a task.
+      <Callout kind="info" title='Don&apos;t say "task."'>
+        <Strong>Task</Strong> is reserved for the future human-style project and todo manager.
+        Scheduled AI work is a <DocLink to="/docs/routines">Routine</DocLink>, never a task.
       </Callout>
 
       <H2 id="company-and-team">Company & team</H2>
@@ -64,8 +54,7 @@ export function Vocabulary() {
             def: (
               <>
                 The employee&apos;s written constitution. Markdown on{" "}
-                <Code>AIEmployee.soulBody</Code>. See{" "}
-                <DocLink to="/docs/soul">Soul</DocLink>.
+                <Code>AIEmployee.soulBody</Code>. See <DocLink to="/docs/soul">Soul</DocLink>.
               </>
             ),
           },
@@ -100,9 +89,10 @@ export function Vocabulary() {
             term: "AI Model",
             def: (
               <>
-                A brain an AI employee runs on — a direct connection to a model
-                API (Anthropic, OpenAI, or a custom OpenAI-compatible endpoint).
-                An employee can hold several and keep one active. See{" "}
+                A brain an AI employee runs on — an Anthropic or OpenAI API connection, a custom
+                OpenAI-compatible endpoint, or a source-managed Linux OpenAI subscription connection
+                through the official Codex app-server. An employee can hold several and keep one
+                active. See{" "}
                 <DocLink to="/docs/models">AI Models</DocLink>.
               </>
             ),

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  Open source &middot; self-hosted &middot; bring your own AI keys.
+  Open source &middot; self-hosted &middot; bring your own AI access.
 </p>
 
 <p align="center">
@@ -92,8 +92,10 @@ and AI alike:
 ## Why Genosyn
 
 - **Open source and self-hosted.** It's your data, on your machine.
-- **Bring your own AI.** Plug in Anthropic (Claude), OpenAI, or any OpenAI-compatible /
-  self-hosted endpoint. Your keys, your spend.
+- **Bring your own AI.** Plug in an Anthropic or OpenAI API key, any
+  OpenAI-compatible / self-hosted endpoint, or — on a source-managed Linux
+  deployment with bubblewrap isolation — an eligible ChatGPT plan with Codex
+  access for OpenAI. Your credentials, your limits, your spend.
 - **No black box.** Souls, Skills, and Routines are markdown. You can read every word an
   employee acts on, and every run leaves a paper trail.
 - **A real company OS.** Not a wrapper around a chat box — a workspace, a task board, a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,21 @@ don't re-litigate them.
    invoice chain work for prospects for free. `Contact.customerId` and
    `Deal.customerId` are both nullable so the relationship can start with
    neither.
+10. **Subscription auth is an OpenAI-only, self-hosted exception.** Direct
+    API-key and custom-endpoint models still run through Genosyn's in-process
+    loop. An OpenAI model may use `authMode: "subscription"` through the
+    official pinned `@openai/codex` app-server, authenticated by ChatGPT device
+    sign-in or a Business / Enterprise Codex access token. The credential stays
+    encrypted on `AIModel.configJson`. Managed sessions are materialized only
+    in a locked temporary `CODEX_HOME`; access tokens enter only the child
+    process environment. `config.security.multiTenant` rejects
+    this mode. Subscription auth requires working Linux `bubblewrap` isolation
+    for coding tools and repository materialization. The standard Docker
+    installer retains host mode because Docker's default namespace policy
+    blocks that isolation; operators currently enable it in a source-managed
+    Linux deployment. This mode supports one App replica. Anthropic
+    subscription credentials remain unsupported because Anthropic prohibits
+    third-party products from routing traffic against subscription limits.
 
 ---
 
@@ -72,12 +87,14 @@ don't re-litigate them.
   `Skill.body`.
 - **Routine** — a scheduled recurring piece of work. Cron-triggered. Markdown
   brief on `Routine.body` alongside cron metadata.
-- **AI Model** — a brain an AI Employee can run on: a direct connection to a
-  model API. An employee can register several and keep exactly one active
-  (`AIModel.isActive`). Provider is `anthropic` (Claude), `openai` (GPT), or
-  `custom` (any OpenAI-compatible endpoint); the API key / base URL lives
-  encrypted on `AIModel.configJson`. Genosyn calls the API in-process and runs
-  the tool-use loop itself — no provider CLIs.
+- **AI Model** — a brain an AI Employee can run on: normally a direct
+  connection to a model API, with a source-managed Linux OpenAI subscription
+  path through the official Codex app-server. An employee can register several
+  and keep exactly one active (`AIModel.isActive`). Provider is `anthropic`
+  (Claude), `openai` (GPT), or `custom` (any OpenAI-compatible endpoint); the
+  API key, base URL, or OpenAI subscription credential lives encrypted on
+  `AIModel.configJson`. API-key and custom models run in-process; generic
+  provider CLI harnesses remain forbidden.
 - **Run** — a single execution of a routine. The agent's transcript (streamed
   text + tool activity) is stored on `Run.logContent` (256 KB cap).
 - **Integration** — a connector type (Stripe, Gmail, Metabase, …). Static
@@ -202,7 +219,10 @@ export const config = {
     bootstrapMasterAdminEmail: "",
   },
   agent: {
-    codingTools: { executionMode: "host", allowNetwork: true },
+    codingTools: {
+      executionMode: "host",
+      allowNetwork: true,
+    },
     browserEnabledInMultiTenant: false,
     maxConcurrentRunsPerCompany: 4,
   },
@@ -534,9 +554,12 @@ sends system mail); this is the company's real inbox. Internal namespace is
 
 ### M6 — AI Models (employee-owned) ✅
 
-> **Superseded by M22.** The provider-CLI harnesses, subscription sign-in, and
-> per-provider config materialization below were removed; Genosyn now calls the
-> model API directly in-process. The employee-owned / one-active model remains.
+> **Superseded by M22.** The generic provider-CLI harnesses, subscription
+> sign-in, and persistent per-provider config materialization below were
+> removed in M22. M22 later gained one deliberately narrow exception:
+> source-managed Linux OpenAI subscription access through the official Codex
+> app-server. That is not a revival of the provider-harness architecture. The
+> employee-owned / one-active model remains.
 
 - [x] `AIModel` employee-owned — many per employee, exactly one active
       (`AIModel.isActive`, newest-added active by default, switchable any time);
@@ -553,9 +576,10 @@ sends system mail); this is the company's real inbox. Internal namespace is
 
 ### M22 — Direct model APIs (harnesses removed) ✅
 
-- [x] Removed the five provider-CLI harnesses (`claude-code`, `codex`,
-      `opencode`, `goose`, `openclaw`) — providers are now `anthropic`,
-      `openai`, `custom` (OpenAI-compatible), authMode `apikey` | `customEndpoint`
+- [x] At initial M22 delivery, removed the five provider-CLI harnesses
+      (`claude-code`, `codex`, `opencode`, `goose`, `openclaw`) — providers
+      became `anthropic`, `openai`, `custom` (OpenAI-compatible), with
+      `authMode: "apikey" | "customEndpoint"`
 - [x] In-process agent runtime (`server/services/agent/`): a provider-agnostic
       tool-use loop over the Anthropic Messages API, OpenAI Chat Completions,
       and OpenAI-compatible custom endpoints, with native streaming
@@ -571,12 +595,49 @@ sends system mail); this is the company's real inbox. Internal namespace is
       copies of itself concurrently (eight briefs per call, twelve per turn),
       then verify and synthesize their ordered results. Workers inherit the
       same Soul, Skills, AI Model, Grants, secrets, working directory, and
-      timeout; recursion stops after one level.
-- [x] Dropped subscription/OAuth sign-in, the in-browser pty install/login
-      surface, node-pty, and the per-provider on-disk credential dirs; model
-      credentials live encrypted on `AIModel.configJson`
+      timeout; recursion stops after one level. Subscription turns omit this
+      tool because managed ChatGPT credential refresh serializes Runs on the
+      model lock.
+- [x] At initial M22 delivery, dropped subscription/OAuth sign-in, the
+      in-browser pty install/login surface, node-pty, and the persistent
+      per-provider credential dirs; model credentials live encrypted on
+      `AIModel.configJson`
 - [x] Data migration remapping existing rows onto the new provider/authMode
       vocabulary
+- [x] **OpenAI subscription access, without reviving provider harnesses.**
+      Source-managed Linux OpenAI models may use `authMode: "subscription"`
+      through the official pinned `@openai/codex` app-server; a Member
+      completes ChatGPT device sign-in or supplies a Business / Enterprise
+      Codex access token. Anthropic subscription credentials are explicitly
+      unsupported.
+- [x] **Ephemeral credential boundary.** Subscription credentials remain
+      encrypted on `AIModel.configJson`. Login and Run processes materialize
+      managed sessions only inside a locked temporary `CODEX_HOME` and inject
+      access tokens only into the child environment. They remove the directory
+      afterward and never place credentials in the employee working tree or a
+      persistent provider directory. Cleanup retries and startup removes stale
+      Genosyn Codex temp directories.
+- [x] **Subscription tool isolation.** Subscription auth is unavailable without
+      working Linux bubblewrap, because any concurrent AI Employee could use the
+      same-UID shell to inspect app-server auth or process environment.
+      Every model turn in a bubblewrap deployment retains only `bash` behind
+      private PID and `/tmp` namespaces; host-process file tools are omitted
+      install-wide so a concurrent API-key or custom-model turn cannot win a
+      symlink race into the subscription credential. Every server-managed Git
+      command that touches an AI-writable checkout runs through that namespace,
+      with a cleared environment, executable Git settings overridden, and only
+      the configured remote fetched. User-configured stdio MCP children are
+      omitted install-wide in bubblewrap mode; HTTP MCP and the audited built-in
+      browser remain available.
+- [x] **Single-tenant boundary.** Model create/update, sign-in, and execution
+      reject subscription auth when `config.security.multiTenant` is true.
+      Shared SaaS uses API keys; API-key and custom-endpoint models continue
+      through the direct in-process agent loop.
+- [x] **Subscription lifecycle hardening.** Per-model turns reload credentials
+      under a refresh lock; credential refresh and device completion use
+      compare-and-swap updates; login starts are reserved per model and capped
+      per process; process exit, abort, and a hard deadline all force cleanup.
+      Device completion also rechecks the initiating Member's admin role.
 
 ### M7 — Chat + Workspace ✅
 
@@ -1760,7 +1821,9 @@ of the original V1 backlog has shipped — what remains is mostly
 ### Runner
 
 - [x] **Real execution** via the in-process agent against the model API
-      (Anthropic / OpenAI / custom OpenAI-compatible); see M22
+      (Anthropic / OpenAI / custom OpenAI-compatible), plus the source-managed
+      Linux OpenAI subscription path through the official Codex app-server;
+      see M22
 - [x] **Streaming logs to UI** (SSE on `employeeSurface.ts`)
 - [x] **cwd-scoped tools** — the coding tools are rooted at the employee's
       working directory; bash inherits company secrets + repo env


### PR DESCRIPTION
## Summary

M22 — Direct model APIs

- Add `authMode: "subscription"` for OpenAI through the exact-pinned official `@openai/codex` 0.146.0 app-server.
- Support managed ChatGPT device sign-in and documented Business / Enterprise `CODEX_ACCESS_TOKEN` authentication. Credentials remain encrypted on `AIModel.configJson`; managed auth is materialized only in a locked temporary `CODEX_HOME`, while access tokens enter only the short-lived child environment.
- Reuse Genosyn's existing message, streaming, and granular tool registry through Codex dynamic tools. Subscription turns serialize per model so managed refresh-token rotation cannot race, and omit parallel delegation.
- Fail closed unless this is a single-tenant, source-managed Linux installation with a working bubblewrap probe. In bubblewrap mode every model turn is sandboxed-`bash`-only, repository Git uses the same namespace with a cleared environment and trusted remote, and user-configured stdio MCP servers are omitted install-wide.
- Add the Model UI, admin-only login lifecycle, audit events, subscription-specific errors, and user/operator documentation.

## Deliberate boundaries

- Anthropic consumer subscriptions are not accepted. Anthropic prohibits third-party products from routing traffic through Claude consumer subscription credentials, so Anthropic remains Console API-key only.
- The standard Docker installer remains in host mode. Docker's default seccomp/AppArmor policy blocks the complete bubblewrap boundary; this PR does not weaken the container with privileged mode, `SYS_ADMIN`, or unconfined profiles. API-key and custom-endpoint models are unchanged.
- Subscription auth is rejected in shared SaaS and currently supports one App process. Cross-replica device sessions and refresh locks need durable coordination before horizontal scaling is safe.
- No schema migration is needed: `authMode` is already a plain varchar. The new runtime dependency is intentionally exact-pinned because its JSON-RPC contract is security-sensitive.

## Verification

- `App`: lint (0 errors; 7 existing warnings), server/client typecheck, production build.
- `App`: full suite passed 1,521/1,521 before the final install-wide sandbox tightening; post-tightening credential-isolation, prompt/toolset, and subscription-focused tests passed 26/26.
- `Home`: lint, all TypeScript checks, and production build with 54 routes prerendered.
- The real pinned Codex 0.146.0 app-server passed initialize, strict-config thread posture, empty runtime-root/instruction-source assertions, and conversation-history injection using the production request shape.
- Browser-smoked the Model add/edit UI, OpenAI subscription choice, Anthropic API-key guidance, and the host-mode unavailability state.
- `git diff --check` is clean, and the branch is rebased onto `main` at v1.79.0.

## Not exercised locally

A live ChatGPT device-flow completion and paid model turn require an eligible ChatGPT workspace plus a Linux host whose bubblewrap namespace probe passes. Those remain explicit draft-PR acceptance tests.
