### PR TITLE
Open onboarding after company creation

### DIFF
--- a/App/client/components/AppShell.tsx
+++ b/App/client/components/AppShell.tsx
@@ -250,6 +250,7 @@ function TopNav({
                       navigate: (destination) => {
                         if (!navigationGuard.request(destination)) navigate(destination);
                       },
+                      suffix: "/onboarding",
                     });
                   } catch (e) {
                     toast((e as Error).message, "error");

--- a/App/server/client/companySwitch.test.ts
+++ b/App/server/client/companySwitch.test.ts
@@ -211,7 +211,22 @@ describe("createCompanyAndSwitch", () => {
     assert.equal(destination, "/c/first-company/onboarding");
   });
 
-  test("keeps both company-creation entry points wired through the sequenced helper", () => {
+  test("opens onboarding at the exact collision-safe slug returned by the server", async () => {
+    let destination = "";
+
+    await createCompanyAndSwitch({
+      createCompany: async () => company("repeated-name-2"),
+      refreshCompanies: async () => undefined,
+      navigate: (next) => {
+        destination = next;
+      },
+      suffix: "/onboarding",
+    });
+
+    assert.equal(destination, "/c/repeated-name-2/onboarding");
+  });
+
+  test("keeps both company-creation entry points wired to sequenced onboarding", () => {
     const appShell = readFileSync(
       new URL("../../client/components/AppShell.tsx", import.meta.url),
       "utf8",
@@ -225,7 +240,9 @@ describe("createCompanyAndSwitch", () => {
     assert.match(appShell, /await createCompanyAndSwitch\(\{/);
     assert.match(appShell, /refreshCompanies: onCompaniesChanged/);
     assert.match(appShell, /navigate: \(destination\) =>/);
+    assert.match(appShell, /suffix: "\/onboarding"/);
     assert.match(app, /onCompaniesChanged=\{refreshAuthenticatedState\}/);
+    assert.match(app, /path="onboarding" element=\{<CompanyOnboarding/);
     assert.match(onboarding, /await createCompanyAndSwitch\(\{/);
     assert.match(onboarding, /refreshCompanies: onDone/);
     assert.match(onboarding, /suffix: "\/onboarding"/);

--- a/Home/client/docs/pages/GettingStarted.tsx
+++ b/Home/client/docs/pages/GettingStarted.tsx
@@ -32,7 +32,7 @@ export function GettingStarted() {
       <P>
         To create another company later, open the company picker in the top bar and select
         <Strong> + New company</Strong>. Genosyn adds you as its owner and switches to the new
-        company as soon as it is ready.
+        company&apos;s onboarding guide as soon as it is ready.
       </P>
 
       <H2 id="employee">Hire the first AI Employee</H2>
@@ -59,8 +59,8 @@ export function GettingStarted() {
 
       <H2 id="launch-plan">Put the new hire to work</H2>
       <P>
-        Every hire ends with a <Strong>Launch plan</Strong>. This is the next step in the
-        first-company guide and the final step when you hire another AI Employee from{" "}
+        Every hire ends with a <Strong>Launch plan</Strong>. This is the next step in the company
+        onboarding guide and the final step when you hire another AI Employee from{" "}
         <Strong>AI → Employees</Strong>. Genosyn combines the employee&apos;s role, chosen template,
         and the company mission and vision to recommend useful first work. The same inputs always
         produce a stable plan, so refreshing or returning to the guide does not reshuffle it.
@@ -163,7 +163,7 @@ export function GettingStarted() {
 
       <H2 id="return">Return to the guide</H2>
       <P>
-        The Launch plan and later setup steps are skippable. If you leave the first-company guide
+        The Launch plan and later setup steps are skippable. If you leave a company onboarding guide
         before finishing, open <Code>/c/&lt;company-slug&gt;/onboarding</Code>. Its URL keeps the
         current step and employee, and the guide re-checks the employee&apos;s Routines,
         Connections, mailbox, and Grants so completed setup does not need to be repeated.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -286,6 +286,8 @@ export const config = {
       healthy Connection and employee Grant status, before optional Gmail setup
       with a safe draft Grant and a reviewable starter chat request. The regular
       later-hire wizard reuses the same skippable Launch plan after Soul review
+- [x] Every additional company created from the app-shell picker becomes active
+      immediately and opens its company onboarding guide at the AI Employee step
 - [x] Company switcher in app shell
 - [x] Invite member by email (token link)
 - [x] Roles: owner / admin / member


### PR DESCRIPTION
## Summary

- open the onboarding guide after creating an additional company
- retain the strict create → refresh → switch sequence and server-returned collision-safe slug
- cover both company-creation entry points and document the behavior

## Root cause

The app-shell company picker used the shared sequenced switch helper without its `/onboarding` suffix. The first-company flow already supplied that suffix, so additional companies landed on the company home instead of guided setup.

## Impact

Members now arrive at `/c/<server-slug>/onboarding` immediately after creating any additional company, including duplicate-name companies.

## Validation

- 11 focused company-switch tests pass
- 9 company-route integration tests pass
- App lint, typecheck, and build pass
- Home lint, typecheck, tests, and build pass
- browser-tested normal creation, duplicate-name creation, and reload persistence
- M2 — Companies & Members
