### PR TITLE
Fix company switching after creation

### DIFF
--- a/App/client/App.tsx
+++ b/App/client/App.tsx
@@ -193,15 +193,19 @@ export default function App() {
   const isPublicSigning = location.pathname.startsWith("/sign/");
   const [auth, setAuth] = React.useState<AuthState>({ status: "loading" });
 
+  const refreshAuthenticatedState = React.useCallback(async () => {
+    const me = await api.get<Me>("/api/auth/me");
+    const companies = await api.get<Company[]>("/api/companies");
+    setAuth({ status: "ready", me, companies });
+  }, []);
+
   const refresh = React.useCallback(async () => {
     try {
-      const me = await api.get<Me>("/api/auth/me");
-      const companies = await api.get<Company[]>("/api/companies");
-      setAuth({ status: "ready", me, companies });
+      await refreshAuthenticatedState();
     } catch {
       setAuth({ status: "anon" });
     }
-  }, []);
+  }, [refreshAuthenticatedState]);
 
   React.useEffect(() => {
     if (!isPublicSigning) void refresh();
@@ -244,7 +248,12 @@ export default function App() {
                   auth.me.emailVerificationRequired ? (
                     <VerifyEmailRequired email={auth.me.email} />
                   ) : (
-                    <AuthedRoutes me={auth.me} companies={auth.companies} onChanged={refresh} />
+                    <AuthedRoutes
+                      me={auth.me}
+                      companies={auth.companies}
+                      onChanged={refresh}
+                      onCompaniesChanged={refreshAuthenticatedState}
+                    />
                   )
                 }
               />
@@ -260,15 +269,17 @@ function AuthedRoutes({
   me,
   companies,
   onChanged,
+  onCompaniesChanged,
 }: {
   me: Me;
   companies: Company[];
   onChanged: () => Promise<void>;
+  onCompaniesChanged: () => Promise<void>;
 }) {
   if (companies.length === 0) {
     return (
       <Routes>
-        <Route path="/onboarding" element={<Onboarding onDone={onChanged} />} />
+        <Route path="/onboarding" element={<Onboarding onDone={onCompaniesChanged} />} />
         <Route path="/invite/:token" element={<Invite />} />
         <Route
           path="/security"
@@ -296,7 +307,14 @@ function AuthedRoutes({
       />
       <Route
         path="/c/:companySlug/*"
-        element={<CompanyRoutes me={me} companies={companies} onChanged={onChanged} />}
+        element={
+          <CompanyRoutes
+            me={me}
+            companies={companies}
+            onChanged={onChanged}
+            onCompaniesChanged={onCompaniesChanged}
+          />
+        }
       />
       <Route path="*" element={<Navigate to={`/c/${companies[0].slug}`} replace />} />
     </Routes>
@@ -307,17 +325,25 @@ function CompanyRoutes({
   me,
   companies,
   onChanged,
+  onCompaniesChanged,
 }: {
   me: Me;
   companies: Company[];
   onChanged: () => Promise<void>;
+  onCompaniesChanged: () => Promise<void>;
 }) {
   const { companySlug } = useParams();
   const company = companies.find((c) => c.slug === companySlug);
   if (!company) return <Navigate to="/" replace />;
 
   return (
-    <AppShell me={me} companies={companies} current={company} onCompaniesChanged={onChanged}>
+    <AppShell
+      me={me}
+      companies={companies}
+      current={company}
+      onAuthChanged={onChanged}
+      onCompaniesChanged={onCompaniesChanged}
+    >
       <ChatSessionsProvider key={company.id}>
         <Routes>
           {/* Home — the post-sign-in landing page: everything that needs the

--- a/App/client/components/AppShell.tsx
+++ b/App/client/components/AppShell.tsx
@@ -15,6 +15,7 @@ import {
   Sun,
 } from "lucide-react";
 import { api, Company, Me } from "../lib/api";
+import { createCompanyAndSwitch } from "../lib/companySwitch";
 import { SECTION_BY_KEY, SectionItem, activeSection } from "../lib/sections";
 import { productIntegrationScope, type ProductIntegrationKey } from "../lib/productIntegrations";
 import { useToast } from "./ui/Toast";
@@ -52,7 +53,8 @@ type AppShellProps = {
   me: Me;
   companies: Company[];
   current: Company;
-  onCompaniesChanged: () => void;
+  onAuthChanged: () => Promise<void>;
+  onCompaniesChanged: () => Promise<void>;
   children: React.ReactNode;
 };
 
@@ -71,7 +73,14 @@ type ContextualSidebarState = {
 };
 const ContextualSidebarContext = React.createContext<ContextualSidebarState | null>(null);
 
-export function AppShell({ me, companies, current, onCompaniesChanged, children }: AppShellProps) {
+export function AppShell({
+  me,
+  companies,
+  current,
+  onAuthChanged,
+  onCompaniesChanged,
+  children,
+}: AppShellProps) {
   const [open, setOpen] = React.useState(false);
   const [hasSidebar, setHasSidebar] = React.useState(false);
   const sidebarState = React.useMemo<ContextualSidebarState>(
@@ -110,6 +119,7 @@ export function AppShell({ me, companies, current, onCompaniesChanged, children 
                   me={me}
                   companies={companies}
                   current={current}
+                  onAuthChanged={onAuthChanged}
                   onCompaniesChanged={onCompaniesChanged}
                 />
                 <div className="flex min-h-0 flex-1">{children}</div>
@@ -126,12 +136,14 @@ function TopNav({
   me,
   companies,
   current,
+  onAuthChanged,
   onCompaniesChanged,
 }: {
   me: Me;
   companies: Company[];
   current: Company;
-  onCompaniesChanged: () => void;
+  onAuthChanged: () => Promise<void>;
+  onCompaniesChanged: () => Promise<void>;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -156,7 +168,7 @@ function TopNav({
 
   async function performLogout() {
     await api.post("/api/auth/logout");
-    await onCompaniesChanged();
+    await onAuthChanged();
     navigate("/login");
   }
 
@@ -232,10 +244,13 @@ function TopNav({
                   });
                   if (!name) return;
                   try {
-                    const c = await api.post<Company>("/api/companies", { name });
-                    onCompaniesChanged();
-                    const destination = `/c/${c.slug}`;
-                    if (!navigationGuard.request(destination)) navigate(destination);
+                    await createCompanyAndSwitch({
+                      createCompany: () => api.post<Company>("/api/companies", { name }),
+                      refreshCompanies: onCompaniesChanged,
+                      navigate: (destination) => {
+                        if (!navigationGuard.request(destination)) navigate(destination);
+                      },
+                    });
                   } catch (e) {
                     toast((e as Error).message, "error");
                   }

--- a/App/client/lib/companySwitch.ts
+++ b/App/client/lib/companySwitch.ts
@@ -1,0 +1,27 @@
+import type { Company } from "./api";
+
+type CreateCompanyAndSwitchOptions = {
+  createCompany: () => Promise<Company>;
+  refreshCompanies: () => Promise<void>;
+  navigate: (destination: string) => void | Promise<void>;
+  suffix?: string;
+};
+
+/**
+ * Creates a company and makes it routable before opening it.
+ *
+ * Company routes resolve slugs from App's in-memory company list. Navigating
+ * before that list is refreshed makes a newly created slug look invalid and
+ * sends the Member back to their previous company.
+ */
+export async function createCompanyAndSwitch({
+  createCompany,
+  refreshCompanies,
+  navigate,
+  suffix = "",
+}: CreateCompanyAndSwitchOptions): Promise<Company> {
+  const company = await createCompany();
+  await refreshCompanies();
+  await navigate(`/c/${company.slug}${suffix}`);
+  return company;
+}

--- a/App/client/pages/Onboarding.tsx
+++ b/App/client/pages/Onboarding.tsx
@@ -16,6 +16,7 @@ import { EmployeeStep } from "./onboarding/EmployeeStep";
 import { FirstRequestStep } from "./onboarding/FirstRequestStep";
 import { RecommendationsStep } from "./onboarding/RecommendationsStep";
 import { selectOnboardingEmployee } from "../lib/onboardingRecommendations";
+import { createCompanyAndSwitch } from "../lib/companySwitch";
 
 type OnboardingStep = "employee" | "recommendations" | "email" | "first_task";
 
@@ -48,13 +49,17 @@ export default function Onboarding({ onDone }: { onDone: () => Promise<void> }) 
     setError(null);
     setLoading(true);
     try {
-      const company = await api.post<Company>("/api/companies", {
-        name: name.trim(),
-        mission: mission.trim(),
-        vision: vision.trim(),
+      await createCompanyAndSwitch({
+        createCompany: () =>
+          api.post<Company>("/api/companies", {
+            name: name.trim(),
+            mission: mission.trim(),
+            vision: vision.trim(),
+          }),
+        refreshCompanies: onDone,
+        navigate,
+        suffix: "/onboarding",
       });
-      await onDone();
-      navigate(`/c/${company.slug}/onboarding`);
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/App/server/client/companySwitch.test.ts
+++ b/App/server/client/companySwitch.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "node:test";
+
+import type { Company } from "../../client/lib/api.js";
+import { createCompanyAndSwitch } from "../../client/lib/companySwitch.js";
+
+function company(slug = "new-company"): Company {
+  return {
+    id: "company-id",
+    name: "New Company",
+    slug,
+    mission: "",
+    vision: "",
+    role: "owner",
+    requireTwoFactor: false,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createCompanyAndSwitch", () => {
+  test("creates, refreshes, and then switches in that exact order", async () => {
+    const events: string[] = [];
+    const created = company();
+
+    const result = await createCompanyAndSwitch({
+      createCompany: async () => {
+        events.push("create");
+        return created;
+      },
+      refreshCompanies: async () => {
+        events.push("refresh");
+      },
+      navigate: (destination) => {
+        assert.equal(destination, "/c/new-company");
+        events.push("switch");
+      },
+    });
+
+    assert.equal(result, created);
+    assert.deepEqual(events, ["create", "refresh", "switch"]);
+  });
+
+  test("does not refresh or switch while company creation is pending", async () => {
+    const creation = deferred<Company>();
+    const events: string[] = [];
+
+    const switching = createCompanyAndSwitch({
+      createCompany: () => creation.promise,
+      refreshCompanies: async () => {
+        events.push("refresh");
+      },
+      navigate: () => {
+        events.push("switch");
+      },
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(events, []);
+    creation.resolve(company());
+    await switching;
+    assert.deepEqual(events, ["refresh", "switch"]);
+  });
+
+  test("does not switch while the company-list refresh is pending", async () => {
+    const refresh = deferred<void>();
+    const events: string[] = [];
+
+    const switching = createCompanyAndSwitch({
+      createCompany: async () => {
+        events.push("create");
+        return company("must-be-routable-first");
+      },
+      refreshCompanies: () => {
+        events.push("refresh-started");
+        return refresh.promise;
+      },
+      navigate: (destination) => {
+        assert.equal(destination, "/c/must-be-routable-first");
+        events.push("switch");
+      },
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(events, ["create", "refresh-started"]);
+    refresh.resolve(undefined);
+    await switching;
+    assert.deepEqual(events, ["create", "refresh-started", "switch"]);
+  });
+
+  test("waits for an asynchronous switch before resolving", async () => {
+    const navigation = deferred<void>();
+    let settled = false;
+
+    const switching = createCompanyAndSwitch({
+      createCompany: async () => company(),
+      refreshCompanies: async () => undefined,
+      navigate: () => navigation.promise,
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(settled, false);
+    navigation.resolve(undefined);
+    await switching;
+    assert.equal(settled, true);
+  });
+
+  test("propagates creation failure without refreshing or switching", async () => {
+    const expected = new Error("create failed");
+    let refreshes = 0;
+    let switches = 0;
+
+    await assert.rejects(
+      createCompanyAndSwitch({
+        createCompany: async () => {
+          throw expected;
+        },
+        refreshCompanies: async () => {
+          refreshes += 1;
+        },
+        navigate: () => {
+          switches += 1;
+        },
+      }),
+      expected,
+    );
+    assert.equal(refreshes, 0);
+    assert.equal(switches, 0);
+  });
+
+  test("propagates refresh failure without switching to an unroutable company", async () => {
+    const expected = new Error("refresh failed");
+    let switches = 0;
+
+    await assert.rejects(
+      createCompanyAndSwitch({
+        createCompany: async () => company(),
+        refreshCompanies: async () => {
+          throw expected;
+        },
+        navigate: () => {
+          switches += 1;
+        },
+      }),
+      expected,
+    );
+    assert.equal(switches, 0);
+  });
+
+  test("propagates switch failure only after creation and refresh complete", async () => {
+    const expected = new Error("switch failed");
+    const events: string[] = [];
+
+    await assert.rejects(
+      createCompanyAndSwitch({
+        createCompany: async () => {
+          events.push("create");
+          return company();
+        },
+        refreshCompanies: async () => {
+          events.push("refresh");
+        },
+        navigate: () => {
+          events.push("switch");
+          throw expected;
+        },
+      }),
+      expected,
+    );
+    assert.deepEqual(events, ["create", "refresh", "switch"]);
+  });
+
+  test("uses the exact collision-safe slug returned by the server", async () => {
+    let destination = "";
+
+    await createCompanyAndSwitch({
+      createCompany: async () => company("new-company-2"),
+      refreshCompanies: async () => undefined,
+      navigate: (next) => {
+        destination = next;
+      },
+    });
+
+    assert.equal(destination, "/c/new-company-2");
+  });
+
+  test("preserves the onboarding suffix for first-company creation", async () => {
+    let destination = "";
+
+    await createCompanyAndSwitch({
+      createCompany: async () => company("first-company"),
+      refreshCompanies: async () => undefined,
+      navigate: (next) => {
+        destination = next;
+      },
+      suffix: "/onboarding",
+    });
+
+    assert.equal(destination, "/c/first-company/onboarding");
+  });
+
+  test("keeps both company-creation entry points wired through the sequenced helper", () => {
+    const appShell = readFileSync(
+      new URL("../../client/components/AppShell.tsx", import.meta.url),
+      "utf8",
+    );
+    const app = readFileSync(new URL("../../client/App.tsx", import.meta.url), "utf8");
+    const onboarding = readFileSync(
+      new URL("../../client/pages/Onboarding.tsx", import.meta.url),
+      "utf8",
+    );
+
+    assert.match(appShell, /await createCompanyAndSwitch\(\{/);
+    assert.match(appShell, /refreshCompanies: onCompaniesChanged/);
+    assert.match(appShell, /navigate: \(destination\) =>/);
+    assert.match(app, /onCompaniesChanged=\{refreshAuthenticatedState\}/);
+    assert.match(onboarding, /await createCompanyAndSwitch\(\{/);
+    assert.match(onboarding, /refreshCompanies: onDone/);
+    assert.match(onboarding, /suffix: "\/onboarding"/);
+  });
+});

--- a/App/server/routes/companies.test.ts
+++ b/App/server/routes/companies.test.ts
@@ -8,6 +8,7 @@ import type { Server } from "node:http";
 import { AppDataSource } from "../db/datasource.js";
 import { Company } from "../db/entities/Company.js";
 import { Membership, type Role } from "../db/entities/Membership.js";
+import { Notebook } from "../db/entities/Notebook.js";
 import { User } from "../db/entities/User.js";
 import { errorHandler } from "../middleware/error.js";
 import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
@@ -82,7 +83,7 @@ async function call<T = Record<string, unknown>>(
   return { status: response.status, body: (text ? JSON.parse(text) : {}) as T };
 }
 
-describe("company mission and vision", () => {
+describe("company routes", () => {
   test("returns company direction from list and detail routes", async () => {
     const list = await call<Array<{ id: string; mission: string; vision: string }>>("GET", "");
     assert.equal(list.status, 200);
@@ -114,6 +115,95 @@ describe("company mission and vision", () => {
     assert.equal(created.status, 200);
     assert.equal(created.body.mission, "");
     assert.equal(created.body.vision, "");
+  });
+
+  test("makes a newly created company visible to the Member's next list refresh", async () => {
+    const created = await call<{
+      id: string;
+      name: string;
+      slug: string;
+      role: Role;
+      requireTwoFactor: boolean;
+    }>("POST", "", { name: "Switch Here" });
+    assert.equal(created.status, 200);
+
+    const list = await call<
+      Array<{
+        id: string;
+        name: string;
+        slug: string;
+        role: Role;
+        requireTwoFactor: boolean;
+      }>
+    >("GET", "");
+    assert.equal(list.status, 200);
+    assert.deepEqual(
+      list.body.find((candidate) => candidate.id === created.body.id),
+      created.body,
+    );
+
+    const membership = await AppDataSource.getRepository(Membership).findOneByOrFail({
+      companyId: created.body.id,
+      userId: actingUserId!,
+    });
+    assert.equal(membership.role, "owner");
+    const notebook = await AppDataSource.getRepository(Notebook).findOneByOrFail({
+      companyId: created.body.id,
+      slug: "general",
+    });
+    assert.equal(notebook.title, "General");
+    assert.equal(notebook.createdById, actingUserId);
+  });
+
+  test("returns a unique routable slug for each same-name company", async () => {
+    const first = await call<{ id: string; slug: string }>("POST", "", {
+      name: "Repeated Name",
+    });
+    const second = await call<{ id: string; slug: string }>("POST", "", {
+      name: "Repeated Name",
+    });
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    assert.equal(first.body.slug, "repeated-name");
+    assert.equal(second.body.slug, "repeated-name-2");
+
+    const list = await call<Array<{ id: string; slug: string }>>("GET", "");
+    assert.equal(list.status, 200);
+    assert.equal(
+      list.body.find((candidate) => candidate.id === first.body.id)?.slug,
+      first.body.slug,
+    );
+    assert.equal(
+      list.body.find((candidate) => candidate.id === second.body.id)?.slug,
+      second.body.slug,
+    );
+  });
+
+  test("rejects unauthenticated creation without writing partial rows", async () => {
+    const companyCount = await AppDataSource.getRepository(Company).count();
+    const membershipCount = await AppDataSource.getRepository(Membership).count();
+    const notebookCount = await AppDataSource.getRepository(Notebook).count();
+    actingUserId = null;
+
+    const response = await call("POST", "", { name: "Must Not Exist" });
+
+    assert.equal(response.status, 401);
+    assert.equal(await AppDataSource.getRepository(Company).count(), companyCount);
+    assert.equal(await AppDataSource.getRepository(Membership).count(), membershipCount);
+    assert.equal(await AppDataSource.getRepository(Notebook).count(), notebookCount);
+  });
+
+  test("rejects invalid creation input without writing partial rows", async () => {
+    const companyCount = await AppDataSource.getRepository(Company).count();
+    const membershipCount = await AppDataSource.getRepository(Membership).count();
+    const notebookCount = await AppDataSource.getRepository(Notebook).count();
+
+    const response = await call("POST", "", { name: "   " });
+
+    assert.equal(response.status, 400);
+    assert.equal(await AppDataSource.getRepository(Company).count(), companyCount);
+    assert.equal(await AppDataSource.getRepository(Membership).count(), membershipCount);
+    assert.equal(await AppDataSource.getRepository(Notebook).count(), notebookCount);
   });
 
   test("updates either field independently and trims its value", async () => {

--- a/Home/client/docs/pages/GettingStarted.tsx
+++ b/Home/client/docs/pages/GettingStarted.tsx
@@ -29,6 +29,11 @@ export function GettingStarted() {
         then add the missing context from the launch plan or <Strong>Settings → Company</Strong>
         later.
       </P>
+      <P>
+        To create another company later, open the company picker in the top bar and select
+        <Strong> + New company</Strong>. Genosyn adds you as its owner and switches to the new
+        company as soon as it is ready.
+      </P>
 
       <H2 id="employee">Hire the first AI Employee</H2>
       <OL>


### PR DESCRIPTION
## Summary
- refresh the authenticated company list before navigating to a newly created company
- keep post-mutation refresh failures visible instead of treating them as sign-out
- share the sequencing between onboarding and the company picker
- document the automatic switch behavior

## Roadmap
- M2 — Companies & Members

## Tests
- 10 company-switch orchestration regression tests
- 9 company-route integration tests, including immediate visibility, ownership, General notebook creation, duplicate slugs, invalid input, and unauthenticated requests
- App lint, typecheck, and production build
- Home lint, typecheck, tests, and production build
- CLI test suite: 75 passed

## Manual verification
- signed up and created Final Alpha
- created Final Beta from the company picker and verified the URL and top bar switched immediately
- reloaded and verified Final Beta remained active
- verified both companies appeared in the picker and switching back to Final Alpha still worked