### PR TITLE
Add AI-native Vault for Members and AI Employees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,12 +165,31 @@ Everything user-generated lives under `config.dataDir` (default `./data`):
 
 ```
 data/
+├── .instance-secrets.json  # generated cookie + encryption roots (mode 0600)
+├── .instance-secrets.required # non-secret loss-detection marker (mode 0600)
+├── .private/
+│   ├── browser-state/<company-id>/<employee-id>.json # cookies/localStorage
+│   └── code-repository-ssh/<company-id>/<employee-id>.known_hosts
 ├── app.sqlite
 └── companies/<company-slug>/employees/<emp-slug>/
     ├── repos/  code-repos/    # git working trees the coding tools operate on
-    ├── .browser-state.json    # Playwright storage state (cookies/localStorage)
     └── …                      # artifacts the agent's tools write into cwd
 ```
+
+Default self-host installs create `.instance-secrets.json` and its non-secret
+loss-detection marker atomically when the public placeholders remain in
+`config.ts`. Back both up with the database: losing the managed encryption key
+makes ciphertext unreadable, and the marker makes a missing key fail closed
+instead of silently creating a new identity. A matching non-secret key ID in
+the database also detects loss or replacement of both files after database
+initialization. Never copy secret values into logs, employee working trees,
+support bundles, or source control. Explicit strong config values remain
+supported and take precedence.
+
+Browser authentication state and repository SSH host-key caches are App-private.
+Repository tokens and SSH private keys are decrypted only for short-lived,
+server-owned clone/fetch operations; they are never written into an employee
+working tree or injected into model coding tools.
 
 - **The database is the source of truth** for Soul, Skill, and Routine prose
   (`AIEmployee.soulBody`, `Skill.body`, `Routine.body`), for captured Run
@@ -189,9 +208,11 @@ data/
   config files. API-key and custom models receive tools from Genosyn's
   in-process loop; OpenAI subscription models run through the official
   pinned `@openai/codex` app-server with the same Genosyn-owned tool registry:
-    * built-in **coding tools** (`bash`, `read_file`, `write_file`,
-      `edit_file`, `list_dir`, `glob`, `grep`), rooted at the employee cwd.
-      Subscription auth is available only when coding tools use `bubblewrap`,
+    * built-in **coding tools**. Host mode exposes only the path-confined
+      `read_file`, `write_file`, `edit_file`, `list_dir`, `glob`, and `grep`
+      tools; it never exposes an unrestricted same-UID shell. Bubblewrap mode
+      exposes only sandboxed `bash`, rooted at the employee cwd. Subscription
+      auth is available only when coding tools use `bubblewrap`,
       whose private PID and `/tmp` namespaces isolate the sibling app-server's
       materialized credential. Every model turn in a bubblewrap deployment
       exposes only the sandboxed `bash` tool from this family; the in-process

--- a/App/Dockerfile
+++ b/App/Dockerfile
@@ -90,9 +90,12 @@ COPY --chown=node:node Home ./.genosyn-source/Home
 COPY --chown=node:node CLI ./.genosyn-source/CLI
 COPY --chown=node:node .github ./.genosyn-source/.github
 # `App/config.ts` may contain deployment secrets in source-built images. Help
-# has its own fail-closed path denylist as defense in depth, and the snapshot
-# does not carry the file at all.
+# does not belong in the Help snapshot. Help then reads only files named by an
+# immutable release manifest and applies a second fail-closed path denylist.
+# Source-managed development derives the equivalent allowlist from Git-tracked
+# files.
 RUN rm .genosyn-source/App/config.ts \
+    && find .genosyn-source -type f -print | sed 's#^\.genosyn-source/##' | sort > .genosyn-source/.genosyn-help-manifest \
     && mv .genosyn-source genosyn-source \
     && chmod -R a-w genosyn-source
 

--- a/App/client/App.tsx
+++ b/App/client/App.tsx
@@ -77,6 +77,7 @@ import TasksIndex from "./pages/TasksIndex";
 import TasksReview from "./pages/TasksReview";
 import ProjectNew from "./pages/ProjectNew";
 import ProjectDetail from "./pages/ProjectDetail";
+import Vault from "./pages/Vault";
 import Approvals from "./pages/Approvals";
 import AuditLog from "./pages/AuditLog";
 import Usage from "./pages/Usage";
@@ -431,6 +432,9 @@ function CompanyRoutes({
             <Route path="new" element={<ProjectNew company={company} />} />
             <Route path="p/:pSlug" element={<ProjectDetail company={company} me={me} />} />
           </Route>
+
+          {/* Vault — encrypted passwords, API keys, and secure notes. */}
+          <Route path="vault" element={<Vault company={company} />} />
 
           {/* Bases (Airtable-style) — structured data for the company. */}
           <Route path="bases" element={<BasesLayout company={company} />}>

--- a/App/client/lib/sections.ts
+++ b/App/client/lib/sections.ts
@@ -8,6 +8,7 @@ import {
   FileSignature,
   GitBranch,
   Home,
+  KeyRound,
   Library,
   type LucideIcon,
   ListChecks,
@@ -44,6 +45,7 @@ export type SectionKey =
   | "skills"
   | "routines"
   | "tasks"
+  | "vault"
   | "bases"
   | "notes"
   | "resources"
@@ -125,6 +127,24 @@ export const SECTION_GROUPS: SectionGroup[] = [
         path: "/tasks",
         iconBg: "bg-rose-100 text-rose-600 dark:bg-rose-500/15 dark:text-rose-300",
         keywords: ["projects", "todos", "kanban", "backlog", "issues"],
+      },
+      {
+        key: "vault",
+        label: "Vault",
+        description: "Passwords and secrets, shared safely.",
+        icon: KeyRound,
+        shortcut: "K",
+        path: "/vault",
+        iconBg: "bg-indigo-100 text-indigo-600 dark:bg-indigo-500/15 dark:text-indigo-300",
+        keywords: [
+          "password",
+          "password manager",
+          "credentials",
+          "secrets",
+          "api keys",
+          "secure notes",
+          "autofill",
+        ],
       },
     ],
   },
@@ -366,7 +386,7 @@ export const SECTION_GROUPS: SectionGroup[] = [
       {
         key: "settings",
         label: "Settings",
-        description: "Members, integrations, email, secrets.",
+        description: "Members, integrations, email, environment secrets.",
         icon: SettingsIcon,
         shortcut: ",",
         path: "/settings",
@@ -375,7 +395,7 @@ export const SECTION_GROUPS: SectionGroup[] = [
           "members",
           "integrations",
           "connections",
-          "secrets",
+          "environment secrets",
           "models",
           "config",
           "api keys",
@@ -449,6 +469,7 @@ export function activeSection(pathname: string): SectionKey {
   if (/\/c\/[^/]+\/skills(\/|$)/.test(pathname)) return "skills";
   if (/\/c\/[^/]+\/routines(\/|$)/.test(pathname)) return "routines";
   if (/\/c\/[^/]+\/tasks(\/|$)/.test(pathname)) return "tasks";
+  if (/\/c\/[^/]+\/vault(\/|$)/.test(pathname)) return "vault";
   if (/\/c\/[^/]+\/bases(\/|$)/.test(pathname)) return "bases";
   if (/\/c\/[^/]+\/notes(\/|$)/.test(pathname)) return "notes";
   if (/\/c\/[^/]+\/resources(\/|$)/.test(pathname)) return "resources";

--- a/App/client/lib/vault.ts
+++ b/App/client/lib/vault.ts
@@ -1,0 +1,306 @@
+import { api } from "@/lib/api";
+
+export type VaultItemType = "login" | "api_key" | "secure_note";
+export type VaultVisibility = "company" | "restricted";
+export type VaultMemberAccessLevel = "view" | "edit";
+export type VaultEmployeeAccessLevel = "use" | "manage";
+
+export type VaultItem = {
+  id: string;
+  companyId: string;
+  type: VaultItemType;
+  visibility: VaultVisibility;
+  title: string;
+  username: string;
+  websiteUrl: string;
+  /** Encrypted auxiliary context returned only to an authorized viewer. */
+  notes: string;
+  version: number;
+  createdByUserId: string | null;
+  createdByEmployeeId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  effectiveAccessLevel: VaultMemberAccessLevel;
+  canEdit: boolean;
+  canShare: boolean;
+  canDelete: boolean;
+  canReveal: boolean;
+};
+
+export type CreateVaultItemInput = {
+  type: VaultItemType;
+  visibility: VaultVisibility;
+  title: string;
+  username?: string;
+  secret: string;
+  websiteUrl?: string;
+  notes?: string;
+};
+
+export type UpdateVaultItemInput = Partial<CreateVaultItemInput> & { expectedVersion: number };
+
+export type VaultMemberAccess = {
+  id: string;
+  vaultItemId: string;
+  userId: string;
+  accessLevel: VaultMemberAccessLevel;
+  createdAt: string;
+  updatedAt: string;
+  member: {
+    id: string;
+    name: string;
+    email: string;
+    role: "owner" | "admin" | "member";
+  };
+};
+
+export type VaultMemberCandidate = {
+  id: string;
+  name: string;
+  email: string;
+  role: "owner" | "admin" | "member";
+  isCreator: boolean;
+  access: { id: string; accessLevel: VaultMemberAccessLevel } | null;
+};
+
+export type VaultEmployeeGrant = {
+  id: string;
+  vaultItemId: string;
+  employeeId: string;
+  accessLevel: VaultEmployeeAccessLevel;
+  createdAt: string;
+  updatedAt: string;
+  employee: {
+    id: string;
+    name: string;
+    slug: string;
+    role: string;
+  };
+};
+
+export type VaultEmployeeCandidate = {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  grant: { id: string; accessLevel: VaultEmployeeAccessLevel } | null;
+};
+
+function vaultBase(companyId: string): string {
+  return `/api/companies/${companyId}/vault`;
+}
+
+function itemBase(companyId: string, itemId: string): string {
+  return `${vaultBase(companyId)}/items/${itemId}`;
+}
+
+export const vaultApi = {
+  async listItems(companyId: string): Promise<VaultItem[]> {
+    const result = await api.get<{ items: VaultItem[] }>(`${vaultBase(companyId)}/items`);
+    return result.items;
+  },
+
+  async getItem(companyId: string, itemId: string): Promise<VaultItem> {
+    const result = await api.get<{ item: VaultItem }>(itemBase(companyId, itemId));
+    return result.item;
+  },
+
+  async createItem(companyId: string, input: CreateVaultItemInput): Promise<VaultItem> {
+    const result = await api.post<{ item: VaultItem }>(`${vaultBase(companyId)}/items`, input);
+    return result.item;
+  },
+
+  async updateItem(
+    companyId: string,
+    itemId: string,
+    input: UpdateVaultItemInput,
+  ): Promise<VaultItem> {
+    const result = await api.patch<{ item: VaultItem }>(itemBase(companyId, itemId), input);
+    return result.item;
+  },
+
+  deleteItem(companyId: string, itemId: string): Promise<{ ok: true }> {
+    return api.del<{ ok: true }>(itemBase(companyId, itemId));
+  },
+
+  async revealItem(companyId: string, itemId: string, purpose: "reveal" | "copy"): Promise<string> {
+    const result = await api.post<{ secret: string }>(`${itemBase(companyId, itemId)}/reveal`, {
+      purpose,
+    });
+    return result.secret;
+  },
+
+  async listMemberAccess(companyId: string, itemId: string): Promise<VaultMemberAccess[]> {
+    const result = await api.get<{ access: VaultMemberAccess[] }>(
+      `${itemBase(companyId, itemId)}/member-access`,
+    );
+    return result.access;
+  },
+
+  async listMemberCandidates(companyId: string, itemId: string): Promise<VaultMemberCandidate[]> {
+    const result = await api.get<{ candidates: VaultMemberCandidate[] }>(
+      `${itemBase(companyId, itemId)}/member-access-candidates`,
+    );
+    return result.candidates;
+  },
+
+  createMemberAccess(
+    companyId: string,
+    itemId: string,
+    userId: string,
+    accessLevel: VaultMemberAccessLevel,
+  ): Promise<unknown> {
+    return api.post(`${itemBase(companyId, itemId)}/member-access`, { userId, accessLevel });
+  },
+
+  updateMemberAccess(
+    companyId: string,
+    itemId: string,
+    accessId: string,
+    accessLevel: VaultMemberAccessLevel,
+  ): Promise<unknown> {
+    return api.patch(`${itemBase(companyId, itemId)}/member-access/${accessId}`, { accessLevel });
+  },
+
+  deleteMemberAccess(companyId: string, itemId: string, accessId: string): Promise<unknown> {
+    return api.del(`${itemBase(companyId, itemId)}/member-access/${accessId}`);
+  },
+
+  async listEmployeeGrants(companyId: string, itemId: string): Promise<VaultEmployeeGrant[]> {
+    const result = await api.get<{ grants: VaultEmployeeGrant[] }>(
+      `${itemBase(companyId, itemId)}/employee-grants`,
+    );
+    return result.grants;
+  },
+
+  async listEmployeeCandidates(
+    companyId: string,
+    itemId: string,
+  ): Promise<VaultEmployeeCandidate[]> {
+    const result = await api.get<{ candidates: VaultEmployeeCandidate[] }>(
+      `${itemBase(companyId, itemId)}/employee-grant-candidates`,
+    );
+    return result.candidates;
+  },
+
+  createEmployeeGrant(
+    companyId: string,
+    itemId: string,
+    employeeId: string,
+    accessLevel: VaultEmployeeAccessLevel,
+  ): Promise<unknown> {
+    return api.post(`${itemBase(companyId, itemId)}/employee-grants`, {
+      employeeId,
+      accessLevel,
+    });
+  },
+
+  updateEmployeeGrant(
+    companyId: string,
+    itemId: string,
+    grantId: string,
+    accessLevel: VaultEmployeeAccessLevel,
+  ): Promise<unknown> {
+    return api.patch(`${itemBase(companyId, itemId)}/employee-grants/${grantId}`, { accessLevel });
+  },
+
+  deleteEmployeeGrant(companyId: string, itemId: string, grantId: string): Promise<unknown> {
+    return api.del(`${itemBase(companyId, itemId)}/employee-grants/${grantId}`);
+  },
+};
+
+export const VAULT_ITEM_TYPES: Array<{ value: VaultItemType; label: string }> = [
+  { value: "login", label: "Login" },
+  { value: "api_key", label: "API key" },
+  { value: "secure_note", label: "Secure note" },
+];
+
+export function vaultItemTypeLabel(type: VaultItemType): string {
+  return VAULT_ITEM_TYPES.find((item) => item.value === type)?.label ?? "Vault item";
+}
+
+export function scheduleVaultClipboardClear(secret: string, delayMs = 30_000): void {
+  window.setTimeout(() => {
+    const clipboard = navigator.clipboard;
+    if (!clipboard?.readText || !clipboard?.writeText) return;
+    void clipboard
+      .readText()
+      .then((current) => (current === secret ? clipboard.writeText("") : undefined))
+      .catch(() => undefined);
+  }, delayMs);
+}
+
+export function vaultSecretLabel(type: VaultItemType): string {
+  if (type === "login") return "Password";
+  if (type === "api_key") return "API key";
+  return "Secure note";
+}
+
+export function vaultUsernameLabel(type: VaultItemType): string {
+  return type === "api_key" ? "Account or key ID" : "Username or email";
+}
+
+export function filterVaultItems(
+  items: VaultItem[],
+  query: string,
+  type: VaultItemType | "all",
+): VaultItem[] {
+  const needle = query.trim().toLocaleLowerCase();
+  return items.filter((item) => {
+    if (type !== "all" && item.type !== type) return false;
+    if (!needle) return true;
+    return [item.title, item.username, item.websiteUrl, item.notes, vaultItemTypeLabel(item.type)]
+      .join("\n")
+      .toLocaleLowerCase()
+      .includes(needle);
+  });
+}
+
+const PASSWORD_ALPHABETS = [
+  "ABCDEFGHJKLMNPQRSTUVWXYZ",
+  "abcdefghijkmnopqrstuvwxyz",
+  "23456789",
+  "!@#$%^&*()-_=+[]{}",
+] as const;
+const PASSWORD_ALPHABET = PASSWORD_ALPHABETS.join("");
+
+function randomIndex(maxExclusive: number): number {
+  if (maxExclusive < 1) throw new Error("Random range must be positive");
+  const range = 0x1_0000_0000;
+  const limit = range - (range % maxExclusive);
+  const sample = new Uint32Array(1);
+  do {
+    globalThis.crypto.getRandomValues(sample);
+  } while (sample[0] >= limit);
+  return sample[0] % maxExclusive;
+}
+
+function randomCharacter(alphabet: string): string {
+  return alphabet[randomIndex(alphabet.length)];
+}
+
+/** Generate a cryptographically strong password with every character class. */
+export function generateVaultPassword(requestedLength = 24): string {
+  const length = Math.max(16, Math.min(128, Math.floor(requestedLength)));
+  const characters = PASSWORD_ALPHABETS.map(randomCharacter);
+  while (characters.length < length) characters.push(randomCharacter(PASSWORD_ALPHABET));
+  for (let index = characters.length - 1; index > 0; index -= 1) {
+    const swapAt = randomIndex(index + 1);
+    [characters[index], characters[swapAt]] = [characters[swapAt], characters[index]];
+  }
+  return characters.join("");
+}
+
+export function safeVaultWebsiteUrl(value: string): string | null {
+  if (!value.trim()) return null;
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      !parsed.username &&
+      !parsed.password
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/App/client/pages/AdminBackup.tsx
+++ b/App/client/pages/AdminBackup.tsx
@@ -63,9 +63,7 @@ const KIND_LABEL: Record<BackupDestinationKind, string> = {
 export function AdminBackup() {
   const [rows, setRows] = React.useState<Backup[] | null>(null);
   const [schedule, setSchedule] = React.useState<BackupSchedule | null>(null);
-  const [destinations, setDestinations] = React.useState<
-    BackupDestination[] | null
-  >(null);
+  const [destinations, setDestinations] = React.useState<BackupDestination[] | null>(null);
   const [running, setRunning] = React.useState(false);
   const [savingSchedule, setSavingSchedule] = React.useState(false);
   const [savingRetention, setSavingRetention] = React.useState(false);
@@ -100,10 +98,7 @@ export function AdminBackup() {
    */
   const saveSchedule = React.useCallback(
     async (patch: Partial<BackupSchedule>): Promise<BackupSchedule> => {
-      const next = await api.put<BackupSchedule>(
-        "/api/backups/schedule",
-        patch,
-      );
+      const next = await api.put<BackupSchedule>("/api/backups/schedule", patch);
       setSchedule(next);
       if (next.prunedNow) setRows(await api.get<Backup[]>("/api/backups"));
       return next;
@@ -316,10 +311,7 @@ export function AdminBackup() {
             ) : (
               <ul className="divide-y divide-slate-100 dark:divide-slate-800">
                 {rows.map((b) => (
-                  <li
-                    key={b.id}
-                    className="flex items-center justify-between gap-3 py-2 text-sm"
-                  >
+                  <li key={b.id} className="flex items-center justify-between gap-3 py-2 text-sm">
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-100">
@@ -329,9 +321,7 @@ export function AdminBackup() {
                       </div>
                       <div className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
                         {formatTimestamp(b.createdAt)} · {formatBytes(b.sizeBytes)}
-                        {b.status === "failed" && b.errorMessage
-                          ? ` · ${b.errorMessage}`
-                          : ""}
+                        {b.status === "failed" && b.errorMessage ? ` · ${b.errorMessage}` : ""}
                       </div>
                     </div>
                     <div className="flex shrink-0 items-center gap-1">
@@ -478,11 +468,10 @@ function DestinationsCard({
           <div>
             <h2 className="text-sm font-semibold">Off-box destinations</h2>
             <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-              Mirror every completed backup to a NAS path, an SFTP host, or an
-              SMB share so a lost disk does not take the backups with it.
-              Deliveries run automatically after each backup; use{" "}
-              <span className="font-medium">Send</span> in History to push an
-              existing archive on demand.
+              Mirror every completed backup to a NAS path, an SFTP host, or an SMB share so a lost
+              disk does not take the backups with it. Deliveries run automatically after each
+              backup; use <span className="font-medium">Send</span> in History to push an existing
+              archive on demand.
             </p>
           </div>
           <Button size="sm" onClick={openNew} className="shrink-0">
@@ -501,10 +490,7 @@ function DestinationsCard({
         ) : (
           <ul className="divide-y divide-slate-100 dark:divide-slate-800">
             {destinations.map((d) => (
-              <li
-                key={d.id}
-                className="flex items-center justify-between gap-3 py-2.5 text-sm"
-              >
+              <li key={d.id} className="flex items-center justify-between gap-3 py-2.5 text-sm">
                 <div className="flex min-w-0 flex-1 items-start gap-2.5">
                   <span className="mt-0.5 text-slate-400 dark:text-slate-500">
                     {d.kind === "local" ? (
@@ -616,7 +602,7 @@ function DestinationHealth({ d }: { d: BackupDestination }) {
       )}
       {d.configError && (
         <span className="text-rose-600 dark:text-rose-400">
-          · Config could not be decrypted (was sessionSecret rotated?)
+          · Config could not be decrypted (was the encryption key rotated?)
         </span>
       )}
       {d.lastStatus === "error" && d.lastError && (
@@ -724,11 +710,7 @@ function DestinationModal({
   };
 
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      title={isEdit ? "Edit destination" : "Add destination"}
-    >
+    <Modal open={open} onClose={onClose} title={isEdit ? "Edit destination" : "Add destination"}>
       <form className="flex flex-col gap-4" onSubmit={submit}>
         <div>
           <label className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300">
@@ -782,9 +764,9 @@ function DestinationModal({
               placeholder="/mnt/nas/genosyn-backups"
             />
             <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-              Mount your NAS share (SMB / NFS) on the host or into the container
-              first, then point here. The folder is created if missing. If you
-              can&apos;t mount it, use the SMB type instead.
+              Mount your NAS share (SMB / NFS) on the host or into the container first, then point
+              here. The folder is created if missing. If you can&apos;t mount it, use the SMB type
+              instead.
             </p>
           </div>
         ) : (
@@ -811,9 +793,7 @@ function DestinationModal({
                   max={65535}
                   className={FIELD_CLASS}
                   value={port}
-                  onChange={(e) =>
-                    setPort(parseInt(e.target.value, 10) || portDefaultFor(kind))
-                  }
+                  onChange={(e) => setPort(parseInt(e.target.value, 10) || portDefaultFor(kind))}
                 />
               </div>
             </div>
@@ -890,8 +870,8 @@ function DestinationModal({
                   <span>
                     Encrypt in transit
                     <span className="mt-0.5 block text-slate-400 dark:text-slate-500">
-                      Uses SMB3 encryption so the archive isn&apos;t readable on
-                      your network. Turn this off only if the NAS predates SMB3.
+                      Uses SMB3 encryption so the archive isn&apos;t readable on your network. Turn
+                      this off only if the NAS predates SMB3.
                     </span>
                   </span>
                 </label>
@@ -945,9 +925,7 @@ function DestinationModal({
                       className={FIELD_CLASS}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
-                      placeholder={
-                        editing?.hasPassword ? "•••••• (unchanged)" : ""
-                      }
+                      placeholder={editing?.hasPassword ? "•••••• (unchanged)" : ""}
                       autoComplete="new-password"
                     />
                   </div>
@@ -1000,19 +978,13 @@ function DestinationModal({
   );
 }
 
-function BackupStatusBadge({
-  status,
-  kind,
-}: {
-  status: Backup["status"];
-  kind: Backup["kind"];
-}) {
+function BackupStatusBadge({ status, kind }: { status: Backup["status"]; kind: Backup["kind"] }) {
   const statusClass =
     status === "completed"
       ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300"
       : status === "running"
-      ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300"
-      : "bg-rose-50 text-rose-700 dark:bg-rose-500/10 dark:text-rose-300";
+        ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-300"
+        : "bg-rose-50 text-rose-700 dark:bg-rose-500/10 dark:text-rose-300";
   return (
     <span className="inline-flex items-center gap-1 text-xs">
       <span className={`rounded px-1.5 py-0.5 ${statusClass}`}>{status}</span>
@@ -1023,15 +995,7 @@ function BackupStatusBadge({
   );
 }
 
-const DAY_LABELS = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-];
+const DAY_LABELS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 function ScheduleCard({
   schedule,
@@ -1070,8 +1034,8 @@ function ScheduleCard({
       <CardHeader>
         <h2 className="text-sm font-semibold">Recurring backup</h2>
         <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-          Server-local time. Schedule fires in the background — the cron restarts
-          automatically on boot.
+          Server-local time. Schedule fires in the background — the cron restarts automatically on
+          boot.
         </p>
       </CardHeader>
       <CardBody>
@@ -1128,9 +1092,7 @@ function ScheduleCard({
               <Select
                 className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
                 value={draft.hour}
-                onChange={(e) =>
-                  setDraft({ ...draft, hour: parseInt(e.target.value, 10) })
-                }
+                onChange={(e) => setDraft({ ...draft, hour: parseInt(e.target.value, 10) })}
                 disabled={!draft.enabled}
               >
                 {Array.from({ length: 24 }).map((_, h) => (
@@ -1149,9 +1111,7 @@ function ScheduleCard({
                 <Select
                   className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
                   value={draft.dayOfWeek}
-                  onChange={(e) =>
-                    setDraft({ ...draft, dayOfWeek: parseInt(e.target.value, 10) })
-                  }
+                  onChange={(e) => setDraft({ ...draft, dayOfWeek: parseInt(e.target.value, 10) })}
                   disabled={!draft.enabled}
                 >
                   {DAY_LABELS.map((d, i) => (
@@ -1246,9 +1206,8 @@ function RetentionCard({
       <CardHeader>
         <h2 className="text-sm font-semibold">Retention</h2>
         <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-          Delete archives once they pass a certain age so the backup folder
-          doesn&apos;t grow forever. Checked hourly, and again after every
-          backup.
+          Delete archives once they pass a certain age so the backup folder doesn&apos;t grow
+          forever. Checked hourly, and again after every backup.
         </p>
       </CardHeader>
       <CardBody>
@@ -1268,13 +1227,9 @@ function RetentionCard({
               type="checkbox"
               className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
               checked={draft.retentionEnabled}
-              onChange={(e) =>
-                setDraft({ ...draft, retentionEnabled: e.target.checked })
-              }
+              onChange={(e) => setDraft({ ...draft, retentionEnabled: e.target.checked })}
             />
-            <span className="font-medium">
-              Automatically delete old backups
-            </span>
+            <span className="font-medium">Automatically delete old backups</span>
           </label>
 
           <div className="grid gap-3 sm:grid-cols-3">
@@ -1297,18 +1252,15 @@ function RetentionCard({
                   }
                   disabled={!draft.retentionEnabled}
                 />
-                <span className="text-sm text-slate-500 dark:text-slate-400">
-                  days
-                </span>
+                <span className="text-sm text-slate-500 dark:text-slate-400">days</span>
               </div>
             </div>
           </div>
 
           <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-            Covers every archive in the backup folder — including ones you made
-            by hand — even when the recurring backup above is off. The newest
-            completed archive is always kept, however old it is. Archives you
-            uploaded here are never deleted, and copies already delivered to
+            Covers every archive in the backup folder — including ones you made by hand — even when
+            the recurring backup above is off. The newest completed archive is always kept, however
+            old it is. Archives you uploaded here are never deleted, and copies already delivered to
             off-box destinations stay on the remote.
           </p>
 

--- a/App/client/pages/Approvals.tsx
+++ b/App/client/pages/Approvals.tsx
@@ -58,7 +58,7 @@ function copyFor(a: Approval): ApprovalCopy {
         // Browser actions don't run server-side — the model re-fires via
         // browser_resume once the row flips to approved. The re-fire is
         // bound to the approved page and runs once.
-        approvedToast: "Approved — the AI will submit it on that page",
+        approvedToast: "Approved — the AI can resume this browser action",
       };
     case "mcp_tool":
       return {

--- a/App/client/pages/CodeRepoAccess.tsx
+++ b/App/client/pages/CodeRepoAccess.tsx
@@ -139,8 +139,8 @@ export default function CodeRepoAccess() {
             AI access
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-slate-500 dark:text-slate-400">
-            Choose who may work in {repo.name}, whether they can push, and who has the GitHub tool
-            needed to open a pull request.
+            Choose who may reference {repo.name} or prepare local branches and commits. Repository
+            credentials never enter AI tools.
           </p>
         </div>
       </div>
@@ -154,7 +154,7 @@ export default function CodeRepoAccess() {
         <ReadinessCard
           icon={<GitPullRequest size={17} />}
           title="PRs use a GitHub Connection"
-          detail="Grant a GitHub Connection to expose the create_pull_request tool after the branch is pushed."
+          detail="After a Member or governed delivery flow publishes the branch, a GitHub Connection can expose the create_pull_request tool."
           to={`/c/${company.slug}/code/integrations`}
           linkLabel="Manage integrations"
         />
@@ -188,8 +188,8 @@ export default function CodeRepoAccess() {
               onChange={(event) => setPickLevel(event.target.value as CodeRepoAccessLevel)}
               disabled={ungranted.length === 0}
             >
-              <option value="write">Read &amp; push</option>
-              <option value="read">Read only</option>
+              <option value="write">Work locally</option>
+              <option value="read">Reference only</option>
             </Select>
           </div>
           <Button onClick={addGrant} disabled={adding || !pickEmployee} className="shrink-0">
@@ -209,8 +209,8 @@ export default function CodeRepoAccess() {
               No AI employees have access
             </div>
             <p className="mx-auto mt-1 max-w-md text-xs leading-5 text-slate-500 dark:text-slate-400">
-              Add one above. Use Read &amp; push when you want it to deliver a branch or pull
-              request.
+              Add one above. Use Work locally when you want it to prepare a branch and commit for
+              governed publishing.
             </p>
           </div>
         ) : (
@@ -253,8 +253,8 @@ export default function CodeRepoAccess() {
                     className="h-9 w-36"
                     aria-label="Repository access level"
                   >
-                    <option value="write">Read &amp; push</option>
-                    <option value="read">Read only</option>
+                    <option value="write">Work locally</option>
+                    <option value="read">Reference only</option>
                   </Select>
                   {grant.employee && (
                     <>
@@ -332,20 +332,20 @@ function DeliveryBadge({ grant }: { grant: CodeRepoGrant }) {
   if (grant.accessLevel === "read") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-        Read only
+        Reference only
       </span>
     );
   }
   if (grant.employee?.pullRequestReady) {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-medium text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300">
-        <GitPullRequest size={11} /> PR ready
+        <GitPullRequest size={11} /> PR tool connected
       </span>
     );
   }
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-[10px] font-medium text-amber-700 dark:bg-amber-500/10 dark:text-amber-300">
-      <PlugZap size={11} /> GitHub Connection needed
+      <PlugZap size={11} /> PR tool unavailable
     </span>
   );
 }

--- a/App/client/pages/CodeRepoForm.tsx
+++ b/App/client/pages/CodeRepoForm.tsx
@@ -6,12 +6,7 @@ import { Textarea } from "../components/ui/Textarea";
 import { Select } from "../components/ui/Select";
 import { Spinner } from "../components/ui/Spinner";
 import { useToast } from "../components/ui/Toast";
-import {
-  api,
-  Company,
-  CodeRepository,
-  CodeRepoAuthMode,
-} from "../lib/api";
+import { api, Company, CodeRepository, CodeRepoAuthMode } from "../lib/api";
 
 /**
  * Shared form fields + create modal for a Code Repository. The detail page
@@ -67,9 +62,7 @@ export function repoToForm(repo: CodeRepository): RepoFormState {
  * user actually typed one — an empty token / key leaves the stored secret in
  * place on edit (and is rejected by the server's schema on create).
  */
-export function repoFormToPayload(
-  form: RepoFormState,
-): Record<string, unknown> {
+export function repoFormToPayload(form: RepoFormState): Record<string, unknown> {
   const body: Record<string, unknown> = {
     name: form.name.trim(),
     gitUrl: form.gitUrl.trim(),
@@ -125,9 +118,7 @@ export function RepoFormFields({
         <Select
           label="Authentication"
           value={form.authMode}
-          onChange={(e) =>
-            patch({ authMode: e.target.value as CodeRepoAuthMode })
-          }
+          onChange={(e) => patch({ authMode: e.target.value as CodeRepoAuthMode })}
         >
           <option value="none">None / GitHub Connection</option>
           <option value="https">HTTPS token / password</option>
@@ -137,9 +128,9 @@ export function RepoFormFields({
 
       {form.authMode === "none" && (
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          Public repositories clone anonymously. For an HTTPS GitHub URL,
-          Genosyn automatically reuses a matching GitHub Connection granted to
-          the same AI employee, including for git push.
+          Public repositories clone anonymously. For an HTTPS GitHub URL, Genosyn automatically
+          reuses a matching GitHub Connection granted to the same AI employee for server-owned clone
+          and refresh operations.
         </p>
       )}
 
@@ -163,9 +154,9 @@ export function RepoFormFields({
             placeholder="ghp_… / glpat-… / app password"
           />
           <p className="text-xs text-slate-500 dark:text-slate-400">
-            Use a personal access token with repo read/write scope. It is
-            encrypted at rest and handed to git at run time via an environment
-            variable — it never lands on disk.
+            Use the narrowest repository-scoped token available. It is encrypted at rest and
+            decrypted only inside a short-lived, server-owned git operation — never into AI tools or
+            the checkout.
           </p>
         </div>
       )}
@@ -185,9 +176,9 @@ export function RepoFormFields({
             className="font-mono text-xs"
           />
           <p className="text-xs text-slate-500 dark:text-slate-400">
-            Add the matching public key as a deploy key on your git host. The
-            private key is encrypted at rest and written to the employee&apos;s
-            workspace (gitignored) only while a checkout exists.
+            Add the matching public key as a deploy key on your git host. The private key is
+            encrypted at rest and materialized only in an App-private temporary directory during
+            clone or refresh.
           </p>
         </div>
       )}

--- a/App/client/pages/CodeRepoOverview.tsx
+++ b/App/client/pages/CodeRepoOverview.tsx
@@ -156,8 +156,8 @@ export default function CodeRepoOverview() {
           <WorkflowStep
             number="2"
             icon={<GitBranch size={17} />}
-            title="Branch, commit, and push"
-            detail="A Read & push grant checks out this repository with stored credentials or its matching GitHub Connection."
+            title="Branch, test, and commit"
+            detail="A Work locally grant gives the AI employee a persistent checkout without exposing repository credentials."
             status={
               grants === null
                 ? "Checking…"
@@ -170,8 +170,8 @@ export default function CodeRepoOverview() {
           <WorkflowStep
             number="3"
             icon={<GitPullRequest size={17} />}
-            title="Open the pull request"
-            detail="For GitHub repositories, grant the same employee a connected GitHub Connection to expose the create_pull_request tool."
+            title="Publish, then open the pull request"
+            detail="A Member or governed delivery action publishes the reported branch; a GitHub Connection can then expose the create_pull_request tool."
             status={
               grants === null
                 ? "Checking…"
@@ -184,7 +184,8 @@ export default function CodeRepoOverview() {
           />
           <div className="flex flex-col gap-3 border-t border-slate-100 bg-slate-50/70 px-4 py-3 text-xs text-slate-600 sm:flex-row sm:items-center sm:justify-between dark:border-slate-800 dark:bg-slate-800/30 dark:text-slate-300">
             <span>
-              Try: “Create a branch, implement this change, run the tests, and send me a draft PR.”
+              Try: “Create a branch, implement this change, run the tests, commit it, and report the
+              branch and commit.”
             </span>
             <Link
               to={`${base}/access`}

--- a/App/client/pages/CodeReposIndex.tsx
+++ b/App/client/pages/CodeReposIndex.tsx
@@ -1,14 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  ArrowUpRight,
-  Clock,
-  FolderGit2,
-  GitBranch,
-  Plus,
-  Search,
-  Users,
-} from "lucide-react";
+import { ArrowUpRight, Clock, FolderGit2, GitBranch, Plus, Search, Users } from "lucide-react";
 import { Breadcrumbs } from "../components/AppShell";
 import { Button } from "../components/ui/Button";
 import { Spinner } from "../components/ui/Spinner";
@@ -39,10 +31,7 @@ export default function CodeReposIndex({ company }: { company: Company }) {
       );
       setItems(rows);
     } catch (err) {
-      toast(
-        err instanceof Error ? err.message : "Could not load repositories",
-        "error",
-      );
+      toast(err instanceof Error ? err.message : "Could not load repositories", "error");
       setItems([]);
     }
   }, [company.id, toast]);
@@ -66,10 +55,7 @@ export default function CodeReposIndex({ company }: { company: Company }) {
     <div className="flex h-full min-w-0 flex-1 flex-col bg-slate-50 dark:bg-slate-900">
       <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/85 px-6 py-2 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
         <Breadcrumbs
-          items={[
-            { label: company.name, to: `/c/${company.slug}` },
-            { label: "Code" },
-          ]}
+          items={[{ label: company.name, to: `/c/${company.slug}` }, { label: "Code" }]}
         />
       </div>
 
@@ -84,10 +70,9 @@ export default function CodeReposIndex({ company }: { company: Company }) {
                 {company.name}
               </h1>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                Add any git repository — GitHub, GitLab, Bitbucket, or a
-                self-hosted server — and grant access to the AI employees you
-                want working on it. They get a real checkout to read, commit,
-                and push.
+                Add any git repository — GitHub, GitLab, Bitbucket, or a self-hosted server — and
+                grant access to the AI employees you want working on it. They get a real checkout to
+                read, commit, and push.
               </p>
             </div>
             <Button onClick={() => setShowNew(true)} className="shrink-0">
@@ -141,13 +126,7 @@ export default function CodeReposIndex({ company }: { company: Company }) {
   );
 }
 
-function RepoList({
-  company,
-  items,
-}: {
-  company: Company;
-  items: CodeRepository[];
-}) {
+function RepoList({ company, items }: { company: Company; items: CodeRepository[] }) {
   const navigate = useNavigate();
   return (
     <div className="mt-2">
@@ -186,8 +165,7 @@ function RepoList({
                 <span className="uppercase">{r.authMode}</span>
                 <span aria-hidden>·</span>
                 <span className="inline-flex items-center gap-1">
-                  <Users size={11} /> {r.grantCount}{" "}
-                  {r.grantCount === 1 ? "employee" : "employees"}
+                  <Users size={11} /> {r.grantCount} {r.grantCount === 1 ? "employee" : "employees"}
                 </span>
               </span>
             </span>
@@ -212,9 +190,9 @@ function EmptyHero({ onAdd }: { onAdd: () => void }) {
         Give your AI employees a codebase
       </h3>
       <p className="mx-auto mt-1 max-w-md text-sm text-slate-500 dark:text-slate-400">
-        Point Genosyn at any git repository and pick which employees can work
-        on it. They get a real checkout — read, branch, commit, and push, all
-        with ordinary git.
+        Point Genosyn at any git repository and pick which employees can work on it. They get a real
+        checkout to read, branch, edit, test, and commit with ordinary git, while credentials stay
+        server-side.
       </p>
       <div className="mt-5">
         <Button onClick={onAdd}>
@@ -225,11 +203,7 @@ function EmptyHero({ onAdd }: { onAdd: () => void }) {
   );
 }
 
-export function SyncBadge({
-  status,
-}: {
-  status: CodeRepository["lastSyncStatus"];
-}) {
+export function SyncBadge({ status }: { status: CodeRepository["lastSyncStatus"] }) {
   if (status === "ok") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300">

--- a/App/client/pages/Settings.tsx
+++ b/App/client/pages/Settings.tsx
@@ -500,17 +500,17 @@ export function SettingsSecrets() {
   const { company } = useCtx();
   return (
     <>
-      <TopBar title="Secrets" />
+      <TopBar title="Environment secrets" />
       <SecretsCard company={company} />
     </>
   );
 }
 
 /**
- * Per-company vault. Secrets are encrypted at rest and injected into every
- * employee spawn (routine + chat) as environment variables. The plaintext
- * value is never returned by the API — only a masked preview. "Edit" lets a
- * user rotate the value; we never show the old one.
+ * Per-company environment secrets. These developer values are distinct from
+ * the structured Password Vault: runtime policy may expose them to AI Employee
+ * coding shells as environment variables. The plaintext value is never
+ * returned by the API — only a masked preview.
  */
 function SecretsCard({ company }: { company: Company }) {
   const [rows, setRows] = React.useState<Secret[] | null>(null);
@@ -540,9 +540,9 @@ function SecretsCard({ company }: { company: Company }) {
       <CardHeader>
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-sm font-semibold">Vault</h2>
+            <h2 className="text-sm font-semibold">Environment secrets</h2>
             <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-              Encrypted at rest. Injected into every employee run and chat as environment variables.
+              Encrypted developer values for AI Employee coding shells where runtime policy allows.
             </p>
           </div>
           <Button size="sm" onClick={() => setCreating(true)}>
@@ -556,7 +556,7 @@ function SecretsCard({ company }: { company: Company }) {
         ) : rows.length === 0 ? (
           <EmptyState
             title="No secrets yet"
-            description="Store API keys, tokens, and other sensitive values once and make them available to every employee."
+            description="Store developer tokens as environment variables for AI Employee coding tools. Use Vault for logins and shared passwords."
           />
         ) : (
           <ul className="divide-y divide-slate-100 dark:divide-slate-800">

--- a/App/client/pages/SettingsLayout.tsx
+++ b/App/client/pages/SettingsLayout.tsx
@@ -39,7 +39,7 @@ const SETTINGS_TAB_LABEL: Record<string, string> = {
   email: "Email",
   providers: "Providers",
   logs: "Logs",
-  secrets: "Secrets",
+  secrets: "Environment secrets",
   "api-keys": "API keys",
   usage: "Usage",
   audit: "Audit log",
@@ -75,7 +75,11 @@ export default function SettingsLayout({
         <SidebarLink to={`${base}/tags`} icon={<Tags size={14} />} label="Tags" />
         <SidebarLink to={`${base}/integrations`} icon={<Plug size={14} />} label="Integrations" />
         <SidebarLink to={`${base}/email`} icon={<Mail size={14} />} label="Email" />
-        <SidebarLink to={`${base}/secrets`} icon={<KeyRound size={14} />} label="Secrets" />
+        <SidebarLink
+          to={`${base}/secrets`}
+          icon={<KeyRound size={14} />}
+          label="Environment secrets"
+        />
         <SidebarLink to={`${base}/api-keys`} icon={<TerminalSquare size={14} />} label="API keys" />
         <SidebarLink to={`${base}/usage`} icon={<BarChart3 size={14} />} label="Usage" />
         <SidebarLink to={`${base}/audit`} icon={<ScrollText size={14} />} label="Audit log" />
@@ -107,10 +111,7 @@ export default function SettingsLayout({
       <div className="page-shell p-8">
         <div className="mb-4">
           <Breadcrumbs
-            items={[
-              { label: "Settings", to: tabCrumbs.length ? base : undefined },
-              ...tabCrumbs,
-            ]}
+            items={[{ label: "Settings", to: tabCrumbs.length ? base : undefined }, ...tabCrumbs]}
           />
         </div>
         <Outlet context={{ company, me, onCompaniesChanged } satisfies SettingsOutletCtx} />

--- a/App/client/pages/Vault.tsx
+++ b/App/client/pages/Vault.tsx
@@ -1,0 +1,328 @@
+import React from "react";
+import {
+  Bot,
+  Building2,
+  KeyRound,
+  LockKeyhole,
+  Plus,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  StickyNote,
+  Users,
+  X,
+} from "lucide-react";
+import { useLiveRefetch } from "@/components/CompanySocket";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Select } from "@/components/ui/Select";
+import { Spinner } from "@/components/ui/Spinner";
+import { useToast } from "@/components/ui/Toast";
+import type { Company } from "@/lib/api";
+import {
+  filterVaultItems,
+  safeVaultWebsiteUrl,
+  VAULT_ITEM_TYPES,
+  vaultApi,
+  type VaultItem,
+  type VaultItemType,
+  vaultItemTypeLabel,
+} from "@/lib/vault";
+import { VaultItemDetail } from "@/pages/vault/VaultItemDetail";
+import { VaultItemEditor } from "@/pages/vault/VaultItemEditor";
+
+export default function Vault({ company }: { company: Company }) {
+  const { toast } = useToast();
+  const [items, setItems] = React.useState<VaultItem[] | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [query, setQuery] = React.useState("");
+  const [type, setType] = React.useState<VaultItemType | "all">("all");
+  const [creating, setCreating] = React.useState(false);
+  const [editing, setEditing] = React.useState<VaultItem | null>(null);
+  const [selected, setSelected] = React.useState<VaultItem | null>(null);
+
+  const reload = React.useCallback(async () => {
+    setError(null);
+    try {
+      const next = await vaultApi.listItems(company.id);
+      setItems(next);
+      setSelected((current) =>
+        current ? (next.find((candidate) => candidate.id === current.id) ?? null) : null,
+      );
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "The Vault could not be loaded.";
+      setError(message);
+      setItems([]);
+      toast(message, "error");
+    }
+  }, [company.id, toast]);
+
+  React.useEffect(() => {
+    setItems(null);
+    setSelected(null);
+    void reload();
+  }, [reload]);
+
+  useLiveRefetch(["vault_item", "vault_member_access", "vault_employee_grant"], reload);
+
+  const filtered = React.useMemo(
+    () => filterVaultItems(items ?? [], query, type),
+    [items, query, type],
+  );
+
+  async function handleSaved(saved: VaultItem) {
+    setCreating(false);
+    setEditing(null);
+    await reload();
+    setSelected(saved);
+  }
+
+  return (
+    <div className="page-shell p-4 pb-14 sm:p-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+            <KeyRound size={21} />
+          </span>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+              Vault
+            </h1>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-slate-500 dark:text-slate-400">
+              Passwords, API keys, and secure notes for Members and explicitly granted AI Employees.
+            </p>
+          </div>
+        </div>
+        <Button className="self-start" onClick={() => setCreating(true)}>
+          <Plus size={14} /> Add item
+        </Button>
+      </div>
+
+      <div className="mt-6 grid gap-3 md:grid-cols-3">
+        <PromiseCard
+          icon={<ShieldCheck size={17} />}
+          title="Encrypted at rest"
+          detail="Stored values and private context stay encrypted until an authorized request needs them."
+        />
+        <PromiseCard
+          icon={<Users size={17} />}
+          title="Member access is explicit"
+          detail="Share company-wide or restrict each item, with separate View and Edit access."
+        />
+        <PromiseCard
+          icon={<Bot size={17} />}
+          title="AI-native, not prompt-native"
+          detail="AI Employees autofill through Vault tools without placing plaintext in model context."
+        />
+      </div>
+
+      <div className="mt-7 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex flex-col gap-3 border-b border-slate-100 p-4 sm:flex-row sm:items-end dark:border-slate-800">
+          <div className="min-w-0 flex-1">
+            <label
+              htmlFor="vault-search"
+              className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300"
+            >
+              Search Vault
+            </label>
+            <div className="relative">
+              <Search
+                size={15}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+              />
+              <input
+                id="vault-search"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search titles, usernames, websites, and context…"
+                className="h-9 w-full rounded-md border border-slate-300 bg-white pl-9 pr-9 text-sm shadow-sm outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery("")}
+                  className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                  aria-label="Clear Vault search"
+                >
+                  <X size={13} />
+                </button>
+              )}
+            </div>
+          </div>
+          <Select
+            label="Item type"
+            value={type}
+            onChange={(event) => setType(event.target.value as VaultItemType | "all")}
+            containerClassName="w-full sm:w-44"
+          >
+            <option value="all">All items</option>
+            {VAULT_ITEM_TYPES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        {items === null ? (
+          <div className="flex min-h-64 items-center justify-center">
+            <Spinner size={20} />
+          </div>
+        ) : error ? (
+          <div className="flex min-h-64 flex-col items-center justify-center gap-3 p-6 text-center">
+            <p className="max-w-md text-sm text-slate-500 dark:text-slate-400">{error}</p>
+            <Button variant="secondary" size="sm" onClick={() => void reload()}>
+              <RefreshCw size={13} /> Try again
+            </Button>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="px-6 py-14">
+            <EmptyState
+              title="Your Vault is empty"
+              description="Add a login, API key, or secure note, then choose exactly which Members and AI Employees can use it."
+            />
+            <div className="mt-4 flex justify-center">
+              <Button size="sm" onClick={() => setCreating(true)}>
+                <Plus size={13} /> Add your first item
+              </Button>
+            </div>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="px-6 py-14 text-center">
+            <Search size={22} className="mx-auto text-slate-300 dark:text-slate-600" />
+            <div className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-200">
+              No matching Vault items
+            </div>
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Try another search or show all item types.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {filtered.map((item) => (
+              <VaultItemRow key={item.id} item={item} onOpen={() => setSelected(item)} />
+            ))}
+          </ul>
+        )}
+
+        {items !== null && !error && items.length > 0 && (
+          <div className="flex items-center justify-between border-t border-slate-100 px-4 py-2.5 text-[11px] text-slate-400 dark:border-slate-800 dark:text-slate-500">
+            <span>
+              {filtered.length === items.length
+                ? `${items.length} ${items.length === 1 ? "item" : "items"}`
+                : `${filtered.length} of ${items.length} items`}
+            </span>
+            <span>Stored values never appear in this list</span>
+          </div>
+        )}
+      </div>
+
+      <VaultItemEditor
+        companyId={company.id}
+        open={creating}
+        onClose={() => setCreating(false)}
+        onSaved={handleSaved}
+      />
+      <VaultItemEditor
+        companyId={company.id}
+        item={editing ?? undefined}
+        open={editing !== null}
+        onClose={() => setEditing(null)}
+        onSaved={handleSaved}
+      />
+      <VaultItemDetail
+        companyId={company.id}
+        item={selected}
+        onClose={() => setSelected(null)}
+        onEdit={(item) => {
+          setSelected(null);
+          setEditing(item);
+        }}
+        onDeleted={async () => {
+          setSelected(null);
+          await reload();
+        }}
+      />
+    </div>
+  );
+}
+
+function VaultItemRow({ item, onOpen }: { item: VaultItem; onOpen: () => void }) {
+  const website = safeVaultWebsiteUrl(item.websiteUrl);
+  let hostname = "";
+  if (website) hostname = new URL(website).hostname;
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="group flex w-full flex-col gap-3 px-4 py-4 text-left transition hover:bg-slate-50 sm:flex-row sm:items-center dark:hover:bg-slate-800/50"
+      >
+        <VaultTypeIcon type={item.type} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+              {item.title}
+            </span>
+            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+              {vaultItemTypeLabel(item.type)}
+            </span>
+          </div>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+            {item.username && <span className="max-w-64 truncate">{item.username}</span>}
+            {hostname && <span className="max-w-64 truncate">{hostname}</span>}
+            {!item.username && !hostname && <span>Encrypted value</span>}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 pl-12 sm:pl-0">
+          <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-medium text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            {item.visibility === "company" ? <Building2 size={11} /> : <Users size={11} />}
+            {item.visibility === "company" ? "Company" : "Restricted"}
+          </span>
+          <span className="rounded-md bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            {item.effectiveAccessLevel === "edit" ? "Can edit" : "View only"}
+          </span>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function VaultTypeIcon({ type }: { type: VaultItemType }) {
+  const icon =
+    type === "login" ? (
+      <LockKeyhole size={16} />
+    ) : type === "api_key" ? (
+      <KeyRound size={16} />
+    ) : (
+      <StickyNote size={16} />
+    );
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+      {icon}
+    </span>
+  );
+}
+
+function PromiseCard({
+  icon,
+  title,
+  detail,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+          {icon}
+        </span>
+        <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</div>
+      </div>
+      <p className="mt-2.5 text-xs leading-5 text-slate-500 dark:text-slate-400">{detail}</p>
+    </div>
+  );
+}

--- a/App/client/pages/vault/VaultAccessPanel.tsx
+++ b/App/client/pages/vault/VaultAccessPanel.tsx
@@ -1,0 +1,458 @@
+import React from "react";
+import { Bot, Plus, RefreshCw, ShieldCheck, Trash2, UserRound, Users } from "lucide-react";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import { Spinner } from "@/components/ui/Spinner";
+import { useToast } from "@/components/ui/Toast";
+import {
+  vaultApi,
+  type VaultEmployeeAccessLevel,
+  type VaultEmployeeCandidate,
+  type VaultEmployeeGrant,
+  type VaultItem,
+  type VaultMemberAccess,
+  type VaultMemberAccessLevel,
+  type VaultMemberCandidate,
+} from "@/lib/vault";
+
+export function VaultAccessPanel({ companyId, item }: { companyId: string; item: VaultItem }) {
+  const { toast } = useToast();
+  const [memberAccess, setMemberAccess] = React.useState<VaultMemberAccess[] | null>(null);
+  const [memberCandidates, setMemberCandidates] = React.useState<VaultMemberCandidate[]>([]);
+  const [employeeGrants, setEmployeeGrants] = React.useState<VaultEmployeeGrant[] | null>(null);
+  const [employeeCandidates, setEmployeeCandidates] = React.useState<VaultEmployeeCandidate[]>([]);
+  const [memberPick, setMemberPick] = React.useState("");
+  const [memberLevel, setMemberLevel] = React.useState<VaultMemberAccessLevel>("view");
+  const [employeePick, setEmployeePick] = React.useState("");
+  const [employeeLevel, setEmployeeLevel] = React.useState<VaultEmployeeAccessLevel>("use");
+  const [busy, setBusy] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const reload = React.useCallback(async () => {
+    setError(null);
+    try {
+      const [access, people, grants, employees] = await Promise.all([
+        vaultApi.listMemberAccess(companyId, item.id),
+        vaultApi.listMemberCandidates(companyId, item.id),
+        vaultApi.listEmployeeGrants(companyId, item.id),
+        vaultApi.listEmployeeCandidates(companyId, item.id),
+      ]);
+      setMemberAccess(access);
+      setMemberCandidates(people);
+      setEmployeeGrants(grants);
+      setEmployeeCandidates(employees);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Vault access could not be loaded.";
+      setError(message);
+      setMemberAccess([]);
+      setEmployeeGrants([]);
+      toast(message, "error");
+    }
+  }, [companyId, item.id, toast]);
+
+  React.useEffect(() => {
+    setMemberAccess(null);
+    setEmployeeGrants(null);
+    setMemberPick("");
+    setEmployeePick("");
+    void reload();
+  }, [reload]);
+
+  const memberIds = new Set((memberAccess ?? []).map((row) => row.userId));
+  const employeeIds = new Set((employeeGrants ?? []).map((row) => row.employeeId));
+  const availableMembers = memberCandidates.filter(
+    (candidate) => !candidate.isCreator && !memberIds.has(candidate.id) && !candidate.access,
+  );
+  const availableEmployees = employeeCandidates.filter(
+    (candidate) => !employeeIds.has(candidate.id) && !candidate.grant,
+  );
+
+  async function addMember() {
+    if (!memberPick || busy) return;
+    setBusy("member:add");
+    try {
+      await vaultApi.createMemberAccess(companyId, item.id, memberPick, memberLevel);
+      setMemberPick("");
+      setMemberLevel("view");
+      await reload();
+      toast("Member access added", "success");
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "Member access could not be added.", "error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function changeMember(row: VaultMemberAccess, accessLevel: VaultMemberAccessLevel) {
+    if (row.accessLevel === accessLevel || busy) return;
+    setBusy(`member:${row.id}`);
+    try {
+      await vaultApi.updateMemberAccess(companyId, item.id, row.id, accessLevel);
+      await reload();
+      toast("Member access updated", "success");
+    } catch (cause) {
+      toast(
+        cause instanceof Error ? cause.message : "Member access could not be updated.",
+        "error",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function removeMember(row: VaultMemberAccess) {
+    if (busy) return;
+    setBusy(`member:${row.id}`);
+    try {
+      await vaultApi.deleteMemberAccess(companyId, item.id, row.id);
+      await reload();
+      toast("Member access removed", "success");
+    } catch (cause) {
+      toast(
+        cause instanceof Error ? cause.message : "Member access could not be removed.",
+        "error",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addEmployee() {
+    if (!employeePick || busy) return;
+    setBusy("employee:add");
+    try {
+      await vaultApi.createEmployeeGrant(companyId, item.id, employeePick, employeeLevel);
+      setEmployeePick("");
+      setEmployeeLevel("use");
+      await reload();
+      toast("AI Employee Grant added", "success");
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "The Grant could not be added.", "error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function changeEmployee(row: VaultEmployeeGrant, accessLevel: VaultEmployeeAccessLevel) {
+    if (row.accessLevel === accessLevel || busy) return;
+    setBusy(`employee:${row.id}`);
+    try {
+      await vaultApi.updateEmployeeGrant(companyId, item.id, row.id, accessLevel);
+      await reload();
+      toast("AI Employee Grant updated", "success");
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "The Grant could not be updated.", "error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function removeEmployee(row: VaultEmployeeGrant) {
+    if (busy) return;
+    setBusy(`employee:${row.id}`);
+    try {
+      await vaultApi.deleteEmployeeGrant(companyId, item.id, row.id);
+      await reload();
+      toast("AI Employee Grant removed", "success");
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "The Grant could not be removed.", "error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (memberAccess === null || employeeGrants === null) {
+    return (
+      <div className="flex min-h-40 items-center justify-center">
+        <Spinner size={18} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-40 flex-col items-center justify-center gap-3 rounded-xl border border-slate-200 text-center dark:border-slate-700">
+        <p className="max-w-md px-4 text-sm text-slate-500 dark:text-slate-400">{error}</p>
+        <Button variant="secondary" size="sm" onClick={() => void reload()}>
+          <RefreshCw size={13} /> Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="rounded-xl border border-slate-200 bg-slate-50/70 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/40">
+        <div className="flex items-start gap-2.5">
+          <ShieldCheck size={16} className="mt-0.5 shrink-0 text-indigo-500" />
+          <div>
+            <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {item.visibility === "company"
+                ? "Every Member can view this item"
+                : "Only selected Members can view this item"}
+            </div>
+            <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
+              View access includes reveal and copy. Edit also changes fields and rotates the stored
+              value. Only the creator and company owners or admins can change access or delete it.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <AccessSection
+        icon={<Users size={16} />}
+        title="Member access"
+        description={
+          item.visibility === "company"
+            ? "Everyone already has View access. Add a Member here only when they should be able to edit."
+            : "Choose the Members who may open this item, then decide who may edit it."
+        }
+      >
+        {memberAccess.length === 0 ? (
+          <EmptyAccessRow
+            icon={<UserRound size={17} />}
+            text={
+              item.visibility === "company"
+                ? "No Members have extra Edit access."
+                : "No Members have been added yet."
+            }
+          />
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {memberAccess.map((row) => (
+              <li
+                key={row.id}
+                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <Avatar name={row.member.name} size="sm" kind="human" />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {row.member.name}
+                    </div>
+                    {row.member.email && (
+                      <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                        {row.member.email}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={row.accessLevel}
+                    disabled={!item.canShare || busy !== null}
+                    onChange={(event) =>
+                      void changeMember(row, event.target.value as VaultMemberAccessLevel)
+                    }
+                    className="h-8 w-28 text-xs"
+                    aria-label={`Access for ${row.member.name}`}
+                  >
+                    <option value="view">View</option>
+                    <option value="edit">Edit</option>
+                  </Select>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={!item.canShare || busy !== null}
+                    onClick={() => void removeMember(row)}
+                    aria-label={`Remove ${row.member.name}'s access`}
+                    title="Remove access"
+                  >
+                    <Trash2 size={13} />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {item.canShare && (
+          <div className="flex flex-col gap-2 border-t border-slate-100 p-4 sm:flex-row sm:items-end dark:border-slate-800">
+            <Select
+              label="Add a Member"
+              value={memberPick}
+              disabled={busy !== null || availableMembers.length === 0}
+              onChange={(event) => setMemberPick(event.target.value)}
+              containerClassName="min-w-0 flex-1"
+            >
+              <option value="">
+                {availableMembers.length ? "Choose a Member…" : "No more Members to add"}
+              </option>
+              {availableMembers.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>
+                  {candidate.name}
+                  {candidate.email ? ` — ${candidate.email}` : ""}
+                </option>
+              ))}
+            </Select>
+            <Select
+              label="Access"
+              value={memberLevel}
+              disabled={busy !== null || availableMembers.length === 0}
+              onChange={(event) => setMemberLevel(event.target.value as VaultMemberAccessLevel)}
+              containerClassName="w-full sm:w-28"
+            >
+              <option value="view">View</option>
+              <option value="edit">Edit</option>
+            </Select>
+            <Button
+              size="sm"
+              disabled={busy !== null || !memberPick}
+              onClick={() => void addMember()}
+            >
+              <Plus size={13} /> Add
+            </Button>
+          </div>
+        )}
+      </AccessSection>
+
+      <div className="rounded-xl border border-indigo-200 bg-indigo-50/60 px-4 py-3 dark:border-indigo-900 dark:bg-indigo-950/30">
+        <div className="flex items-start gap-2.5">
+          <Bot size={16} className="mt-0.5 shrink-0 text-indigo-600 dark:text-indigo-300" />
+          <div>
+            <div className="text-sm font-medium text-indigo-900 dark:text-indigo-100">
+              AI-native access without plaintext in the model
+            </div>
+            <p className="mt-0.5 text-xs leading-5 text-indigo-800/75 dark:text-indigo-200/75">
+              <strong>Use</strong> exposes safe metadata. For Login items, it also lets an AI
+              Employee fill the saved username or password server-side; the password goes only into
+              a password input and never appears in chat or model context. API-key and secure-note
+              values have no AI plaintext or Browser-fill path. <strong>Manage</strong> can also
+              update a Login&apos;s title, username, and private context while preserving its saved
+              website origin. It never lets AI rebind, reveal, rotate, or delete the stored value;
+              items an AI Employee creates or captures grant it Manage automatically.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <AccessSection
+        icon={<Bot size={16} />}
+        title="AI Employee Grants"
+        description="Company visibility never grants AI access. Add each AI Employee explicitly and start with Use."
+      >
+        {employeeGrants.length === 0 ? (
+          <EmptyAccessRow icon={<Bot size={17} />} text="No AI Employees can use this item." />
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {employeeGrants.map((row) => (
+              <li
+                key={row.id}
+                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <Avatar name={row.employee.name} size="sm" kind="ai" />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {row.employee.name}
+                    </div>
+                    <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                      {row.employee.role}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={row.accessLevel}
+                    disabled={!item.canShare || busy !== null}
+                    onChange={(event) =>
+                      void changeEmployee(row, event.target.value as VaultEmployeeAccessLevel)
+                    }
+                    className="h-8 w-28 text-xs"
+                    aria-label={`Grant for ${row.employee.name}`}
+                  >
+                    <option value="use">Use</option>
+                    <option value="manage">Manage</option>
+                  </Select>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={!item.canShare || busy !== null}
+                    onClick={() => void removeEmployee(row)}
+                    aria-label={`Remove ${row.employee.name}'s Grant`}
+                    title="Remove Grant"
+                  >
+                    <Trash2 size={13} />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {item.canShare && (
+          <div className="flex flex-col gap-2 border-t border-slate-100 p-4 sm:flex-row sm:items-end dark:border-slate-800">
+            <Select
+              label="Grant to an AI Employee"
+              value={employeePick}
+              disabled={busy !== null || availableEmployees.length === 0}
+              onChange={(event) => setEmployeePick(event.target.value)}
+              containerClassName="min-w-0 flex-1"
+            >
+              <option value="">
+                {availableEmployees.length
+                  ? "Choose an AI Employee…"
+                  : "No more AI Employees to add"}
+              </option>
+              {availableEmployees.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>
+                  {candidate.name} — {candidate.role}
+                </option>
+              ))}
+            </Select>
+            <Select
+              label="Grant"
+              value={employeeLevel}
+              disabled={busy !== null || availableEmployees.length === 0}
+              onChange={(event) => setEmployeeLevel(event.target.value as VaultEmployeeAccessLevel)}
+              containerClassName="w-full sm:w-28"
+            >
+              <option value="use">Use</option>
+              <option value="manage">Manage</option>
+            </Select>
+            <Button
+              size="sm"
+              disabled={busy !== null || !employeePick}
+              onClick={() => void addEmployee()}
+            >
+              <Plus size={13} /> Add
+            </Button>
+          </div>
+        )}
+      </AccessSection>
+    </div>
+  );
+}
+
+function AccessSection({
+  icon,
+  title,
+  description,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+      <div className="border-b border-slate-100 px-4 py-3 dark:border-slate-800">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+          <span className="text-slate-500 dark:text-slate-400">{icon}</span>
+          {title}
+        </div>
+        <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyAccessRow({ icon, text }: { icon: React.ReactNode; text: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-slate-400 dark:text-slate-500">
+      {icon}
+      {text}
+    </div>
+  );
+}

--- a/App/client/pages/vault/VaultItemDetail.tsx
+++ b/App/client/pages/vault/VaultItemDetail.tsx
@@ -1,0 +1,436 @@
+import React from "react";
+import {
+  Building2,
+  Check,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  KeyRound,
+  LockKeyhole,
+  Pencil,
+  ShieldCheck,
+  StickyNote,
+  Trash2,
+  UserRound,
+  Users,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { useDialog } from "@/components/ui/Dialog";
+import { Modal } from "@/components/ui/Modal";
+import { Spinner } from "@/components/ui/Spinner";
+import { useToast } from "@/components/ui/Toast";
+import { copyToClipboard } from "@/lib/clipboard";
+import {
+  safeVaultWebsiteUrl,
+  scheduleVaultClipboardClear,
+  vaultApi,
+  type VaultItem,
+  vaultItemTypeLabel,
+  vaultSecretLabel,
+  vaultUsernameLabel,
+} from "@/lib/vault";
+import { VaultAccessPanel } from "@/pages/vault/VaultAccessPanel";
+
+const SECRET_LIFETIME_SECONDS = 30;
+
+export function VaultItemDetail({
+  companyId,
+  item,
+  onClose,
+  onEdit,
+  onDeleted,
+}: {
+  companyId: string;
+  item: VaultItem | null;
+  onClose: () => void;
+  onEdit: (item: VaultItem) => void;
+  onDeleted: (item: VaultItem) => void | Promise<void>;
+}) {
+  const { toast } = useToast();
+  const dialog = useDialog();
+  const [detail, setDetail] = React.useState<VaultItem | null>(item);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [revealedSecret, setRevealedSecret] = React.useState<string | null>(null);
+  const [revealExpiresAt, setRevealExpiresAt] = React.useState<number | null>(null);
+  const [secondsLeft, setSecondsLeft] = React.useState(0);
+  const [revealing, setRevealing] = React.useState(false);
+  const [copying, setCopying] = React.useState(false);
+  const [copiedField, setCopiedField] = React.useState<string | null>(null);
+
+  const hideSecret = React.useCallback(() => {
+    setRevealedSecret(null);
+    setRevealExpiresAt(null);
+    setSecondsLeft(0);
+  }, []);
+
+  React.useEffect(() => {
+    setDetail(item);
+    setError(null);
+    hideSecret();
+    if (!item) return;
+    let active = true;
+    setLoading(true);
+    vaultApi
+      .getItem(companyId, item.id)
+      .then((next) => {
+        if (active) setDetail(next);
+      })
+      .catch((cause: unknown) => {
+        if (!active) return;
+        const message =
+          cause instanceof Error ? cause.message : "The Vault item could not be loaded.";
+        setError(message);
+        toast(message, "error");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [companyId, hideSecret, item, toast]);
+
+  React.useEffect(() => {
+    if (!revealExpiresAt) return;
+    const update = () => {
+      const remaining = Math.max(0, Math.ceil((revealExpiresAt - Date.now()) / 1_000));
+      setSecondsLeft(remaining);
+      if (remaining === 0) hideSecret();
+    };
+    update();
+    const timer = window.setInterval(update, 500);
+    return () => window.clearInterval(timer);
+  }, [hideSecret, revealExpiresAt]);
+
+  async function reveal() {
+    if (!detail || revealing) return;
+    setRevealing(true);
+    try {
+      const secret = await vaultApi.revealItem(companyId, detail.id, "reveal");
+      setRevealedSecret(secret);
+      setRevealExpiresAt(Date.now() + SECRET_LIFETIME_SECONDS * 1_000);
+      setSecondsLeft(SECRET_LIFETIME_SECONDS);
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "The value could not be revealed.", "error");
+    } finally {
+      setRevealing(false);
+    }
+  }
+
+  async function copyStoredSecret() {
+    if (!detail || copying) return;
+    setCopying(true);
+    try {
+      const secret = await vaultApi.revealItem(companyId, detail.id, "copy");
+      const copied = await copyToClipboard(secret);
+      if (!copied) throw new Error("Could not access the clipboard");
+      setCopiedField("secret");
+      toast("Copied. Clipboard will be cleared after 30 seconds when supported.", "success");
+      scheduleVaultClipboardClear(secret, SECRET_LIFETIME_SECONDS * 1_000);
+    } catch (cause) {
+      toast(cause instanceof Error ? cause.message : "The value could not be copied.", "error");
+    } finally {
+      setCopying(false);
+    }
+  }
+
+  async function copyMetadata(value: string, field: string) {
+    if (!(await copyToClipboard(value))) {
+      toast("Could not access the clipboard", "error");
+      return;
+    }
+    setCopiedField(field);
+    toast("Copied to clipboard", "success");
+  }
+
+  async function remove() {
+    if (!detail) return;
+    const confirmed = await dialog.confirm({
+      title: `Delete “${detail.title}”?`,
+      message:
+        "This permanently removes the encrypted value and every Member access entry and AI Employee Grant. This cannot be undone.",
+      confirmLabel: "Delete Vault item",
+      variant: "danger",
+    });
+    if (!confirmed) return;
+    try {
+      await vaultApi.deleteItem(companyId, detail.id);
+      hideSecret();
+      await onDeleted(detail);
+      toast("Vault item deleted", "success");
+    } catch (cause) {
+      toast(
+        cause instanceof Error ? cause.message : "The Vault item could not be deleted.",
+        "error",
+      );
+    }
+  }
+
+  const open = item !== null;
+  const websiteHref = detail ? safeVaultWebsiteUrl(detail.websiteUrl) : null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => {
+        hideSecret();
+        onClose();
+      }}
+      title={detail?.title ?? "Vault item"}
+      size="xl"
+    >
+      {loading && !detail ? (
+        <div className="flex min-h-64 items-center justify-center">
+          <Spinner size={20} />
+        </div>
+      ) : !detail ? null : (
+        <div className="flex flex-col gap-7">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-start gap-3">
+              <VaultTypeIcon item={detail} large />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                    {vaultItemTypeLabel(detail.type)}
+                  </span>
+                  <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                    {detail.visibility === "company" ? (
+                      <Building2 size={11} />
+                    ) : (
+                      <Users size={11} />
+                    )}
+                    {detail.visibility === "company" ? "Company" : "Restricted"}
+                  </span>
+                </div>
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  Updated {new Date(detail.updatedAt).toLocaleString()}
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {detail.canEdit && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    hideSecret();
+                    onEdit(detail);
+                  }}
+                >
+                  <Pencil size={13} /> Edit
+                </Button>
+              )}
+              {detail.canDelete && (
+                <Button variant="ghost" size="sm" onClick={() => void remove()}>
+                  <Trash2 size={13} /> Delete
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900 dark:bg-rose-950/30 dark:text-rose-300">
+              {error}
+            </div>
+          )}
+
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Item details
+            </h3>
+            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+              {detail.type !== "secure_note" && detail.username && (
+                <DetailRow
+                  icon={<UserRound size={15} />}
+                  label={vaultUsernameLabel(detail.type)}
+                  value={detail.username}
+                  action={
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void copyMetadata(detail.username, "username")}
+                    >
+                      {copiedField === "username" ? <Check size={13} /> : <Copy size={13} />}
+                      <span className="hidden sm:inline">Copy</span>
+                    </Button>
+                  }
+                />
+              )}
+              {detail.type !== "secure_note" && detail.websiteUrl && (
+                <DetailRow
+                  icon={<ExternalLink size={15} />}
+                  label="Website"
+                  value={detail.websiteUrl}
+                  action={
+                    websiteHref ? (
+                      <a
+                        href={websiteHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                      >
+                        <ExternalLink size={13} /> Open
+                      </a>
+                    ) : null
+                  }
+                />
+              )}
+              <div className="border-t border-slate-100 px-4 py-3 first:border-t-0 dark:border-slate-800">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
+                    <KeyRound size={15} className="mt-0.5 shrink-0 text-slate-400" />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                        {vaultSecretLabel(detail.type)}
+                      </div>
+                      {detail.type === "secure_note" && revealedSecret !== null ? (
+                        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 font-mono text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-100">
+                          {revealedSecret}
+                        </pre>
+                      ) : (
+                        <code className="mt-1 block break-all font-mono text-sm text-slate-800 dark:text-slate-100">
+                          {revealedSecret ?? "••••••••••••••••"}
+                        </code>
+                      )}
+                      {revealedSecret !== null && (
+                        <div className="mt-1 text-xs tabular-nums text-amber-600 dark:text-amber-300">
+                          Auto-hides in {secondsLeft}s
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  {detail.canReveal && (
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={revealing}
+                        onClick={() => (revealedSecret === null ? void reveal() : hideSecret())}
+                      >
+                        {revealedSecret === null ? <Eye size={13} /> : <EyeOff size={13} />}
+                        {revealing ? "Revealing…" : revealedSecret === null ? "Reveal" : "Hide"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={copying}
+                        onClick={() => void copyStoredSecret()}
+                      >
+                        {copiedField === "secret" ? <Check size={13} /> : <Copy size={13} />}
+                        {copying ? "Copying…" : "Copy"}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+              {detail.notes && (
+                <DetailRow
+                  icon={<StickyNote size={15} />}
+                  label="Private context"
+                  value={detail.notes}
+                  multiline
+                />
+              )}
+            </div>
+          </section>
+
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950/30">
+            <div className="flex items-start gap-2.5">
+              <LockKeyhole
+                size={16}
+                className="mt-0.5 shrink-0 text-amber-700 dark:text-amber-300"
+              />
+              <p className="text-xs leading-5 text-amber-900 dark:text-amber-100">
+                Reveal decrypts this value for this browser request only and hides it after 30
+                seconds. Copy fetches the value without displaying it, then attempts to clear the
+                clipboard after 30 seconds if your browser allows clipboard reads.
+              </p>
+            </div>
+          </div>
+
+          <section>
+            <div className="mb-3 flex items-center gap-2">
+              <ShieldCheck size={15} className="text-slate-400" />
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                Access
+              </h3>
+            </div>
+            {detail.canShare ? (
+              <VaultAccessPanel companyId={companyId} item={detail} />
+            ) : (
+              <div className="rounded-xl border border-slate-200 bg-slate-50/70 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/40">
+                <div className="flex items-start gap-2.5">
+                  <ShieldCheck size={16} className="mt-0.5 shrink-0 text-indigo-500" />
+                  <div>
+                    <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                      You have {detail.effectiveAccessLevel === "edit" ? "Edit" : "View"} access
+                    </div>
+                    <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                      Only the item&apos;s creator and company owners or admins can see or change
+                      its Member access and AI Employee Grants.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function DetailRow({
+  icon,
+  label,
+  value,
+  action,
+  multiline = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  action?: React.ReactNode;
+  multiline?: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3 border-t border-slate-100 px-4 py-3 first:border-t-0 dark:border-slate-800">
+      <span className="mt-0.5 shrink-0 text-slate-400">{icon}</span>
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+          {label}
+        </div>
+        <div
+          className={
+            multiline
+              ? "mt-1 whitespace-pre-wrap break-words text-sm leading-6 text-slate-700 dark:text-slate-200"
+              : "mt-1 truncate text-sm text-slate-800 dark:text-slate-100"
+          }
+        >
+          {value}
+        </div>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}
+
+function VaultTypeIcon({ item, large = false }: { item: VaultItem; large?: boolean }) {
+  const icon =
+    item.type === "login" ? (
+      <LockKeyhole size={large ? 20 : 16} />
+    ) : item.type === "api_key" ? (
+      <KeyRound size={large ? 20 : 16} />
+    ) : (
+      <StickyNote size={large ? 20 : 16} />
+    );
+  return (
+    <span
+      className={`${large ? "h-11 w-11 rounded-xl" : "h-9 w-9 rounded-lg"} flex shrink-0 items-center justify-center bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300`}
+    >
+      {icon}
+    </span>
+  );
+}

--- a/App/client/pages/vault/VaultItemEditor.tsx
+++ b/App/client/pages/vault/VaultItemEditor.tsx
@@ -1,0 +1,313 @@
+import React from "react";
+import { Check, Copy, Eye, EyeOff, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { FormError } from "@/components/ui/FormError";
+import { Input } from "@/components/ui/Input";
+import { Modal } from "@/components/ui/Modal";
+import { Select } from "@/components/ui/Select";
+import { useToast } from "@/components/ui/Toast";
+import { copyToClipboard } from "@/lib/clipboard";
+import {
+  generateVaultPassword,
+  scheduleVaultClipboardClear,
+  VAULT_ITEM_TYPES,
+  vaultApi,
+  type VaultItem,
+  type VaultItemType,
+  type VaultVisibility,
+  vaultSecretLabel,
+  vaultUsernameLabel,
+} from "@/lib/vault";
+
+export function VaultItemEditor({
+  companyId,
+  item,
+  open,
+  onClose,
+  onSaved,
+}: {
+  companyId: string;
+  item?: VaultItem;
+  open: boolean;
+  onClose: () => void;
+  onSaved: (item: VaultItem) => void | Promise<void>;
+}) {
+  const editing = !!item;
+  const { toast } = useToast();
+  const [type, setType] = React.useState<VaultItemType>(item?.type ?? "login");
+  const [visibility, setVisibility] = React.useState<VaultVisibility>(
+    item?.visibility ?? "restricted",
+  );
+  const [title, setTitle] = React.useState(item?.title ?? "");
+  const [username, setUsername] = React.useState(item?.username ?? "");
+  const [websiteUrl, setWebsiteUrl] = React.useState(item?.websiteUrl ?? "");
+  const [notes, setNotes] = React.useState(item?.notes ?? "");
+  const [secret, setSecret] = React.useState("");
+  const [showSecret, setShowSecret] = React.useState(false);
+  const [generated, setGenerated] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      setSecret("");
+      setShowSecret(false);
+      setGenerated(false);
+      setCopied(false);
+      return;
+    }
+    setType(item?.type ?? "login");
+    setVisibility(item?.visibility ?? "restricted");
+    setTitle(item?.title ?? "");
+    setUsername(item?.username ?? "");
+    setWebsiteUrl(item?.websiteUrl ?? "");
+    setNotes(item?.notes ?? "");
+    setSecret("");
+    setShowSecret(false);
+    setGenerated(false);
+    setCopied(false);
+    setBusy(false);
+    setError(null);
+  }, [item, open]);
+
+  async function copyGeneratedSecret() {
+    if (!secret) return;
+    if (await copyToClipboard(secret)) {
+      setCopied(true);
+      scheduleVaultClipboardClear(secret);
+      toast(
+        "Generated password copied. Clipboard will clear after 30 seconds when supported.",
+        "success",
+      );
+    } else {
+      toast("Could not access the clipboard", "error");
+    }
+  }
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const common = {
+        type,
+        title: title.trim(),
+        username: type === "secure_note" ? "" : username.trim(),
+        websiteUrl: type === "secure_note" ? "" : websiteUrl.trim(),
+        notes: notes.trim(),
+      };
+      const saved = editing
+        ? await vaultApi.updateItem(companyId, item.id, {
+            ...common,
+            expectedVersion: item.version,
+            ...(item.canShare ? { visibility } : {}),
+            ...(secret ? { secret } : {}),
+          })
+        : await vaultApi.createItem(companyId, { ...common, visibility, secret });
+      await onSaved(saved);
+      toast(editing ? "Vault item updated" : "Vault item created", "success");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "The Vault item could not be saved.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => (busy ? undefined : onClose())}
+      title={editing ? `Edit ${item.title}` : "Add to Vault"}
+      size="lg"
+    >
+      <form className="flex flex-col gap-4" onSubmit={submit}>
+        <FormError message={error} />
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Select
+            label="Item type"
+            value={type}
+            disabled={busy}
+            onChange={(event) => setType(event.target.value as VaultItemType)}
+          >
+            {VAULT_ITEM_TYPES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+          <Select
+            label="Visibility"
+            value={visibility}
+            disabled={busy || (editing && !item.canShare)}
+            onChange={(event) => setVisibility(event.target.value as VaultVisibility)}
+          >
+            <option value="company">Everyone in the company</option>
+            <option value="restricted">Only selected Members</option>
+          </Select>
+        </div>
+
+        <Input
+          label="Title"
+          value={title}
+          disabled={busy}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder={
+            type === "login" ? "GitHub" : type === "api_key" ? "Stripe live key" : "Recovery codes"
+          }
+          autoFocus
+          required
+        />
+
+        {type !== "secure_note" && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input
+              label={vaultUsernameLabel(type)}
+              value={username}
+              disabled={busy}
+              onChange={(event) => setUsername(event.target.value)}
+              autoComplete="off"
+              placeholder={type === "login" ? "name@example.com" : "Production"}
+            />
+            <Input
+              label="Website"
+              type="url"
+              value={websiteUrl}
+              disabled={busy}
+              onChange={(event) => setWebsiteUrl(event.target.value)}
+              placeholder="https://example.com"
+            />
+          </div>
+        )}
+
+        <div>
+          <div className="mb-1 flex flex-wrap items-center justify-between gap-2">
+            <label
+              htmlFor="vault-secret-value"
+              className="text-xs font-medium text-slate-600 dark:text-slate-300"
+            >
+              {vaultSecretLabel(type)}
+              {editing && (
+                <span className="ml-1 font-normal text-slate-400 dark:text-slate-500">
+                  (leave blank to keep the current value)
+                </span>
+              )}
+            </label>
+            {type === "login" && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => {
+                  setSecret(generateVaultPassword());
+                  setGenerated(true);
+                  setCopied(false);
+                  setShowSecret(true);
+                }}
+                className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 disabled:opacity-50 dark:text-indigo-300 dark:hover:text-indigo-200"
+              >
+                <RefreshCw size={12} /> Generate strong password
+              </button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            {type === "secure_note" ? (
+              <textarea
+                id="vault-secret-value"
+                rows={6}
+                value={secret}
+                disabled={busy}
+                required={!editing}
+                onChange={(event) => {
+                  setSecret(event.target.value);
+                  setGenerated(false);
+                  setCopied(false);
+                }}
+                placeholder={
+                  editing ? "Leave blank to keep the current note" : "Write the private note…"
+                }
+                className="min-w-0 flex-1 resize-y rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-60 dark:border-slate-600 dark:bg-slate-900"
+              />
+            ) : (
+              <input
+                id="vault-secret-value"
+                type={showSecret ? "text" : "password"}
+                value={secret}
+                disabled={busy}
+                required={!editing}
+                autoComplete="new-password"
+                onChange={(event) => {
+                  setSecret(event.target.value);
+                  setGenerated(false);
+                  setCopied(false);
+                }}
+                placeholder={
+                  editing ? "Leave blank to keep the current value" : vaultSecretLabel(type)
+                }
+                className="min-w-0 flex-1 rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-60 dark:border-slate-600 dark:bg-slate-900"
+              />
+            )}
+            {type !== "secure_note" && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={!secret || busy}
+                onClick={() => setShowSecret((current) => !current)}
+                aria-label={showSecret ? "Hide value" : "Show value"}
+                title={showSecret ? "Hide value" : "Show value"}
+              >
+                {showSecret ? <EyeOff size={14} /> : <Eye size={14} />}
+              </Button>
+            )}
+            {generated && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={!secret || busy}
+                onClick={() => void copyGeneratedSecret()}
+              >
+                {copied ? <Check size={14} /> : <Copy size={14} />}
+                <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="vault-item-notes"
+            className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300"
+          >
+            Private context <span className="font-normal text-slate-400">(optional)</span>
+          </label>
+          <textarea
+            id="vault-item-notes"
+            rows={3}
+            value={notes}
+            disabled={busy}
+            onChange={(event) => setNotes(event.target.value)}
+            placeholder="Account owner, rotation instructions, or other encrypted context…"
+            className="w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:opacity-60 dark:border-slate-600 dark:bg-slate-900"
+          />
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs leading-5 text-slate-500 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
+          Vault values and private context are encrypted at rest. The stored value is never loaded
+          into this form while editing; enter a replacement only when you want to rotate it.
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 pt-1 sm:flex-row sm:justify-end">
+          <Button type="button" variant="ghost" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={busy || !title.trim() || (!editing && !secret)}>
+            {busy ? "Saving…" : editing ? "Save changes" : "Add to Vault"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/App/config.ts
+++ b/App/config.ts
@@ -11,6 +11,10 @@ export const config = {
 
   // API server
   port: 8471,
+  // Default self-host installs replace this public placeholder with a strong,
+  // persistent value in data/.instance-secrets.json. Set an explicit secret
+  // of at least 32 characters to take precedence. Shared multi-tenant installs
+  // must always configure an explicit value.
   sessionSecret: "change-me-in-production",
 
   // Security posture. `multiTenant` is intentionally false for existing
@@ -19,9 +23,11 @@ export const config = {
   // isolation settings below meet the shared-SaaS baseline.
   security: {
     multiTenant: false,
-    // Separate from sessionSecret. New ciphertexts derive a distinct key per
-    // company (or per user for account secrets). Keep old values in
-    // previousEncryptionSecrets while rotating so existing rows stay readable.
+    // Separate from sessionSecret. Default self-host installs replace this
+    // placeholder with the distinct managed encryption key stored in
+    // data/.instance-secrets.json. Explicit values take precedence. New
+    // ciphertexts derive a scoped key per company (or user); keep old explicit
+    // values in previousEncryptionSecrets while rotating so rows stay readable.
     encryptionSecret: "change-me-in-production-too",
     previousEncryptionSecrets: [] as string[],
     // "auto" sets Secure whenever the Admin → General public URL is https,
@@ -52,14 +58,16 @@ export const config = {
   },
 
   // AI Employee execution controls. Coding execution is disabled by default:
-  // a plain host shell shares the App process UID and is not confined by cwd.
-  // ChatGPT subscription auth is available only
-  // when an operator deliberately selects `bubblewrap` on a Linux deployment
-  // whose user-namespace policy passes Genosyn's startup probe. Bubblewrap runs
-  // every shell invocation and repository Git child in user/mount/PID
-  // namespaces with only the employee workspace writable. Shared SaaS requires
-  // bubblewrap and disables network access inside the coding sandbox; networked
-  // work goes through governed Integration, browser, and HTTP surfaces instead.
+  // `host` keeps the path-confined file/search tools but never exposes bash: a
+  // same-UID host shell could read App data, Vault encryption roots, and sibling
+  // process tokens. Sandboxed bash and ChatGPT subscription auth are available
+  // only when an operator deliberately selects `bubblewrap` on a Linux
+  // deployment whose user-namespace policy passes Genosyn's startup probe.
+  // Bubblewrap runs every shell invocation and repository Git child in
+  // user/mount/PID namespaces with only the employee workspace writable. Shared
+  // SaaS requires bubblewrap and disables network access inside the coding
+  // sandbox; networked work goes through governed Integration, browser, and
+  // HTTP surfaces instead.
   agent: {
     codingTools: {
       enabled: true,
@@ -67,9 +75,9 @@ export const config = {
       bubblewrapPath: "/usr/bin/bwrap",
       allowNetwork: false,
       // Emergency compatibility escape hatch for a trusted, single-company
-      // install only. `host` can read the whole App filesystem and reach the
-      // network; selecting host mode is not sufficient without this separate
-      // acknowledgement.
+      // install only. Host mode keeps model tools path-confined, but its
+      // server-owned Git work still runs outside a namespace; selecting host
+      // mode is not sufficient without this separate acknowledgement.
       allowUnsafeHostExecution: false,
     },
     // The current app-owned Chromium process shares the API container. Keep it

--- a/App/package.json
+++ b/App/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch --ignore='**/vite.config.*' --ignore='client/**' --ignore='dist/**' --ignore='data/**' server/index.ts",
     "build": "npm run build:server && npm run build:client",
-    "build:server": "tsc -p tsconfig.server.json && mkdir -p dist/server/mcp-browser/viewer && cp server/mcp-browser/*.mjs dist/server/mcp-browser/ && cp server/mcp-browser/viewer/index.html server/mcp-browser/viewer/viewer.js dist/server/mcp-browser/viewer/ && cp -R server/assets dist/server/",
+    "build:server": "rm -rf dist/server && tsc -p tsconfig.server.json && mkdir -p dist/server/mcp-browser/viewer && cp server/mcp-browser/*.mjs dist/server/mcp-browser/ && cp server/mcp-browser/viewer/index.html server/mcp-browser/viewer/viewer.js dist/server/mcp-browser/viewer/ && cp -R server/assets dist/server/",
     "build:client": "vite build",
     "start": "node dist/server/index.js",
     "lint": "eslint . --ext .ts,.tsx",

--- a/App/server/db/datasource.ts
+++ b/App/server/db/datasource.ts
@@ -166,6 +166,9 @@ import { MarketingCreative } from "./entities/MarketingCreative.js";
 import { MarketingExperiment } from "./entities/MarketingExperiment.js";
 import { MarketingPerformanceSnapshot } from "./entities/MarketingPerformanceSnapshot.js";
 import { EmployeeMarketingGrant } from "./entities/EmployeeMarketingGrant.js";
+import { VaultItem } from "./entities/VaultItem.js";
+import { VaultItemMemberAccess } from "./entities/VaultItemMemberAccess.js";
+import { EmployeeVaultGrant } from "./entities/EmployeeVaultGrant.js";
 
 const entities = [
   User,
@@ -331,6 +334,9 @@ const entities = [
   MarketingExperiment,
   MarketingPerformanceSnapshot,
   EmployeeMarketingGrant,
+  VaultItem,
+  VaultItemMemberAccess,
+  EmployeeVaultGrant,
 ];
 
 // Migrations glob -- matches .ts files under server/db/migrations in dev (via tsx)

--- a/App/server/db/entities/BackupDestination.ts
+++ b/App/server/db/entities/BackupDestination.ts
@@ -30,7 +30,7 @@ import {
  *
  * Kind-specific settings — including the SFTP password / private key and the
  * SMB password — live inside {@link encryptedConfig}, an AES-256-GCM blob
- * keyed from `config.sessionSecret` (same helper as model API keys,
+ * keyed from the instance encryption key ring (same helper as model API keys,
  * `lib/secret.ts`). The raw secret is never returned to the client; the
  * serializer surfaces only whether a credential is set. {@link hint} is a
  * plaintext, non-secret display string (e.g. `/mnt/nas`,

--- a/App/server/db/entities/EmailProvider.ts
+++ b/App/server/db/entities/EmailProvider.ts
@@ -23,7 +23,7 @@ import {
  *   - postmark : { serverToken }
  *
  * `fromAddress` is required and used as the envelope from. `replyTo` is
- * optional. Credentials live encrypted with the same sessionSecret-derived
+ * optional. Credentials live encrypted with the same scoped instance-encryption
  * key as Secrets / IntegrationConnections / AIModel apikeys.
  */
 export type EmailProviderKind = "smtp" | "sendgrid" | "mailgun" | "resend" | "postmark";

--- a/App/server/db/entities/EmployeeCodeRepositoryGrant.ts
+++ b/App/server/db/entities/EmployeeCodeRepositoryGrant.ts
@@ -1,10 +1,4 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  CreateDateColumn,
-  Index,
-} from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm";
 
 /**
  * Two escalating capabilities a human grants an AI employee on a Code
@@ -13,8 +7,9 @@ import {
  *               fetched; the agent can read, branch, and commit locally, but
  *               `git push` is blocked (the push URL is disabled on the
  *               materialized checkout).
- *   - `write` → everything `read` allows, plus push. This is what "let this
- *               employee commit and push changes" means.
+ *   - `write` → records authority to prepare a local deliverable. Reusable
+ *               repository credentials still stay server-side; authenticated
+ *               publication needs a governed delivery or Member step.
  *
  * `read` is the floor because a private repo can't even be cloned without
  * credentials, so withholding a grant entirely (rather than granting `read`)

--- a/App/server/db/entities/EmployeeVaultGrant.ts
+++ b/App/server/db/entities/EmployeeVaultGrant.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+export type EmployeeVaultAccessLevel = "use" | "manage";
+
+export const EMPLOYEE_VAULT_ACCESS_LEVELS: EmployeeVaultAccessLevel[] = ["use", "manage"];
+
+export const EMPLOYEE_VAULT_ACCESS_RANK: Record<EmployeeVaultAccessLevel, number> = {
+  use: 0,
+  manage: 1,
+};
+
+/**
+ * Item-level Vault Grant for one AI Employee. Company visibility never grants
+ * AI access implicitly: without one of these rows the item is invisible to
+ * that employee. `use` permits governed use without management; `manage` is
+ * reserved for AI-native item maintenance tools.
+ */
+@Entity("employee_vault_grants")
+@Index(["companyId"])
+@Index(["employeeId"])
+@Index(["vaultItemId", "employeeId"], { unique: true })
+export class EmployeeVaultGrant {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar" })
+  companyId!: string;
+
+  @Column({ type: "varchar" })
+  vaultItemId!: string;
+
+  @Column({ type: "varchar" })
+  employeeId!: string;
+
+  @Column({ type: "varchar", default: "use" })
+  accessLevel!: EmployeeVaultAccessLevel;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/App/server/db/entities/IntegrationConnection.ts
+++ b/App/server/db/entities/IntegrationConnection.ts
@@ -27,7 +27,7 @@ export type IntegrationConnectionStatus = "connected" | "error" | "expired";
  * and health-check status.
  *
  * `encryptedConfig` is an AES-256-GCM ciphertext (shared helper in
- * `server/lib/secret.ts`, keyed from `config.sessionSecret`) wrapping a
+ * `server/lib/secret.ts`, keyed from the instance encryption key ring) wrapping a
  * JSON blob whose shape is provider-specific:
  *   - apikey          : { apiKey, baseUrl?, ...providerMeta }
  *   - oauth2          : { clientId, clientSecret, accessToken, refreshToken,

--- a/App/server/db/entities/Secret.ts
+++ b/App/server/db/entities/Secret.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Per-company vault for secrets that flow into employee spawns as env vars.
  * The plaintext value is never returned by the API — only the masked preview.
- * Encrypted at rest with the same sessionSecret-derived key as model API keys.
+ * Encrypted at rest with the same scoped instance encryption key as model API keys.
  */
 @Entity("secrets")
 @Index(["companyId", "name"], { unique: true })

--- a/App/server/db/entities/VaultItem.ts
+++ b/App/server/db/entities/VaultItem.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  VersionColumn,
+} from "typeorm";
+
+export type VaultItemType = "login" | "api_key" | "secure_note";
+export type VaultItemVisibility = "company" | "restricted";
+
+/**
+ * One encrypted credential or secure note in a company's Vault.
+ *
+ * The display title, username, secret, website URL and notes are stored as one
+ * authenticated encrypted JSON payload. Keeping them together avoids leaking
+ * useful credential metadata through a raw database read and makes updates a
+ * single atomic ciphertext replacement.
+ */
+@Entity("vault_items")
+@Index(["companyId", "visibility"])
+@Index(["createdByUserId"])
+@Index(["createdByEmployeeId"])
+export class VaultItem {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar" })
+  companyId!: string;
+
+  @Column({ type: "varchar" })
+  type!: VaultItemType;
+
+  @Column({ type: "varchar", default: "restricted" })
+  visibility!: VaultItemVisibility;
+
+  /** AES-256-GCM payload written through `services/vault.ts`. */
+  @Column({ type: "text" })
+  encryptedPayload!: string;
+
+  /** Optimistic concurrency guard for whole-payload ciphertext replacement. */
+  @VersionColumn({ default: 1 })
+  version!: number;
+
+  /** Null only after the creating Member is deleted. */
+  @Column({ type: "varchar", nullable: true })
+  createdByUserId!: string | null;
+
+  /** AI Employee provenance for browser/MCP-created credentials. */
+  @Column({ type: "varchar", nullable: true })
+  createdByEmployeeId!: string | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/App/server/db/entities/VaultItemMemberAccess.ts
+++ b/App/server/db/entities/VaultItemMemberAccess.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+export type VaultMemberAccessLevel = "view" | "edit";
+
+/**
+ * Explicit human Member access to a restricted Vault item.
+ *
+ * This is deliberately named Access, not Grant: in Genosyn, Grant is the
+ * product term for an AI Employee's access to a resource. Company-visible
+ * items need no rows here; an access row remains useful if the item is later
+ * switched back to restricted visibility.
+ */
+@Entity("vault_item_member_access")
+@Index(["companyId"])
+@Index(["userId"])
+@Index(["vaultItemId", "userId"], { unique: true })
+export class VaultItemMemberAccess {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar" })
+  companyId!: string;
+
+  @Column({ type: "varchar" })
+  vaultItemId!: string;
+
+  @Column({ type: "varchar" })
+  userId!: string;
+
+  @Column({ type: "varchar", default: "view" })
+  accessLevel!: VaultMemberAccessLevel;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/App/server/db/migrations/1786721255451-AiNativeVault.ts
+++ b/App/server/db/migrations/1786721255451-AiNativeVault.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AiNativeVault1786721255451 implements MigrationInterface {
+    name = 'AiNativeVault1786721255451'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "vault_items" ("id" varchar PRIMARY KEY NOT NULL, "companyId" varchar NOT NULL, "type" varchar NOT NULL, "visibility" varchar NOT NULL DEFAULT ('restricted'), "encryptedPayload" text NOT NULL, "version" integer NOT NULL DEFAULT (1), "createdByUserId" varchar, "createdByEmployeeId" varchar, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`);
+        await queryRunner.query(`CREATE INDEX "IDX_10abe72928ce7c8dcf8c6d817e" ON "vault_items" ("createdByEmployeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_6b2875632821cccefb74a15fea" ON "vault_items" ("createdByUserId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_d16cff0c51777d2d3dfd489952" ON "vault_items" ("companyId", "visibility") `);
+        await queryRunner.query(`CREATE TABLE "vault_item_member_access" ("id" varchar PRIMARY KEY NOT NULL, "companyId" varchar NOT NULL, "vaultItemId" varchar NOT NULL, "userId" varchar NOT NULL, "accessLevel" varchar NOT NULL DEFAULT ('view'), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_eb7e484e7a153624e7f84eda04" ON "vault_item_member_access" ("vaultItemId", "userId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_d675558fd6d68b517c6159a909" ON "vault_item_member_access" ("userId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_9a67483e913872a31e335c6339" ON "vault_item_member_access" ("companyId") `);
+        await queryRunner.query(`CREATE TABLE "employee_vault_grants" ("id" varchar PRIMARY KEY NOT NULL, "companyId" varchar NOT NULL, "vaultItemId" varchar NOT NULL, "employeeId" varchar NOT NULL, "accessLevel" varchar NOT NULL DEFAULT ('use'), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_dfebd881ae0a6cd985a8bea9cb" ON "employee_vault_grants" ("vaultItemId", "employeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_e461de7b978d8cb7e39e5f623f" ON "employee_vault_grants" ("employeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_40a316c0e994cec7a1934e9f18" ON "employee_vault_grants" ("companyId") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_40a316c0e994cec7a1934e9f18"`);
+        await queryRunner.query(`DROP INDEX "IDX_e461de7b978d8cb7e39e5f623f"`);
+        await queryRunner.query(`DROP INDEX "IDX_dfebd881ae0a6cd985a8bea9cb"`);
+        await queryRunner.query(`DROP TABLE "employee_vault_grants"`);
+        await queryRunner.query(`DROP INDEX "IDX_9a67483e913872a31e335c6339"`);
+        await queryRunner.query(`DROP INDEX "IDX_d675558fd6d68b517c6159a909"`);
+        await queryRunner.query(`DROP INDEX "IDX_eb7e484e7a153624e7f84eda04"`);
+        await queryRunner.query(`DROP TABLE "vault_item_member_access"`);
+        await queryRunner.query(`DROP INDEX "IDX_d16cff0c51777d2d3dfd489952"`);
+        await queryRunner.query(`DROP INDEX "IDX_6b2875632821cccefb74a15fea"`);
+        await queryRunner.query(`DROP INDEX "IDX_10abe72928ce7c8dcf8c6d817e"`);
+        await queryRunner.query(`DROP TABLE "vault_items"`);
+    }
+
+}

--- a/App/server/db/migrations/postgres/1786721320941-AiNativeVault.ts
+++ b/App/server/db/migrations/postgres/1786721320941-AiNativeVault.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AiNativeVault1786721320941 implements MigrationInterface {
+    name = 'AiNativeVault1786721320941'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "vault_items" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "companyId" character varying NOT NULL, "type" character varying NOT NULL, "visibility" character varying NOT NULL DEFAULT 'restricted', "encryptedPayload" text NOT NULL, "version" integer NOT NULL DEFAULT '1', "createdByUserId" character varying, "createdByEmployeeId" character varying, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_5f8f06333e32f168cfce6f3158f" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_10abe72928ce7c8dcf8c6d817e" ON "vault_items" ("createdByEmployeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_6b2875632821cccefb74a15fea" ON "vault_items" ("createdByUserId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_d16cff0c51777d2d3dfd489952" ON "vault_items" ("companyId", "visibility") `);
+        await queryRunner.query(`CREATE TABLE "vault_item_member_access" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "companyId" character varying NOT NULL, "vaultItemId" character varying NOT NULL, "userId" character varying NOT NULL, "accessLevel" character varying NOT NULL DEFAULT 'view', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_35fb42b3a2eed08842862015a53" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_eb7e484e7a153624e7f84eda04" ON "vault_item_member_access" ("vaultItemId", "userId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_d675558fd6d68b517c6159a909" ON "vault_item_member_access" ("userId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_9a67483e913872a31e335c6339" ON "vault_item_member_access" ("companyId") `);
+        await queryRunner.query(`CREATE TABLE "employee_vault_grants" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "companyId" character varying NOT NULL, "vaultItemId" character varying NOT NULL, "employeeId" character varying NOT NULL, "accessLevel" character varying NOT NULL DEFAULT 'use', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_ede338b527fc279e5b3b3f596a2" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_dfebd881ae0a6cd985a8bea9cb" ON "employee_vault_grants" ("vaultItemId", "employeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_e461de7b978d8cb7e39e5f623f" ON "employee_vault_grants" ("employeeId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_40a316c0e994cec7a1934e9f18" ON "employee_vault_grants" ("companyId") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_40a316c0e994cec7a1934e9f18"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_e461de7b978d8cb7e39e5f623f"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_dfebd881ae0a6cd985a8bea9cb"`);
+        await queryRunner.query(`DROP TABLE "employee_vault_grants"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_9a67483e913872a31e335c6339"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_d675558fd6d68b517c6159a909"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_eb7e484e7a153624e7f84eda04"`);
+        await queryRunner.query(`DROP TABLE "vault_item_member_access"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_d16cff0c51777d2d3dfd489952"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_6b2875632821cccefb74a15fea"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_10abe72928ce7c8dcf8c6d817e"`);
+        await queryRunner.query(`DROP TABLE "vault_items"`);
+    }
+
+}

--- a/App/server/db/subscribers/resourceChangeSubscriber.ts
+++ b/App/server/db/subscribers/resourceChangeSubscriber.ts
@@ -8,7 +8,11 @@ import type {
   ObjectLiteral,
 } from "typeorm";
 import { AppDataSource } from "../datasource.js";
-import { emitResourceChange, resourceEventsActive } from "../../services/resourceEvents.js";
+import {
+  emitMembershipAuthorizationChange,
+  emitResourceChange,
+  resourceEventsActive,
+} from "../../services/resourceEvents.js";
 
 /**
  * The one write choke-point behind app-wide live sync.
@@ -53,18 +57,38 @@ type Mapping = {
 const REGISTRY: Record<string, Mapping> = {
   // ── AI substrate ─────────────────────────────────────────────────────────
   AIEmployee: { kind: "employee", company: "direct" },
-  AIModel: { kind: "employee", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
+  AIModel: {
+    kind: "employee",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
   Skill: { kind: "skill", company: { fk: "employeeId", parent: "AIEmployee" } },
   Routine: { kind: "routine", company: { fk: "employeeId", parent: "AIEmployee" } },
   Run: { kind: "run", company: { fk: "routineId", parent: "Routine" }, scopeFk: "routineId" },
   Handoff: { kind: "handoff", company: "direct" },
-  JournalEntry: { kind: "journal", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeMemory: { kind: "memory", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  McpServer: { kind: "mcpserver", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
+  JournalEntry: {
+    kind: "journal",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeMemory: {
+    kind: "memory",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  McpServer: {
+    kind: "mcpserver",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
 
   // ── Tasks (Projects + Todos) ─────────────────────────────────────────────
   Project: { kind: "project", company: "direct" },
-  ProjectMember: { kind: "project", company: { fk: "projectId", parent: "Project" }, scopeFk: "projectId" },
+  ProjectMember: {
+    kind: "project",
+    company: { fk: "projectId", parent: "Project" },
+    scopeFk: "projectId",
+  },
   Todo: { kind: "todo", company: { fk: "projectId", parent: "Project" }, scopeFk: "projectId" },
   // No scopeFk on children: a comment's id granularity (todoId) differs from
   // what a board filters by (projectId), so it emits an empty scope that
@@ -80,7 +104,11 @@ const REGISTRY: Record<string, Mapping> = {
   BaseTable: { kind: "base", company: { fk: "baseId", parent: "Base" }, scopeFk: "baseId" },
   BaseField: { kind: "base", company: { fk: "tableId", parent: "BaseTable" }, scopeFk: "tableId" },
   BaseView: { kind: "base", company: { fk: "tableId", parent: "BaseTable" }, scopeFk: "tableId" },
-  BaseRecord: { kind: "baserecord", company: { fk: "tableId", parent: "BaseTable" }, scopeFk: "tableId" },
+  BaseRecord: {
+    kind: "baserecord",
+    company: { fk: "tableId", parent: "BaseTable" },
+    scopeFk: "tableId",
+  },
   // Children emit an empty scope (see TodoComment) so a record drawer's
   // comment/attachment write still reaches a grid filtered by tableId.
   BaseRecordComment: { kind: "baserecord", company: { fk: "recordId", parent: "BaseRecord" } },
@@ -96,14 +124,22 @@ const REGISTRY: Record<string, Mapping> = {
   // ── Explore (charts + dashboards) ────────────────────────────────────────
   Chart: { kind: "chart", company: "direct" },
   Dashboard: { kind: "dashboard", company: "direct" },
-  DashboardCard: { kind: "dashboard", company: { fk: "dashboardId", parent: "Dashboard" }, scopeFk: "dashboardId" },
+  DashboardCard: {
+    kind: "dashboard",
+    company: { fk: "dashboardId", parent: "Dashboard" },
+    scopeFk: "dashboardId",
+  },
 
   // ── Code repositories ────────────────────────────────────────────────────
   CodeRepository: { kind: "coderepo", company: "direct" },
 
   // ── Pipelines ────────────────────────────────────────────────────────────
   Pipeline: { kind: "pipeline", company: "direct" },
-  PipelineRun: { kind: "pipeline", company: { fk: "pipelineId", parent: "Pipeline" }, scopeFk: "pipelineId" },
+  PipelineRun: {
+    kind: "pipeline",
+    company: { fk: "pipelineId", parent: "Pipeline" },
+    scopeFk: "pipelineId",
+  },
 
   // ── Customers & contracts ────────────────────────────────────────────────
   Customer: { kind: "customer", company: "direct" },
@@ -156,7 +192,11 @@ const REGISTRY: Record<string, Mapping> = {
   Product: { kind: "product", company: "direct" },
   TaxRate: { kind: "taxrate", company: "direct" },
   Invoice: { kind: "invoice", company: "direct" },
-  InvoicePayment: { kind: "invoice", company: { fk: "invoiceId", parent: "Invoice" }, scopeFk: "invoiceId" },
+  InvoicePayment: {
+    kind: "invoice",
+    company: { fk: "invoiceId", parent: "Invoice" },
+    scopeFk: "invoiceId",
+  },
   RecurringInvoice: { kind: "recurringinvoice", company: "direct" },
   Estimate: { kind: "estimate", company: "direct" },
   Vendor: { kind: "vendor", company: "direct" },
@@ -177,6 +217,9 @@ const REGISTRY: Record<string, Mapping> = {
   // ── Integrations, settings, org ──────────────────────────────────────────
   IntegrationConnection: { kind: "connection", company: "direct" },
   Secret: { kind: "secret", company: "direct" },
+  VaultItem: { kind: "vault_item", company: "direct" },
+  VaultItemMemberAccess: { kind: "vault_member_access", company: "direct", scopeFk: "vaultItemId" },
+  EmployeeVaultGrant: { kind: "vault_employee_grant", company: "direct", scopeFk: "vaultItemId" },
   ApiKey: { kind: "apikey", company: "direct" },
   Tag: { kind: "tag", company: "direct" },
   Team: { kind: "team", company: "direct" },
@@ -187,15 +230,51 @@ const REGISTRY: Record<string, Mapping> = {
 
   // ── AI-access grants (the "AI access" panels) ────────────────────────────
   EmployeeFinanceGrant: { kind: "grant", company: "direct", scopeFk: "employeeId" },
-  EmployeeConnectionGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeResourceGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeBaseGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeCodeRepositoryGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeNoteGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeNotebookGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeChartGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeDashboardGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
-  EmployeeMailAccountGrant: { kind: "grant", company: { fk: "employeeId", parent: "AIEmployee" }, scopeFk: "employeeId" },
+  EmployeeConnectionGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeResourceGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeBaseGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeCodeRepositoryGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeNoteGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeNotebookGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeChartGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeDashboardGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
+  EmployeeMailAccountGrant: {
+    kind: "grant",
+    company: { fk: "employeeId", parent: "AIEmployee" },
+    scopeFk: "employeeId",
+  },
 };
 
 /**
@@ -246,15 +325,27 @@ export class ResourceChangeSubscriber implements EntitySubscriberInterface {
   }
 
   afterUpdate(event: UpdateEvent<ObjectLiteral>): void {
-    this.handle(event.metadata.name, event.entity ?? event.databaseEntity);
+    this.handle(
+      event.metadata.name,
+      { ...(event.databaseEntity ?? {}), ...(event.entity ?? {}) },
+      event.metadata.name === "Membership",
+    );
   }
 
   afterRemove(event: RemoveEvent<ObjectLiteral>): void {
-    this.handle(event.metadata.name, event.databaseEntity ?? event.entity);
+    this.handle(
+      event.metadata.name,
+      event.databaseEntity ?? event.entity,
+      event.metadata.name === "Membership",
+    );
   }
 
   afterSoftRemove(event: SoftRemoveEvent<ObjectLiteral>): void {
-    this.handle(event.metadata.name, event.entity ?? event.databaseEntity);
+    this.handle(
+      event.metadata.name,
+      event.entity ?? event.databaseEntity,
+      event.metadata.name === "Membership",
+    );
   }
 
   afterRecover(event: RecoverEvent<ObjectLiteral>): void {
@@ -267,7 +358,15 @@ export class ResourceChangeSubscriber implements EntitySubscriberInterface {
    * resolve their company in the background so the originating save never waits
    * and a lookup failure can never throw back into TypeORM.
    */
-  private handle(entityName: string, entity: ObjectLiteral | undefined): void {
+  private handle(
+    entityName: string,
+    entity: ObjectLiteral | undefined,
+    membershipAuthorizationChanged = false,
+  ): void {
+    if (membershipAuthorizationChanged && entity) {
+      const companyId = str(entity.companyId);
+      if (companyId) emitMembershipAuthorizationChange(companyId);
+    }
     if (!resourceEventsActive()) return;
     const reg = REGISTRY[entityName];
     if (!reg || !entity) return;

--- a/App/server/index.ts
+++ b/App/server/index.ts
@@ -38,6 +38,7 @@ import { mcpRouter } from "./routes/mcp.js";
 import { mcpConnectRouter } from "./routes/mcpConnect.js";
 import { mcpInternalRouter } from "./routes/mcpInternal.js";
 import { secretsRouter } from "./routes/secrets.js";
+import { vaultRouter } from "./routes/vault.js";
 import { auditRouter } from "./routes/audit.js";
 import { usageRouter } from "./routes/usage.js";
 import { templatesRouter } from "./routes/templates.js";
@@ -91,13 +92,20 @@ import { installOutboundNetworkPolicy } from "./services/outboundNetworkPolicy.j
 import { bootPublicUrl } from "./services/publicUrl.js";
 import { bootDurableChatTurnRecovery } from "./services/durableChatTurns.js";
 import { bootSignatureExpirySweeper } from "./services/signing.js";
+import { getEffectiveInstanceSecrets } from "./lib/instanceSecrets.js";
+import { bindInstanceSecretsToDatabase } from "./services/instanceSecretsDatabase.js";
+import { rejectAiBrowserAppRequests } from "./services/browserRequestBoundary.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function main() {
+  // Resolve or create durable self-host secrets before migrations, timers or
+  // any other subsystem can observe placeholder credentials.
+  getEffectiveInstanceSecrets();
   installOutboundNetworkPolicy();
   await initDb();
+  await bindInstanceSecretsToDatabase();
   await bootPublicUrl();
   validateRuntimeSecurity();
   await validateRuntimeDependencies();
@@ -159,21 +167,37 @@ async function main() {
   // email clients that omit Origin can view, consent, complete, or decline.
   app.use("/api/sign", publicSignaturesRouter);
 
-  const sessionMiddleware = cookieSession({
-    name: "genosyn.sid",
-    secret: config.sessionSecret,
-    maxAge: 1000 * 60 * 60 * 24 * config.security.sessionMaxAgeDays,
-    httpOnly: true,
-    sameSite: "lax",
-  });
+  let sessionMiddleware: ReturnType<typeof cookieSession> | null = null;
+  let sessionMiddlewareSecret = "";
+  const currentSessionMiddleware = () => {
+    const secret = getEffectiveInstanceSecrets().sessionSecret;
+    if (!sessionMiddleware || sessionMiddlewareSecret !== secret) {
+      sessionMiddlewareSecret = secret;
+      sessionMiddleware = cookieSession({
+        name: "genosyn.sid",
+        secret,
+        maxAge: 1000 * 60 * 60 * 24 * config.security.sessionMaxAgeDays,
+        httpOnly: true,
+        sameSite: "lax",
+      });
+    }
+    return sessionMiddleware;
+  };
   app.use((req, res, next) => {
-    sessionMiddleware(req, res, () => {
+    currentSessionMiddleware()(req, res, () => {
       // `cookie-session` reads this again when it writes the response. Resolve
       // it per request so saving an HTTPS public URL takes effect immediately.
       req.sessionOptions.secure = secureSessionCookies();
       next();
     });
   });
+
+  // A human may temporarily sign into Genosyn inside an AI Employee's
+  // persistent Browser. Once that context carries the Member session cookie,
+  // browserChromium adds this marker after page code chooses its headers.
+  // Reject every App API centrally so the session cannot mint API keys,
+  // change roles, or route around item-level Vault Grants.
+  app.use("/api", rejectAiBrowserAppRequests);
 
   // Public webhooks (token in URL is the credential). Mounted before auth
   // so session-less POSTs from external systems aren't gated.
@@ -263,6 +287,7 @@ async function main() {
   app.use("/api/companies/:cid", basesRouter);
   app.use("/api/companies/:cid", approvalsRouter);
   app.use("/api/companies/:cid", secretsRouter);
+  app.use("/api/companies/:cid/vault", vaultRouter);
   app.use("/api/companies/:cid", auditRouter);
   app.use("/api/companies/:cid", usageRouter);
   // Per-user programmatic API keys (M14). Bearer tokens minted here

--- a/App/server/lib/instanceSecrets.test.ts
+++ b/App/server/lib/instanceSecrets.test.ts
@@ -1,0 +1,452 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import Keygrip from "keygrip";
+
+import { config } from "../../config.js";
+import {
+  ENCRYPTION_SECRET_PLACEHOLDER,
+  SESSION_SECRET_PLACEHOLDER,
+  getEffectiveInstanceSecrets,
+  isStrongInstanceSecret,
+  reloadEffectiveInstanceSecrets,
+  resetInstanceSecretsCacheForTests,
+  restoreManagedInstanceSecretsIfMissing,
+  snapshotManagedInstanceSecrets,
+} from "./instanceSecrets.js";
+import { decryptSecret, decryptSecretWithStrongKeys, encryptSecret } from "./secret.js";
+import {
+  deriveUnsubscribeSecret,
+  signUnsubscribeToken,
+  unsubscribeSecret,
+  unsubscribeSecrets,
+  verifyUnsubscribeToken,
+} from "../services/revenue/unsubscribeToken.js";
+
+type MutableConfig = {
+  dataDir: string;
+  db: {
+    driver: "sqlite" | "postgres";
+    sqlitePath: string;
+  };
+  sessionSecret: string;
+  security: {
+    multiTenant: boolean;
+    encryptionSecret: string;
+    previousEncryptionSecrets: string[];
+  };
+};
+
+const mutable = config as unknown as MutableConfig;
+const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+let original: MutableConfig;
+let tempDir = "";
+
+beforeEach(() => {
+  original = structuredClone(mutable);
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-instance-secrets-"));
+  mutable.dataDir = tempDir;
+  mutable.db.driver = "sqlite";
+  mutable.db.sqlitePath = path.join(tempDir, "app.sqlite");
+  mutable.sessionSecret = SESSION_SECRET_PLACEHOLDER;
+  mutable.security.multiTenant = false;
+  mutable.security.encryptionSecret = ENCRYPTION_SECRET_PLACEHOLDER;
+  mutable.security.previousEncryptionSecrets = [];
+  resetInstanceSecretsCacheForTests();
+});
+
+afterEach(() => {
+  mutable.dataDir = original.dataDir;
+  mutable.db.driver = original.db.driver;
+  mutable.db.sqlitePath = original.db.sqlitePath;
+  mutable.sessionSecret = original.sessionSecret;
+  mutable.security.multiTenant = original.security.multiTenant;
+  mutable.security.encryptionSecret = original.security.encryptionSecret;
+  mutable.security.previousEncryptionSecrets = original.security.previousEncryptionSecrets;
+  resetInstanceSecretsCacheForTests();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function managedPath(): string {
+  return path.join(tempDir, ".instance-secrets.json");
+}
+
+function sentinelPath(): string {
+  return path.join(tempDir, ".instance-secrets.required");
+}
+
+function encryptV2WithMaster(plaintext: string, master: string, scope: string): string {
+  const key = Buffer.from(
+    crypto.hkdfSync(
+      "sha256",
+      Buffer.from(master, "utf8"),
+      Buffer.from("genosyn-secret-v2", "utf8"),
+      Buffer.from(scope, "utf8"),
+      32,
+    ),
+  );
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.from(`v2:${scope}`, "utf8"));
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return [
+    "v2",
+    Buffer.from(scope, "utf8").toString("base64url"),
+    iv.toString("base64url"),
+    cipher.getAuthTag().toString("base64url"),
+    encrypted.toString("base64url"),
+  ].join(".");
+}
+
+function encryptLegacyWithSessionSecret(plaintext: string, sessionSecret: string): string {
+  const key = crypto.createHash("sha256").update(sessionSecret).digest();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString("base64");
+}
+
+async function resolveInChild(dataDir: string): Promise<[string, string]> {
+  const script = `
+    import { config } from "./config.ts";
+    config.dataDir = ${JSON.stringify(dataDir)};
+    config.db.sqlitePath = ${JSON.stringify(path.join(dataDir, "app.sqlite"))};
+    config.security.multiTenant = false;
+    const { getEffectiveInstanceSecrets } = await import("./server/lib/instanceSecrets.ts");
+    const value = getEffectiveInstanceSecrets();
+    process.stdout.write(JSON.stringify([value.sessionSecret, value.encryptionSecret]));
+  `;
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { cwd: APP_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`child exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve(JSON.parse(stdout) as [string, string]);
+    });
+  });
+}
+
+describe("managed instance secrets", () => {
+  test("concurrent first-boot processes converge on one atomic value pair", async () => {
+    const [first, second] = await Promise.all([resolveInChild(tempDir), resolveInChild(tempDir)]);
+    assert.deepEqual(first, second);
+    resetInstanceSecretsCacheForTests();
+    const parent = getEffectiveInstanceSecrets();
+    assert.deepEqual(first, [parent.sessionSecret, parent.encryptionSecret]);
+    assert.equal(fs.statSync(managedPath()).mode & 0o777, 0o600);
+  });
+
+  test("creates distinct durable 0600 secrets without enabling public fallbacks on a fresh install", () => {
+    const first = getEffectiveInstanceSecrets();
+    assert.equal(first.sessionSecret.length, 64);
+    assert.equal(first.encryptionSecret.length, 64);
+    assert.notEqual(first.sessionSecret, first.encryptionSecret);
+    assert.equal(first.usingManagedSessionSecret, true);
+    assert.equal(first.usingManagedEncryptionSecret, true);
+    assert.equal(first.placeholderSessionFallbackEnabled, false);
+    assert.equal(first.placeholderEncryptionFallbackEnabled, false);
+    assert.equal(first.encryptionDecryptionSecrets.includes(ENCRYPTION_SECRET_PLACEHOLDER), false);
+    assert.equal(first.encryptionDecryptionSecrets.includes(SESSION_SECRET_PLACEHOLDER), false);
+    assert.equal(first.legacySessionDecryptionSecrets.includes(SESSION_SECRET_PLACEHOLDER), false);
+    assert.equal(fs.statSync(managedPath()).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(sentinelPath()).mode & 0o777, 0o600);
+    const signedCookie = "genosyn.sid=forged-session";
+    const publicSignature = new Keygrip([SESSION_SECRET_PLACEHOLDER]).sign(signedCookie);
+    assert.equal(new Keygrip([first.sessionSecret]).verify(signedCookie, publicSignature), false);
+
+    const freshPlaceholderV2 = encryptV2WithMaster(
+      "forged",
+      ENCRYPTION_SECRET_PLACEHOLDER,
+      "company:fresh",
+    );
+    const freshPlaceholderLegacy = encryptLegacyWithSessionSecret(
+      "forged",
+      SESSION_SECRET_PLACEHOLDER,
+    );
+    assert.throws(() => decryptSecret(freshPlaceholderV2));
+    assert.throws(() => decryptSecret(freshPlaceholderLegacy));
+
+    resetInstanceSecretsCacheForTests();
+    const afterRestart = getEffectiveInstanceSecrets();
+    assert.equal(afterRestart.sessionSecret, first.sessionSecret);
+    assert.equal(afterRestart.encryptionSecret, first.encryptionSecret);
+  });
+
+  test("enables decrypt-only placeholder compatibility for an existing self-host upgrade", () => {
+    fs.writeFileSync(mutable.db.sqlitePath, "existing database marker");
+    const effective = getEffectiveInstanceSecrets();
+    assert.equal(effective.placeholderSessionFallbackEnabled, true);
+    assert.equal(effective.placeholderEncryptionFallbackEnabled, true);
+
+    const oldV2 = encryptV2WithMaster(
+      "old v2 value",
+      ENCRYPTION_SECRET_PLACEHOLDER,
+      "company:upgrade",
+    );
+    const oldLegacy = encryptLegacyWithSessionSecret(
+      "old legacy value",
+      SESSION_SECRET_PLACEHOLDER,
+    );
+    assert.equal(decryptSecret(oldV2), "old v2 value");
+    assert.equal(decryptSecret(oldLegacy), "old legacy value");
+    assert.throws(() => decryptSecretWithStrongKeys(oldV2));
+
+    const newlyEncrypted = encryptSecret("new managed value", "company:upgrade");
+    assert.equal(decryptSecret(newlyEncrypted), "new managed value");
+    assert.equal(decryptSecretWithStrongKeys(newlyEncrypted), "new managed value");
+    assert.throws(() => {
+      const parts = newlyEncrypted.split(".");
+      const scope = Buffer.from(parts[1], "base64url").toString("utf8");
+      const key = Buffer.from(
+        crypto.hkdfSync(
+          "sha256",
+          Buffer.from(ENCRYPTION_SECRET_PLACEHOLDER, "utf8"),
+          Buffer.from("genosyn-secret-v2", "utf8"),
+          Buffer.from(scope, "utf8"),
+          32,
+        ),
+      );
+      const decipher = crypto.createDecipheriv(
+        "aes-256-gcm",
+        key,
+        Buffer.from(parts[2], "base64url"),
+      );
+      decipher.setAAD(Buffer.from(`v2:${scope}`, "utf8"));
+      decipher.setAuthTag(Buffer.from(parts[3], "base64url"));
+      decipher.update(Buffer.from(parts[4], "base64url"));
+      decipher.final();
+    });
+  });
+
+  test("keeps explicit strong values authoritative without creating managed state", () => {
+    const explicitSession = "s".repeat(48);
+    const explicitEncryption = "e".repeat(48);
+    mutable.sessionSecret = explicitSession;
+    mutable.security.encryptionSecret = explicitEncryption;
+    const effective = getEffectiveInstanceSecrets();
+    assert.equal(effective.sessionSecret, explicitSession);
+    assert.equal(effective.encryptionSecret, explicitEncryption);
+    assert.equal(effective.managedFilePath, null);
+    assert.equal(fs.existsSync(managedPath()), false);
+    assert.equal(
+      effective.encryptionDecryptionSecrets.includes(ENCRYPTION_SECRET_PLACEHOLDER),
+      false,
+    );
+  });
+
+  test("supports a mixed explicit session and managed encryption configuration", () => {
+    const explicitSession = "explicit-session-secret-".padEnd(48, "s");
+    mutable.sessionSecret = explicitSession;
+    const effective = getEffectiveInstanceSecrets();
+    assert.equal(effective.sessionSecret, explicitSession);
+    assert.equal(effective.usingManagedSessionSecret, false);
+    assert.equal(effective.usingManagedEncryptionSecret, true);
+    assert.notEqual(effective.encryptionSecret, ENCRYPTION_SECRET_PLACEHOLDER);
+    assert.notEqual(effective.encryptionSecret, explicitSession);
+    assert.ok(fs.existsSync(managedPath()));
+  });
+
+  test("retains an existing managed encryption key after moving to explicit config", () => {
+    const managed = getEffectiveInstanceSecrets();
+    const managedCiphertext = encryptSecret("managed era", "company:rotation");
+    mutable.sessionSecret = "explicit-session-".padEnd(48, "s");
+    mutable.security.encryptionSecret = "explicit-encryption-".padEnd(48, "e");
+    resetInstanceSecretsCacheForTests();
+
+    const explicit = getEffectiveInstanceSecrets();
+    assert.equal(explicit.sessionSecret, mutable.sessionSecret);
+    assert.equal(explicit.encryptionSecret, mutable.security.encryptionSecret);
+    assert.ok(explicit.encryptionDecryptionSecrets.includes(managed.encryptionSecret));
+    assert.ok(explicit.legacySessionDecryptionSecrets.includes(managed.sessionSecret));
+    assert.equal(decryptSecret(managedCiphertext), "managed era");
+  });
+
+  test("preserves the identity and old ciphertext across a pre-managed data restore", () => {
+    const before = getEffectiveInstanceSecrets();
+    const snapshot = snapshotManagedInstanceSecrets();
+    assert.ok(snapshot);
+    fs.rmSync(managedPath());
+    fs.rmSync(sentinelPath());
+
+    restoreManagedInstanceSecretsIfMissing(snapshot, {
+      enablePlaceholderCompatibility: true,
+    });
+    const after = reloadEffectiveInstanceSecrets();
+    assert.equal(after.sessionSecret, before.sessionSecret);
+    assert.equal(after.encryptionSecret, before.encryptionSecret);
+    assert.equal(after.placeholderSessionFallbackEnabled, true);
+    assert.equal(after.placeholderEncryptionFallbackEnabled, true);
+    assert.equal(
+      decryptSecret(
+        encryptV2WithMaster("restored old v2", ENCRYPTION_SECRET_PLACEHOLDER, "company:restored"),
+      ),
+      "restored old v2",
+    );
+    assert.equal(
+      decryptSecret(
+        encryptLegacyWithSessionSecret("restored old legacy", SESSION_SECRET_PLACEHOLDER),
+      ),
+      "restored old legacy",
+    );
+    assert.equal(fs.statSync(managedPath()).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(sentinelPath()).mode & 0o777, 0o600);
+  });
+
+  test("reloads an archive-supplied managed identity instead of mixing it with the current one", () => {
+    const first = getEffectiveInstanceSecrets();
+    const firstSnapshot = snapshotManagedInstanceSecrets();
+    assert.ok(firstSnapshot);
+
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-other-instance-"));
+    try {
+      mutable.dataDir = otherDir;
+      mutable.db.sqlitePath = path.join(otherDir, "app.sqlite");
+      resetInstanceSecretsCacheForTests();
+      const other = getEffectiveInstanceSecrets();
+      const otherSnapshot = snapshotManagedInstanceSecrets();
+      assert.ok(otherSnapshot);
+      assert.notEqual(other.encryptionSecret, first.encryptionSecret);
+
+      mutable.dataDir = tempDir;
+      mutable.db.sqlitePath = path.join(tempDir, "app.sqlite");
+      fs.rmSync(managedPath());
+      fs.rmSync(sentinelPath());
+      resetInstanceSecretsCacheForTests();
+      restoreManagedInstanceSecretsIfMissing(otherSnapshot);
+      // A preserved current snapshot must not overwrite archive-supplied state.
+      restoreManagedInstanceSecretsIfMissing(firstSnapshot);
+      const restored = reloadEffectiveInstanceSecrets();
+      assert.equal(restored.sessionSecret, other.sessionSecret);
+      assert.equal(restored.encryptionSecret, other.encryptionSecret);
+    } finally {
+      fs.rmSync(otherDir, { recursive: true, force: true });
+      mutable.dataDir = tempDir;
+      mutable.db.sqlitePath = path.join(tempDir, "app.sqlite");
+      resetInstanceSecretsCacheForTests();
+    }
+  });
+
+  test("requires explicit secrets in multi-tenant mode and never creates a managed file", () => {
+    mutable.security.multiTenant = true;
+    assert.throws(getEffectiveInstanceSecrets, /require explicit session and encryption secrets/);
+    assert.equal(fs.existsSync(managedPath()), false);
+  });
+
+  test("fails closed on malformed managed state and repairs its permissions before reading", () => {
+    fs.writeFileSync(managedPath(), "not json", { mode: 0o644 });
+    assert.throws(getEffectiveInstanceSecrets, /could not be read as JSON/);
+    assert.equal(fs.statSync(managedPath()).mode & 0o777, 0o600);
+    assert.equal(fs.readFileSync(managedPath(), "utf8"), "not json");
+  });
+
+  test("rejects short, equal, and non-regular managed secret state", () => {
+    const base = {
+      version: 1,
+      sessionSecret: "s".repeat(48),
+      encryptionSecret: "e".repeat(48),
+      compatibility: {
+        placeholderSessionDecryption: false,
+        placeholderEncryptionDecryption: false,
+      },
+    };
+    for (const candidate of [
+      { ...base, sessionSecret: "short" },
+      { ...base, encryptionSecret: base.sessionSecret },
+      { ...base, version: 99 },
+    ]) {
+      fs.writeFileSync(managedPath(), JSON.stringify(candidate), { mode: 0o600 });
+      resetInstanceSecretsCacheForTests();
+      assert.throws(getEffectiveInstanceSecrets);
+      fs.rmSync(managedPath());
+    }
+    fs.mkdirSync(managedPath());
+    resetInstanceSecretsCacheForTests();
+    assert.throws(getEffectiveInstanceSecrets, /must be a regular file/);
+  });
+
+  test("refuses to regenerate after a managed secret file is lost", () => {
+    getEffectiveInstanceSecrets();
+    fs.rmSync(managedPath());
+    resetInstanceSecretsCacheForTests();
+    assert.throws(
+      getEffectiveInstanceSecrets,
+      /is missing; restore it from the same backup as the database/,
+    );
+    assert.equal(fs.existsSync(managedPath()), false);
+  });
+
+  test("never accepts public-placeholder unsubscribe forgeries", () => {
+    mutable.security.previousEncryptionSecrets = [
+      ENCRYPTION_SECRET_PLACEHOLDER,
+      SESSION_SECRET_PLACEHOLDER,
+      "weak-previous-key",
+    ];
+    const payload = {
+      companyId: "company-safe",
+      contactId: "contact-safe",
+      email: "recipient@example.com",
+    };
+    const forged = signUnsubscribeToken(
+      payload,
+      deriveUnsubscribeSecret(ENCRYPTION_SECRET_PLACEHOLDER),
+    );
+    assert.equal(
+      unsubscribeSecrets().some((secret) => verifyUnsubscribeToken(forged, secret) !== null),
+      false,
+    );
+    assert.equal(
+      getEffectiveInstanceSecrets().encryptionDecryptionSecrets.some(
+        (secret) => !isStrongInstanceSecret(secret),
+      ),
+      false,
+    );
+
+    const valid = signUnsubscribeToken(payload, unsubscribeSecret());
+    resetInstanceSecretsCacheForTests();
+    assert.deepEqual(
+      unsubscribeSecrets()
+        .map((secret) => verifyUnsubscribeToken(valid, secret))
+        .find(Boolean),
+      payload,
+    );
+  });
+
+  test("keeps links signed by a strong configured previous encryption key valid", () => {
+    const oldEncryptionSecret = "old-private-encryption-key-".padEnd(48, "x");
+    mutable.security.previousEncryptionSecrets = [oldEncryptionSecret];
+    const payload = {
+      companyId: "company-rotation",
+      contactId: null,
+      email: "rotation@example.com",
+    };
+    const oldToken = signUnsubscribeToken(payload, deriveUnsubscribeSecret(oldEncryptionSecret));
+    assert.deepEqual(
+      unsubscribeSecrets()
+        .map((secret) => verifyUnsubscribeToken(oldToken, secret))
+        .find(Boolean),
+      payload,
+    );
+  });
+});

--- a/App/server/lib/instanceSecrets.ts
+++ b/App/server/lib/instanceSecrets.ts
@@ -1,0 +1,526 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { config } from "../../config.js";
+
+export const SESSION_SECRET_PLACEHOLDER = "change-me-in-production";
+export const ENCRYPTION_SECRET_PLACEHOLDER = "change-me-in-production-too";
+
+const MANAGED_SECRET_VERSION = 1;
+export const INSTANCE_SECRETS_FILENAME = ".instance-secrets.json";
+export const INSTANCE_SECRETS_SENTINEL_FILENAME = ".instance-secrets.required";
+const SECRET_BYTES = 48;
+
+type ManagedInstanceSecrets = {
+  version: typeof MANAGED_SECRET_VERSION;
+  sessionSecret: string;
+  encryptionSecret: string;
+  compatibility: {
+    placeholderSessionDecryption: boolean;
+    placeholderEncryptionDecryption: boolean;
+  };
+};
+
+type InstanceSecretsSentinel = {
+  version: typeof MANAGED_SECRET_VERSION;
+  keyId: string;
+};
+
+export type EffectiveInstanceSecrets = {
+  sessionSecret: string;
+  encryptionSecret: string;
+  /** Current key first, followed by read-only rotation/compatibility keys. */
+  encryptionDecryptionSecrets: readonly string[];
+  /** Session-derived keys used only to read pre-v2 ciphertext. */
+  legacySessionDecryptionSecrets: readonly string[];
+  managedFilePath: string | null;
+  /** Non-secret digest used to bind the managed file to its database. */
+  managedKeyId: string | null;
+  usingManagedSessionSecret: boolean;
+  usingManagedEncryptionSecret: boolean;
+  placeholderSessionFallbackEnabled: boolean;
+  placeholderEncryptionFallbackEnabled: boolean;
+};
+
+/** Opaque in-memory copy used only while replacing dataDir during restore. */
+export type InstanceSecretsDiskSnapshot = {
+  secretsJson: string;
+  sentinelJson: string;
+};
+
+let cached: { fingerprint: string; value: EffectiveInstanceSecrets } | null = null;
+
+export function isInstanceSecretPlaceholder(value: string): boolean {
+  return value === SESSION_SECRET_PLACEHOLDER || value === ENCRYPTION_SECRET_PLACEHOLDER;
+}
+
+export function isStrongInstanceSecret(value: string): boolean {
+  return value.length >= 32 && !isInstanceSecretPlaceholder(value);
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function generateSecret(exclusions: readonly string[] = []): string {
+  for (;;) {
+    const candidate = crypto.randomBytes(SECRET_BYTES).toString("base64url");
+    if (!exclusions.includes(candidate)) return candidate;
+  }
+}
+
+function validateManagedSecrets(value: unknown, filePath: string): ManagedInstanceSecrets {
+  if (!value || typeof value !== "object") {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+  const candidate = value as Partial<ManagedInstanceSecrets>;
+  if (candidate.version !== MANAGED_SECRET_VERSION) {
+    throw new Error(`${filePath} has an unsupported version`);
+  }
+  if (
+    typeof candidate.sessionSecret !== "string" ||
+    !isStrongInstanceSecret(candidate.sessionSecret)
+  ) {
+    throw new Error(`${filePath} contains an invalid session secret`);
+  }
+  if (
+    typeof candidate.encryptionSecret !== "string" ||
+    !isStrongInstanceSecret(candidate.encryptionSecret)
+  ) {
+    throw new Error(`${filePath} contains an invalid encryption secret`);
+  }
+  if (candidate.sessionSecret === candidate.encryptionSecret) {
+    throw new Error(`${filePath} must contain distinct session and encryption secrets`);
+  }
+  if (
+    !candidate.compatibility ||
+    typeof candidate.compatibility.placeholderSessionDecryption !== "boolean" ||
+    typeof candidate.compatibility.placeholderEncryptionDecryption !== "boolean"
+  ) {
+    throw new Error(`${filePath} contains invalid compatibility state`);
+  }
+  return {
+    version: MANAGED_SECRET_VERSION,
+    sessionSecret: candidate.sessionSecret,
+    encryptionSecret: candidate.encryptionSecret,
+    compatibility: {
+      placeholderSessionDecryption: candidate.compatibility.placeholderSessionDecryption,
+      placeholderEncryptionDecryption: candidate.compatibility.placeholderEncryptionDecryption,
+    },
+  };
+}
+
+function readManagedSecrets(filePath: string): ManagedInstanceSecrets | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${filePath} must be a regular file`);
+  }
+  // Repair permissive modes left by a manual copy before reading any values.
+  fs.chmodSync(filePath, 0o600);
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(`${filePath} could not be read as JSON`, { cause: error });
+  }
+  return validateManagedSecrets(decoded, filePath);
+}
+
+function syncDirectory(directory: string): void {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(directory, "r");
+    fs.fsyncSync(fd);
+  } catch {
+    // Some platforms do not allow fsync on directories. The file itself was
+    // still fsynced and linked atomically, so this is a durability enhancement.
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+function publishFileAtomically(filePath: string, contents: string): void {
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true });
+  const tempPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+  );
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(tempPath, "wx", 0o600);
+    fs.writeFileSync(fd, contents, "utf8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+
+    try {
+      // A hard link publishes the fully-written inode only if the destination
+      // does not already exist. Concurrent starters therefore share one winner
+      // without ever observing a partial JSON file or overwriting each other.
+      fs.linkSync(tempPath, filePath);
+      fs.chmodSync(filePath, 0o600);
+      syncDirectory(directory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The published file is already durable and the unpublished sibling is
+      // mode 0600. A failed best-effort cleanup must not mask the real result.
+    }
+  }
+}
+
+function replaceFileAtomically(filePath: string, contents: string): void {
+  const directory = path.dirname(filePath);
+  const tempPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+  );
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(tempPath, "wx", 0o600);
+    fs.writeFileSync(fd, contents, "utf8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tempPath, filePath);
+    fs.chmodSync(filePath, 0o600);
+    syncDirectory(directory);
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The rename normally consumed the temporary file. A remaining 0600
+      // sibling is safe to clean up on a later operator maintenance pass.
+    }
+  }
+}
+
+function createManagedSecrets(
+  filePath: string,
+  compatibility: ManagedInstanceSecrets["compatibility"],
+): ManagedInstanceSecrets {
+  const sessionSecret = generateSecret([
+    String(config.sessionSecret),
+    String(config.security.encryptionSecret),
+  ]);
+  const encryptionSecret = generateSecret([
+    sessionSecret,
+    String(config.sessionSecret),
+    String(config.security.encryptionSecret),
+  ]);
+  const value: ManagedInstanceSecrets = {
+    version: MANAGED_SECRET_VERSION,
+    sessionSecret,
+    encryptionSecret,
+    compatibility,
+  };
+  publishFileAtomically(filePath, `${JSON.stringify(value, null, 2)}\n`);
+
+  // Re-read even when this process won. That applies the same validation path
+  // to disk bytes and returns the other process's value if it won the race.
+  const stored = readManagedSecrets(filePath);
+  if (!stored) throw new Error(`Failed to create ${filePath}`);
+  return stored;
+}
+
+function managedKeyId(managed: ManagedInstanceSecrets): string {
+  return crypto
+    .createHash("sha256")
+    .update(managed.sessionSecret)
+    .update("\0")
+    .update(managed.encryptionSecret)
+    .digest("hex");
+}
+
+function validateSentinel(value: unknown, filePath: string): InstanceSecretsSentinel {
+  const candidate = value as Partial<InstanceSecretsSentinel>;
+  if (
+    candidate.version !== MANAGED_SECRET_VERSION ||
+    typeof candidate.keyId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(candidate.keyId)
+  ) {
+    throw new Error(`${filePath} contains invalid managed-secret state`);
+  }
+  return { version: MANAGED_SECRET_VERSION, keyId: candidate.keyId };
+}
+
+function readSentinel(filePath: string): InstanceSecretsSentinel | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${filePath} must be a regular file`);
+  }
+  fs.chmodSync(filePath, 0o600);
+  try {
+    return validateSentinel(JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown, filePath);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`${filePath} could not be read as JSON`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+function ensureSentinel(filePath: string, managed: ManagedInstanceSecrets): void {
+  const expected: InstanceSecretsSentinel = {
+    version: MANAGED_SECRET_VERSION,
+    keyId: managedKeyId(managed),
+  };
+  const existing = readSentinel(filePath);
+  if (existing && existing.keyId !== expected.keyId) {
+    throw new Error(`${filePath} does not match ${INSTANCE_SECRETS_FILENAME}`);
+  }
+  if (!existing) {
+    publishFileAtomically(filePath, `${JSON.stringify(expected, null, 2)}\n`);
+    const stored = readSentinel(filePath);
+    if (!stored || stored.keyId !== expected.keyId) {
+      throw new Error(`Failed to create ${filePath}`);
+    }
+  }
+}
+
+function installationHasExistingData(dataDir: string): boolean {
+  try {
+    const sqlitePath = path.resolve(config.db.sqlitePath);
+    if (fs.statSync(sqlitePath).size > 0) return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  try {
+    return fs
+      .readdirSync(dataDir)
+      .some(
+        (entry) =>
+          entry !== INSTANCE_SECRETS_FILENAME &&
+          entry !== INSTANCE_SECRETS_SENTINEL_FILENAME &&
+          !entry.startsWith(`.${INSTANCE_SECRETS_FILENAME}.`) &&
+          !entry.startsWith(`.${INSTANCE_SECRETS_SENTINEL_FILENAME}.`),
+      );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/**
+ * Resolve the active installation secrets and every compatibility read key.
+ *
+ * Placeholder self-host installs receive durable generated secrets. Shared
+ * multi-tenant installs never substitute managed values for placeholders:
+ * runtime validation requires operators to configure explicit secrets there.
+ */
+export function getEffectiveInstanceSecrets(): EffectiveInstanceSecrets {
+  const dataDir = path.resolve(config.dataDir);
+  const fingerprint = JSON.stringify([
+    dataDir,
+    config.security.multiTenant,
+    config.sessionSecret,
+    config.security.encryptionSecret,
+    config.security.previousEncryptionSecrets,
+  ]);
+  if (cached?.fingerprint === fingerprint) return cached.value;
+
+  const filePath = path.join(dataDir, INSTANCE_SECRETS_FILENAME);
+  const sentinelPath = path.join(dataDir, INSTANCE_SECRETS_SENTINEL_FILENAME);
+  const configuredSession = String(config.sessionSecret);
+  const configuredEncryption = String(config.security.encryptionSecret);
+  if (
+    config.security.multiTenant &&
+    (configuredSession === SESSION_SECRET_PLACEHOLDER ||
+      configuredEncryption === ENCRYPTION_SECRET_PLACEHOLDER)
+  ) {
+    throw new Error("Shared multi-tenant installs require explicit session and encryption secrets");
+  }
+  const mayUseManaged = !config.security.multiTenant;
+  const needsManaged =
+    mayUseManaged &&
+    (configuredSession === SESSION_SECRET_PLACEHOLDER ||
+      configuredEncryption === ENCRYPTION_SECRET_PLACEHOLDER);
+  const sentinel = readSentinel(sentinelPath);
+  let managed = readManagedSecrets(filePath);
+  if (!managed && sentinel) {
+    throw new Error(`${filePath} is missing; restore it from the same backup as the database`);
+  }
+  if (!managed && needsManaged) {
+    const existingData = installationHasExistingData(dataDir);
+    managed = createManagedSecrets(filePath, {
+      placeholderSessionDecryption:
+        existingData && configuredSession === SESSION_SECRET_PLACEHOLDER,
+      placeholderEncryptionDecryption:
+        existingData && configuredEncryption === ENCRYPTION_SECRET_PLACEHOLDER,
+    });
+  }
+  if (managed) ensureSentinel(sentinelPath, managed);
+
+  const usingManagedSessionSecret =
+    mayUseManaged && configuredSession === SESSION_SECRET_PLACEHOLDER;
+  const usingManagedEncryptionSecret =
+    mayUseManaged && configuredEncryption === ENCRYPTION_SECRET_PLACEHOLDER;
+  const sessionSecret = usingManagedSessionSecret ? managed!.sessionSecret : configuredSession;
+  const encryptionSecret = usingManagedEncryptionSecret
+    ? managed!.encryptionSecret
+    : configuredEncryption;
+  const placeholderSessionFallbackEnabled = Boolean(
+    mayUseManaged && managed?.compatibility.placeholderSessionDecryption,
+  );
+  const placeholderEncryptionFallbackEnabled = Boolean(
+    mayUseManaged && managed?.compatibility.placeholderEncryptionDecryption,
+  );
+
+  const value: EffectiveInstanceSecrets = Object.freeze({
+    sessionSecret,
+    encryptionSecret,
+    encryptionDecryptionSecrets: Object.freeze(
+      unique([
+        encryptionSecret,
+        ...config.security.previousEncryptionSecrets.filter(isStrongInstanceSecret),
+        managed?.encryptionSecret ?? "",
+        placeholderEncryptionFallbackEnabled ? ENCRYPTION_SECRET_PLACEHOLDER : "",
+      ]),
+    ),
+    legacySessionDecryptionSecrets: Object.freeze(
+      unique([
+        sessionSecret,
+        managed?.sessionSecret ?? "",
+        placeholderSessionFallbackEnabled ? SESSION_SECRET_PLACEHOLDER : "",
+      ]),
+    ),
+    managedFilePath: managed ? filePath : null,
+    managedKeyId: managed ? managedKeyId(managed) : null,
+    usingManagedSessionSecret,
+    usingManagedEncryptionSecret,
+    placeholderSessionFallbackEnabled,
+    placeholderEncryptionFallbackEnabled,
+  });
+  cached = { fingerprint, value };
+  return value;
+}
+
+/**
+ * Durably add decrypt-only compatibility after the database proves this is a
+ * legacy installation. Current cookie, encryption and unsubscribe signing keys
+ * remain managed; this changes read fallbacks only.
+ */
+export function enableLegacyPlaceholderDecryption(options: {
+  session: boolean;
+  encryption: boolean;
+}): EffectiveInstanceSecrets {
+  if (config.security.multiTenant) {
+    throw new Error("Placeholder compatibility is unavailable in multi-tenant mode");
+  }
+  const dataDir = path.resolve(config.dataDir);
+  const filePath = path.join(dataDir, INSTANCE_SECRETS_FILENAME);
+  const sentinelPath = path.join(dataDir, INSTANCE_SECRETS_SENTINEL_FILENAME);
+  const managed = readManagedSecrets(filePath);
+  if (!managed) {
+    throw new Error(`${filePath} is required for placeholder compatibility`);
+  }
+  ensureSentinel(sentinelPath, managed);
+  const next: ManagedInstanceSecrets = {
+    ...managed,
+    compatibility: {
+      placeholderSessionDecryption:
+        managed.compatibility.placeholderSessionDecryption || options.session,
+      placeholderEncryptionDecryption:
+        managed.compatibility.placeholderEncryptionDecryption || options.encryption,
+    },
+  };
+  if (
+    next.compatibility.placeholderSessionDecryption !==
+      managed.compatibility.placeholderSessionDecryption ||
+    next.compatibility.placeholderEncryptionDecryption !==
+      managed.compatibility.placeholderEncryptionDecryption
+  ) {
+    replaceFileAtomically(filePath, `${JSON.stringify(next, null, 2)}\n`);
+  }
+  return reloadEffectiveInstanceSecrets();
+}
+
+/**
+ * Hold the current managed files in memory across an in-process backup restore.
+ * Callers must never serialize, log, or return this snapshot.
+ */
+export function snapshotManagedInstanceSecrets(): InstanceSecretsDiskSnapshot | null {
+  const dataDir = path.resolve(config.dataDir);
+  const filePath = path.join(dataDir, INSTANCE_SECRETS_FILENAME);
+  const sentinelPath = path.join(dataDir, INSTANCE_SECRETS_SENTINEL_FILENAME);
+  const managed = readManagedSecrets(filePath);
+  const sentinel = readSentinel(sentinelPath);
+  if (!managed) {
+    if (sentinel) {
+      throw new Error(`${filePath} is missing; restore it from the same backup as the database`);
+    }
+    return null;
+  }
+  ensureSentinel(sentinelPath, managed);
+  const verifiedSentinel = readSentinel(sentinelPath);
+  if (!verifiedSentinel) throw new Error(`Failed to read ${sentinelPath}`);
+  return {
+    secretsJson: `${JSON.stringify(managed, null, 2)}\n`,
+    sentinelJson: `${JSON.stringify(verifiedSentinel, null, 2)}\n`,
+  };
+}
+
+/** Preserve this install's managed identity when restoring a pre-managed backup. */
+export function restoreManagedInstanceSecretsIfMissing(
+  snapshot: InstanceSecretsDiskSnapshot | null,
+  options: { enablePlaceholderCompatibility?: boolean } = {},
+): void {
+  if (!snapshot) return;
+  const dataDir = path.resolve(config.dataDir);
+  const filePath = path.join(dataDir, INSTANCE_SECRETS_FILENAME);
+  const sentinelPath = path.join(dataDir, INSTANCE_SECRETS_SENTINEL_FILENAME);
+  // An archive-supplied identity wins as a pair. Partial archive state is left
+  // untouched so the reload below fails closed rather than mixing identities.
+  if (fs.existsSync(filePath) || fs.existsSync(sentinelPath)) return;
+
+  const preservedManaged = validateManagedSecrets(
+    JSON.parse(snapshot.secretsJson) as unknown,
+    filePath,
+  );
+  const managed: ManagedInstanceSecrets = options.enablePlaceholderCompatibility
+    ? {
+        ...preservedManaged,
+        compatibility: {
+          placeholderSessionDecryption: true,
+          placeholderEncryptionDecryption: true,
+        },
+      }
+    : preservedManaged;
+  const sentinel = validateSentinel(JSON.parse(snapshot.sentinelJson) as unknown, sentinelPath);
+  if (sentinel.keyId !== managedKeyId(managed)) {
+    throw new Error("The preserved managed-secret files do not match");
+  }
+  publishFileAtomically(filePath, `${JSON.stringify(managed, null, 2)}\n`);
+  publishFileAtomically(sentinelPath, snapshot.sentinelJson);
+}
+
+/** Reload managed state after an in-process dataDir replacement. */
+export function reloadEffectiveInstanceSecrets(): EffectiveInstanceSecrets {
+  cached = null;
+  return getEffectiveInstanceSecrets();
+}
+
+/** Tests change config and temporary data directories inside one process. */
+export function resetInstanceSecretsCacheForTests(): void {
+  cached = null;
+}

--- a/App/server/lib/secret.test.ts
+++ b/App/server/lib/secret.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import test from "node:test";
-import { config } from "../../config.js";
+import { getEffectiveInstanceSecrets } from "./instanceSecrets.js";
 import { decryptSecret, encryptSecret } from "./secret.js";
 
 test("round-trips scoped authenticated ciphertext", () => {
@@ -24,7 +24,10 @@ test("round-trips scoped authenticated ciphertext", () => {
 });
 
 test("reads legacy session-secret ciphertexts during rotation", () => {
-  const key = crypto.createHash("sha256").update(config.sessionSecret).digest();
+  const key = crypto
+    .createHash("sha256")
+    .update(getEffectiveInstanceSecrets().sessionSecret)
+    .digest();
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
   const encrypted = Buffer.concat([cipher.update("legacy", "utf8"), cipher.final()]);

--- a/App/server/lib/secret.ts
+++ b/App/server/lib/secret.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
-import { config } from "../../config.js";
+
+import { getEffectiveInstanceSecrets, isStrongInstanceSecret } from "./instanceSecrets.js";
 
 const VERSION = "v2";
 const KEY_BYTES = 32;
@@ -23,17 +24,14 @@ function scopedKey(master: string, scope: string): Buffer {
   );
 }
 
-function legacyKey(): Buffer {
-  return crypto.createHash("sha256").update(config.sessionSecret).digest();
+function legacyKey(secret: string): Buffer {
+  return crypto.createHash("sha256").update(secret).digest();
 }
 
 export function encryptSecret(plaintext: string, scope = "instance"): string {
+  const { encryptionSecret } = getEffectiveInstanceSecrets();
   const iv = crypto.randomBytes(IV_BYTES);
-  const cipher = crypto.createCipheriv(
-    "aes-256-gcm",
-    scopedKey(config.security.encryptionSecret, scope),
-    iv,
-  );
+  const cipher = crypto.createCipheriv("aes-256-gcm", scopedKey(encryptionSecret, scope), iv);
   cipher.setAAD(Buffer.from(`${VERSION}:${scope}`, "utf8"));
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
@@ -46,7 +44,7 @@ export function encryptSecret(plaintext: string, scope = "instance"): string {
   ].join(".");
 }
 
-function decryptV2(blob: string): string {
+function decryptV2(blob: string, masters: readonly string[]): string {
   const parts = blob.split(".");
   if (parts.length !== 5 || parts[0] !== VERSION) {
     throw new Error("Unsupported encrypted-secret format");
@@ -60,7 +58,6 @@ function decryptV2(blob: string): string {
     throw new Error("Invalid encrypted-secret payload");
   }
 
-  const masters = [config.security.encryptionSecret, ...config.security.previousEncryptionSecrets];
   for (const master of masters) {
     try {
       const decipher = crypto.createDecipheriv("aes-256-gcm", scopedKey(master, scope), iv);
@@ -76,15 +73,40 @@ function decryptV2(blob: string): string {
 
 /** Read both scoped v2 ciphertexts and legacy sessionSecret-derived rows. */
 export function decryptSecret(blob: string): string {
-  if (blob.startsWith(`${VERSION}.`)) return decryptV2(blob);
+  if (blob.startsWith(`${VERSION}.`)) {
+    return decryptV2(blob, getEffectiveInstanceSecrets().encryptionDecryptionSecrets);
+  }
   const buf = Buffer.from(blob, "base64");
   if (buf.length < IV_BYTES + TAG_BYTES) throw new Error("Invalid encrypted-secret payload");
   const iv = buf.subarray(0, IV_BYTES);
   const tag = buf.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
   const encrypted = buf.subarray(IV_BYTES + TAG_BYTES);
-  const decipher = crypto.createDecipheriv("aes-256-gcm", legacyKey(), iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+  for (const sessionSecret of getEffectiveInstanceSecrets().legacySessionDecryptionSecrets) {
+    try {
+      const decipher = crypto.createDecipheriv("aes-256-gcm", legacyKey(sessionSecret), iv);
+      decipher.setAuthTag(tag);
+      return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+    } catch {
+      // Try the next managed/configured/placeholder compatibility key.
+    }
+  }
+  throw new Error("Legacy encrypted secret could not be decrypted with the configured key ring");
+}
+
+/**
+ * Read a v2 ciphertext only with private, strong keys. New security-sensitive
+ * formats such as Vault items have no legitimate placeholder-key history, so
+ * accepting the public self-host compatibility key would permit DB-write
+ * forgery on an upgraded installation.
+ */
+export function decryptSecretWithStrongKeys(blob: string): string {
+  if (!blob.startsWith(`${VERSION}.`)) {
+    throw new Error("A scoped v2 encrypted secret is required");
+  }
+  return decryptV2(
+    blob,
+    getEffectiveInstanceSecrets().encryptionDecryptionSecrets.filter(isStrongInstanceSecret),
+  );
 }
 
 /** Mask for display: `sk-...abc123` → `sk-…c123`. */

--- a/App/server/mcp-browser/index.mjs
+++ b/App/server/mcp-browser/index.mjs
@@ -46,11 +46,46 @@ import crypto from "node:crypto";
 const MCP_API_BASE = process.env.GENOSYN_MCP_API ?? "";
 const MCP_TOKEN = process.env.GENOSYN_MCP_TOKEN ?? "";
 const BROWSER_API_BASE = process.env.GENOSYN_BROWSER_API ?? "";
+const BROWSER_SESSION_ID = process.env.GENOSYN_BROWSER_SESSION_ID ?? "";
 const BROWSER_TOKEN = process.env.GENOSYN_BROWSER_SESSION_TOKEN ?? "";
 const APPROVAL_REQUIRED = process.env.GENOSYN_BROWSER_APPROVAL_REQUIRED === "1";
 
-/** @type {Map<string, { tool: "submit"; selector: string; key?: string }>} */
+/** @type {Map<string,
+ *   { tool: "submit"; selector: string; key?: string } |
+ *   { tool: "vault_capture"; selector: string; title: string; username: string; notes: string }
+ * >} */
 const pendingActions = new Map();
+
+// The App re-validates this allowlist at the HTTP boundary. Keeping the same
+// check here gives the model an immediate, useful error and prevents invalid
+// browser_submit requests from creating approvals that can never be executed.
+const MODEL_PRESS_KEYS = [
+  "Enter",
+  "NumpadEnter",
+  "Tab",
+  "Escape",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Backspace",
+  "Delete",
+  "Space",
+  "Spacebar",
+];
+const MODEL_PRESS_KEY_SET = new Set(MODEL_PRESS_KEYS);
+
+function assertModelPressKeyAllowed(key) {
+  if (!MODEL_PRESS_KEY_SET.has(key)) {
+    throw new Error(
+      "Unsupported browser key. Modifier chords, clipboard shortcuts, and context-menu keys are not allowed.",
+    );
+  }
+}
 
 // ---------- HTTP helpers ----------
 
@@ -206,9 +241,105 @@ async function browserFill(args) {
   return textResult(reply.snapshot ?? "");
 }
 
+/**
+ * Fill a login field from an Employee Vault Grant without returning the
+ * stored value to the model (or even to this MCP child). The App resolves the
+ * item, enforces the Grant + exact website origin, and types directly into its
+ * App-owned Chromium page.
+ */
+async function browserFillVault(args) {
+  const selector = String(args?.selector ?? "").trim();
+  const itemId = String(args?.itemId ?? "").trim();
+  const field = String(args?.field ?? "").trim();
+  if (!selector) throw new Error("`selector` is required");
+  if (!itemId) throw new Error("`itemId` is required");
+  if (field !== "username" && field !== "secret") {
+    throw new Error("`field` must be `username` or `secret`");
+  }
+  const reply = await callBrowser("/vault/fill", { selector, itemId, field });
+  return textResult(
+    reply.message ??
+      `Filled the ${field === "secret" ? "stored value" : "username"} field from Vault. The value was not revealed.`,
+  );
+}
+
+/**
+ * Capture a password already present in a browser input and save it to the
+ * Vault without putting the value in model context. This covers signup flows
+ * and provider-generated passwords while keeping the secret server-side.
+ */
+async function browserSaveVaultLogin(args) {
+  const selector = String(args?.selector ?? "").trim();
+  const title = String(args?.title ?? "").trim();
+  const username = typeof args?.username === "string" ? args.username.trim() : "";
+  const notes = typeof args?.notes === "string" ? args.notes.trim() : "";
+  if (!selector) throw new Error("`selector` is required");
+  if (!title) throw new Error("`title` is required");
+  const target = await callBrowser("/approval/describe-target", {
+    action: "vault_capture",
+    selector,
+    key: null,
+  });
+  if (
+    typeof target?.targetFingerprint !== "string" ||
+    !target?.targetDescriptor ||
+    typeof target.targetDescriptor !== "object"
+  ) {
+    throw new Error("The App could not bind the live password target to an approval");
+  }
+
+  const id = crypto.randomUUID();
+  const action = { tool: "vault_capture", selector, title, username, notes };
+  pendingActions.set(id, action);
+  try {
+    const reply = await callGenosyn("/tools/queue_browser_approval", {
+      action: "vault_capture",
+      clientApprovalId: id,
+      summary: `Save the current password field as restricted Vault login "${title}" (password hidden)`,
+      pageUrl: typeof target.pageUrl === "string" ? target.pageUrl : "",
+      browserSessionId: BROWSER_SESSION_ID,
+      targetFingerprint: target.targetFingerprint,
+      targetDescriptor: target.targetDescriptor,
+      selector,
+      key: null,
+      vaultTitle: title,
+      vaultUsername: username,
+      vaultNotes: notes,
+    });
+    const approvalId = reply?.approvalId ?? id;
+    if (approvalId !== id) {
+      pendingActions.set(approvalId, action);
+      pendingActions.delete(id);
+    }
+    return textResult(
+      `Approval queued. status: pending_approval. approvalId: ${approvalId}. A company owner or admin must approve saving this hidden password as a restricted Vault login; call browser_resume("${approvalId}") afterward.`,
+    );
+  } catch (err) {
+    pendingActions.delete(id);
+    throw new Error(
+      `Could not queue Vault capture approval: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function executeVaultCapture(action, approvalId) {
+  const reply = await callBrowser("/vault/capture-login", {
+    approvalId,
+    selector: action.selector,
+    title: action.title,
+    username: action.username,
+    notes: action.notes,
+  });
+  return textResult(
+    reply.message ??
+      `Saved login ${reply.itemId ?? ""} to Vault. The captured password was not revealed.`,
+  );
+}
+
 async function browserPress(args) {
   const key = String(args?.key ?? "").trim();
   if (!key) throw new Error("`key` is required (e.g. 'Enter', 'Tab', 'ArrowDown')");
+  assertModelPressKeyAllowed(key);
   const body = { key };
   if (typeof args?.selector === "string" && args.selector.length > 0) {
     body.selector = args.selector;
@@ -239,6 +370,7 @@ async function browserSubmit(args) {
   const selector = String(args?.selector ?? "").trim();
   if (!selector) throw new Error("`selector` is required");
   const key = typeof args?.key === "string" ? args.key : undefined;
+  if (key) assertModelPressKeyAllowed(key);
   const summary =
     typeof args?.summary === "string" ? args.summary.trim() : "Submit a form via the browser MCP";
 
@@ -246,15 +378,17 @@ async function browserSubmit(args) {
     return executeSubmit(selector, key);
   }
 
-  // Get the current URL so the approver has context. /url is a cheap
-  // read of already-known state — it never launches Chromium or builds
-  // a snapshot.
-  let pageUrl = "";
-  try {
-    const reply = await callBrowser("/url", {});
-    if (typeof reply?.url === "string") pageUrl = reply.url;
-  } catch {
-    // best-effort
+  const target = await callBrowser("/approval/describe-target", {
+    action: "submit",
+    selector,
+    key: key ?? null,
+  });
+  if (
+    typeof target?.targetFingerprint !== "string" ||
+    !target?.targetDescriptor ||
+    typeof target.targetDescriptor !== "object"
+  ) {
+    throw new Error("The App could not bind the live submit target to an approval");
   }
 
   const id = crypto.randomUUID();
@@ -262,8 +396,12 @@ async function browserSubmit(args) {
   try {
     const reply = await callGenosyn("/tools/queue_browser_approval", {
       clientApprovalId: id,
+      action: "submit",
       summary,
-      pageUrl,
+      pageUrl: typeof target.pageUrl === "string" ? target.pageUrl : "",
+      browserSessionId: BROWSER_SESSION_ID,
+      targetFingerprint: target.targetFingerprint,
+      targetDescriptor: target.targetDescriptor,
       selector,
       key: key ?? null,
     });
@@ -283,12 +421,13 @@ async function browserSubmit(args) {
   }
 }
 
-async function executeSubmit(selector, key) {
+async function executeSubmit(selector, key, approvalId) {
   if (key) {
-    const reply = await callBrowser("/press", { selector, key });
+    assertModelPressKeyAllowed(key);
+    const reply = await callBrowser("/press", { selector, key, approvalId });
     return textResult(reply.snapshot ?? "");
   }
-  const reply = await callBrowser("/click", { selector });
+  const reply = await callBrowser("/click", { selector, approvalId });
   return textResult(reply.snapshot ?? "");
 }
 
@@ -302,7 +441,7 @@ async function executeSubmit(selector, key) {
  * Exact query ordering is fail-closed; a changed serialization needs a fresh
  * human approval even if an application might interpret it equivalently.
  */
-function sameApprovedPage(approvedUrl, currentUrl) {
+function sameApprovedPageExact(approvedUrl, currentUrl) {
   if (!approvedUrl || !currentUrl) return false;
   try {
     const a = new URL(approvedUrl);
@@ -316,12 +455,109 @@ function sameApprovedPage(approvedUrl, currentUrl) {
   }
 }
 
+function sameApprovedTargetPage(approvedUrl, currentUrl) {
+  if (!approvedUrl || !currentUrl) return false;
+  try {
+    const approved = new URL(approvedUrl);
+    const current = new URL(currentUrl);
+    return approved.origin === current.origin && approved.pathname === current.pathname;
+  } catch {
+    return false;
+  }
+}
+
+async function executeLegacyApprovedAction(approvalId, fallbackSelector) {
+  let claim;
+  try {
+    claim = await callGenosyn(
+      `/tools/claim_browser_approval/${encodeURIComponent(approvalId)}`,
+      {},
+    );
+  } catch (err) {
+    pendingActions.delete(approvalId);
+    throw new Error(
+      `Approval ${approvalId} could not be claimed and was not submitted: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const claimToken = typeof claim?.claimToken === "string" ? claim.claimToken : "";
+  const selector =
+    typeof claim?.selector === "string" ? claim.selector : fallbackSelector;
+  const key = typeof claim?.key === "string" ? claim.key : undefined;
+  const approvedUrl = typeof claim?.pageUrl === "string" ? claim.pageUrl : "";
+  if (!claimToken || !selector) {
+    pendingActions.delete(approvalId);
+    throw new Error(
+      `Approval ${approvalId} was consumed but the server returned an invalid claim receipt. Its outcome is unknown and it will not be replayed.`,
+    );
+  }
+
+  let currentUrl = "";
+  try {
+    const current = await callBrowser("/url", {});
+    if (typeof current?.url === "string") currentUrl = current.url;
+  } catch {
+    // Fall through to the terminal mismatch below.
+  }
+  if (!sameApprovedPageExact(approvedUrl, currentUrl)) {
+    pendingActions.delete(approvalId);
+    try {
+      await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
+        claimToken,
+        outcome: "failed",
+        errorMessage:
+          "The exact approved browser URL changed before the claimed browser action fired.",
+      });
+    } catch {
+      // The executing claim is already non-replayable if the receipt fails.
+    }
+    throw new Error(
+      `The browser URL changed while approval ${approvalId} was being claimed. It was not submitted and the consumed approval will not be replayed.`,
+    );
+  }
+
+  pendingActions.delete(approvalId);
+  let result;
+  try {
+    result = await executeSubmit(selector, key);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    try {
+      await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
+        claimToken,
+        outcome: "failed",
+        errorMessage,
+      });
+    } catch {
+      // The executing claim remains terminal and cannot replay.
+    }
+    throw new Error(
+      `Approval ${approvalId} was claimed, but the browser action failed. It will not be replayed automatically: ${errorMessage}`,
+    );
+  }
+  try {
+    await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
+      claimToken,
+      outcome: "executed",
+    });
+  } catch (err) {
+    result.content.push({
+      type: "text",
+      text:
+        `The browser action ran, but Genosyn could not persist its completion receipt (${err instanceof Error ? err.message : String(err)}). ` +
+        "The approval remains consumed and cannot be replayed.",
+    });
+  }
+  return result;
+}
+
 async function browserResume(args) {
   const approvalId = String(args?.approvalId ?? "").trim();
   if (!approvalId) throw new Error("`approvalId` is required");
   let reply;
   try {
-    reply = await getGenosyn(`/tools/check_browser_approval/${encodeURIComponent(approvalId)}`);
+    reply = await getGenosyn(
+      `/tools/check_browser_approval/${encodeURIComponent(approvalId)}?browserSessionId=${encodeURIComponent(BROWSER_SESSION_ID)}`,
+    );
   } catch (err) {
     throw new Error(
       `Could not check approval status: ${err instanceof Error ? err.message : String(err)}`,
@@ -341,11 +577,20 @@ async function browserResume(args) {
     // across chat turns — this MCP child is spawned per turn, and the
     // human usually approves after the turn that queued it has ended.
     const action = pendingActions.get(approvalId);
+    const actionKind =
+      action?.tool ?? (reply?.action === "vault_capture" ? "vault_capture" : "submit");
+    const targetBound = reply?.targetBound === true;
     const selector =
       action?.selector ?? (typeof reply?.selector === "string" ? reply.selector : "");
+    const key =
+      action?.tool === "submit"
+        ? action.key
+        : typeof reply?.key === "string"
+          ? reply.key
+          : undefined;
     if (!selector) {
       throw new Error(
-        `Approval ${approvalId} is approved but its held action is missing. Call browser_submit again.`,
+        `Approval ${approvalId} is approved but its held action is missing. Queue the browser action again.`,
       );
     }
     // Bind to the page the human actually saw. If the browser has since
@@ -360,100 +605,48 @@ async function browserResume(args) {
     } catch {
       // fall through — treated as a mismatch below
     }
-    if (!sameApprovedPage(approvedUrl, currentUrl)) {
+    const pageStillMatches = targetBound
+      ? sameApprovedTargetPage(approvedUrl, currentUrl)
+      : sameApprovedPageExact(approvedUrl, currentUrl);
+    if (!pageStillMatches) {
       pendingActions.delete(approvalId);
       throw new Error(
-        "The browser URL changed since this action was approved. The approval is bound to the exact canonical URL, including its query and fragment, so it will not fire here. Navigate back and call browser_submit again if you still want to submit.",
+        targetBound
+          ? "The page changed since this action was approved. The approval is bound to the reviewed page, so it will not fire here. Navigate back and queue the action again if you still want to continue."
+          : "The browser URL changed since this action was approved. The approval is bound to the exact canonical URL, including its query and fragment, so it will not fire here. Navigate back and call browser_submit again if you still want to submit.",
       );
     }
-
-    // Security boundary: consume approved -> executing before touching the
-    // page. Concurrent resume calls may both observe `approved`, but exactly
-    // one conditional UPDATE wins this claim and receives the secret token
-    // needed to finish it. A crash after the claim leaves an ambiguous
-    // `executing` row that cannot be claimed again.
-    let claim;
-    try {
-      claim = await callGenosyn(
-        `/tools/claim_browser_approval/${encodeURIComponent(approvalId)}`,
-        {},
-      );
-    } catch (err) {
-      pendingActions.delete(approvalId);
-      throw new Error(
-        `Approval ${approvalId} could not be claimed and was not submitted: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    if (!targetBound) {
+      return executeLegacyApprovedAction(approvalId, selector);
     }
-    const claimToken = typeof claim?.claimToken === "string" ? claim.claimToken : "";
-    const claimedSelector = typeof claim?.selector === "string" ? claim.selector : selector;
-    const claimedKey = typeof claim?.key === "string" ? claim.key : undefined;
-    const claimedUrl = typeof claim?.pageUrl === "string" ? claim.pageUrl : "";
-    if (!claimToken || !claimedSelector) {
-      pendingActions.delete(approvalId);
-      throw new Error(
-        `Approval ${approvalId} was consumed but the server returned an invalid claim receipt. Its outcome is unknown and it will not be replayed.`,
-      );
-    }
-    // Re-read after the atomic claim. A human or another browser tool can
-    // navigate between the pre-claim check and the click; once consumed, a
-    // mismatch is terminal rather than replayable because the claim itself is
-    // already durable.
-    let claimedCurrentUrl = "";
-    try {
-      const u = await callBrowser("/url", {});
-      if (typeof u?.url === "string") claimedCurrentUrl = u.url;
-    } catch {
-      // fall through — treated as a mismatch below
-    }
-    if (!sameApprovedPage(claimedUrl, claimedCurrentUrl)) {
-      pendingActions.delete(approvalId);
-      try {
-        await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
-          claimToken,
-          outcome: "failed",
-          errorMessage:
-            "The exact approved browser URL changed before the claimed browser action fired.",
-        });
-      } catch {
-        // The executing claim is already non-replayable if the receipt fails.
-      }
-      throw new Error(
-        `The browser URL changed while approval ${approvalId} was being claimed. It was not submitted and the consumed approval will not be replayed.`,
-      );
-    }
-
     pendingActions.delete(approvalId);
-    let result;
-    try {
-      result = await executeSubmit(claimedSelector, claimedKey);
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      try {
-        await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
-          claimToken,
-          outcome: "failed",
-          errorMessage,
-        });
-      } catch {
-        // The executing claim remains a terminal ambiguity and cannot replay.
-      }
-      throw new Error(
-        `Approval ${approvalId} was claimed, but the browser action failed. It will not be replayed automatically: ${errorMessage}`,
-      );
-    }
-    try {
-      await callGenosyn(`/tools/finish_browser_approval/${encodeURIComponent(approvalId)}`, {
-        claimToken,
-        outcome: "executed",
-      });
-    } catch (err) {
-      result.content.push({
-        type: "text",
-        text:
-          `The browser action ran, but Genosyn could not persist its completion receipt (${err instanceof Error ? err.message : String(err)}). ` +
-          "The approval remains consumed and cannot be replayed.",
-      });
-    }
+    const result =
+      actionKind === "vault_capture"
+        ? await executeVaultCapture(
+            {
+              selector,
+              title:
+                action?.tool === "vault_capture"
+                  ? action.title
+                  : typeof reply?.vaultTitle === "string"
+                    ? reply.vaultTitle
+                    : "",
+              username:
+                action?.tool === "vault_capture"
+                  ? action.username
+                  : typeof reply?.vaultUsername === "string"
+                    ? reply.vaultUsername
+                    : "",
+              notes:
+                action?.tool === "vault_capture"
+                  ? action.notes
+                  : typeof reply?.vaultNotes === "string"
+                    ? reply.vaultNotes
+                    : "",
+            },
+            approvalId,
+          )
+        : await executeSubmit(selector, key, approvalId);
     return result;
   }
   if (status === "executing") {
@@ -509,7 +702,7 @@ const TOOLS = [
   {
     name: "browser_snapshot",
     description:
-      "Return a fresh snapshot of the current page (URL, title, ref-annotated page outline). Use to recover state at the start of a new turn — the browser persists, so the page the human was just looking at is still loaded. Actions already return a snapshot, so you rarely need this right after one.",
+      "Return a fresh snapshot of the current page (URL, title, ref-annotated page outline). Password-input values are redacted, including inside frames. Use to recover state at the start of a new turn — the browser persists, so the page the human was just looking at is still loaded. Actions already return a snapshot, so you rarely need this right after one.",
     inputSchema: { type: "object", properties: {}, additionalProperties: false },
     handler: browserSnapshot,
   },
@@ -547,6 +740,58 @@ const TOOLS = [
     handler: browserFill,
   },
   {
+    name: "browser_fill_vault",
+    description: `Fill a username or a Vault Login password without revealing the password to you or placing it in the transcript. Stored passwords only go into type=password inputs; API-key and secure-note values have no Browser-fill path. Call list_vault_items first to get an item id. The top page and target frame must exactly match the item's saved origin (scheme, host and port), and Browser access plus the host allow list still apply. ${SELECTOR_HINT}`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        selector: {
+          type: "string",
+          description: "The login input — aria-ref=eN from the snapshot, or CSS / text= / role=.",
+        },
+        itemId: {
+          type: "string",
+          description: "Vault item UUID from list_vault_items.",
+        },
+        field: {
+          type: "string",
+          enum: ["username", "secret"],
+          description:
+            "Which login field to fill. `secret` is allowed only for a login password targeting type=password.",
+        },
+      },
+      required: ["selector", "itemId", "field"],
+      additionalProperties: false,
+    },
+    handler: browserFillVault,
+  },
+  {
+    name: "browser_save_vault_login",
+    description: `Request mandatory company-owner/admin approval to save the current value of a same-origin password input as a restricted Vault Login without reading or returning that value. Use after a signup page or service has generated a password in the browser. The item is bound to the exact current origin, you receive a manage Grant, and Browser access plus the host allow list still apply. ${SELECTOR_HINT}`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        selector: {
+          type: "string",
+          description: "The password input whose current value should be captured server-side.",
+        },
+        title: { type: "string", description: "Human-readable Vault item title." },
+        username: {
+          type: "string",
+          description:
+            "Optional username or email for this login. This is metadata, not the password.",
+        },
+        notes: {
+          type: "string",
+          description: "Optional non-secret context for Members who use this login later.",
+        },
+      },
+      required: ["selector", "title"],
+      additionalProperties: false,
+    },
+    handler: browserSaveVaultLogin,
+  },
+  {
     name: "browser_select",
     description: `Choose an option in a native <select> dropdown by its value or visible label (browser_fill cannot set selects). ${SELECTOR_HINT}`,
     inputSchema: {
@@ -563,11 +808,15 @@ const TOOLS = [
   {
     name: "browser_press",
     description:
-      "Press a keyboard key. Common values: 'Enter' (submit a form), 'Tab', 'Escape', 'ArrowDown'. Pass `selector` to focus an element first; omit to send the key to whatever is currently focused. For form submissions, prefer browser_submit.",
+      "Press a plain navigation or editing key. Modifier chords, clipboard shortcuts, and context-menu keys are blocked. Pass `selector` to focus an element first; omit to send the key to whatever is currently focused. For form submissions, prefer browser_submit.",
     inputSchema: {
       type: "object",
       properties: {
-        key: { type: "string", description: "Key name, e.g. 'Enter', 'Tab', 'ArrowDown'." },
+        key: {
+          type: "string",
+          enum: MODEL_PRESS_KEYS,
+          description: "A supported plain key, e.g. 'Enter', 'Tab', or 'ArrowDown'.",
+        },
         selector: { type: "string", description: "Optional element to focus first." },
       },
       required: ["key"],
@@ -633,7 +882,7 @@ const TOOLS = [
   {
     name: "browser_screenshot",
     description:
-      "Capture a JPEG screenshot of the current viewport and return it as image content. Use sparingly — screenshots are heavy in the context window. Prefer browser_snapshot when you only need structure/text; screenshot when layout or imagery matters. Humans can also watch the page live in the chat panel.",
+      "Capture a JPEG screenshot of the current viewport and return it as image content. This is refused after the browser session has observed or filled a password; use browser_snapshot, which redacts password inputs, instead. Screenshots are heavy in the context window, so use them only when layout or imagery matters. Humans can also watch the page live in the chat panel.",
     inputSchema: { type: "object", properties: {}, additionalProperties: false },
     handler: browserScreenshot,
   },
@@ -658,8 +907,9 @@ const TOOLS = [
         },
         key: {
           type: "string",
+          enum: MODEL_PRESS_KEYS,
           description:
-            "Optional. When set, the action is a key press on `selector` (e.g. 'Enter') instead of a click.",
+            "Optional supported plain key. When set, the action is a key press on `selector` (e.g. 'Enter') instead of a click.",
         },
         summary: {
           type: "string",
@@ -674,13 +924,13 @@ const TOOLS = [
   {
     name: "browser_resume",
     description:
-      "Re-fire a previously queued browser_submit once a human has approved it — in this turn or a later one. Genosyn atomically claims the approval before touching the page, so concurrent calls cannot submit twice and an ambiguous crashed attempt is never replayed. The action runs only while the browser is still on the approved page; if the page changed before the claim you'll be asked to submit again. Returns still-pending if the human hasn't decided yet; errors if it was rejected, already claimed, already fired, or the page moved on.",
+      "Run a previously queued browser_submit or restricted Vault capture after the required human has approved it — in this turn or a later one. Genosyn atomically claims the reviewed action before Chromium acts, so concurrent calls cannot submit twice and an ambiguous crashed attempt is never replayed. The action is bound to its Browser session and reviewed page; if either changed, queue it again. Returns still-pending if the human has not decided yet and errors for rejection, expiry, prior use, or a stale target.",
     inputSchema: {
       type: "object",
       properties: {
         approvalId: {
           type: "string",
-          description: "The id returned by the original browser_submit call.",
+          description: "The id returned by browser_submit or browser_save_vault_login.",
         },
       },
       required: ["approvalId"],

--- a/App/server/mcp/toolManifest.ts
+++ b/App/server/mcp/toolManifest.ts
@@ -1563,6 +1563,74 @@ export const STATIC_TOOLS: McpToolSpec[] = [
     },
   },
   {
+    name: "list_vault_items",
+    description:
+      "List the Vault items explicitly granted to you. Returns safe metadata only: item id, type, title, username, saved website origin and your Grant level. Stored passwords, API keys and secure-note bodies are never returned to the model. Only a Login username or password has a Browser-fill path, and a stored password can go only into a password input. Browser access, the host allow list, the live top-page and target-frame origin, and the item Grant must all allow each fill.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["login", "api_key", "secure_note"],
+          description: "Optional item-type filter.",
+        },
+        query: {
+          type: "string",
+          description: "Optional title, username, or website search.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "create_vault_login",
+    description:
+      "Create a company-visible Vault login with a strong password generated inside Genosyn. The password is encrypted immediately and is never returned in this tool result or written to the transcript. You receive a `manage` Grant on the item. Use browser_fill_vault to put the Login password only into a password input when the top page and target frame match its exact saved origin and Browser policy allows the site. For a password already present in the browser, use browser_save_vault_login; that path always needs owner/admin approval and creates a restricted item.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Human-readable login title." },
+        username: {
+          type: "string",
+          description: "Optional username or email. This is visible as Vault metadata.",
+        },
+        websiteUrl: {
+          type: "string",
+          description:
+            "Absolute http(s) login URL. Its origin (scheme, host and port) is fixed; browser_fill_vault requires both the top page and target frame to match it exactly.",
+        },
+        notes: {
+          type: "string",
+          description: "Optional non-secret context for Members using this login later.",
+        },
+        passwordLength: {
+          type: "integer",
+          minimum: 16,
+          maximum: 128,
+          description: "Generated password length. Defaults to 24.",
+        },
+      },
+      required: ["title", "websiteUrl"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "update_vault_login",
+    description:
+      "Update safe metadata on a granted Vault login: title, username, or notes. Needs the item-level `manage` Grant. The encrypted password and saved website origin are preserved and never returned. AI Employees cannot rebind, rotate, or delete a credential; a Member performs those deliberate actions from Vault.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "Vault item UUID from list_vault_items." },
+        title: { type: "string" },
+        username: { type: "string" },
+        notes: { type: "string", description: "Optional non-secret context for Members." },
+      },
+      required: ["itemId"],
+      additionalProperties: false,
+    },
+  },
+  {
     name: "list_signature_envelopes",
     description:
       "List the company's signature envelopes you are allowed to inspect, newest first. Filter by lifecycle status or customer when useful. Returns compact progress and recipient counts; call `get_signature_envelope` for fields and the tamper-evident event trail. Needs `read` signing access.",

--- a/App/server/middleware/auth.ts
+++ b/App/server/middleware/auth.ts
@@ -5,6 +5,10 @@ import { User } from "../db/entities/User.js";
 import { Membership, Role } from "../db/entities/Membership.js";
 import { ApiKey } from "../db/entities/ApiKey.js";
 import { Company } from "../db/entities/Company.js";
+import {
+  AI_BROWSER_REQUEST_HEADER,
+  AI_BROWSER_REQUEST_VALUE,
+} from "../services/browserRequestBoundary.js";
 import { hasTwoFactorMethod } from "../services/twoFactor.js";
 import { config } from "../../config.js";
 
@@ -99,6 +103,12 @@ export function companyIdFromApiPath(originalUrl: string): string | null {
 }
 
 export async function requireAuth(req: Request, res: Response, next: NextFunction) {
+  if (req.get(AI_BROWSER_REQUEST_HEADER) === AI_BROWSER_REQUEST_VALUE) {
+    return res.status(403).json({
+      error:
+        "Authenticated Genosyn APIs are unavailable inside an AI Browser. Use AI Employee Grants and governed tools.",
+    });
+  }
   // Cookie-session path — what the web UI uses.
   const uid = req.session?.userId as string | undefined;
   if (uid) {

--- a/App/server/routes/approvals.ts
+++ b/App/server/routes/approvals.ts
@@ -13,26 +13,21 @@ import {
 } from "../middleware/auth.js";
 import {
   approvePendingApproval,
+  readBrowserActionPayload,
   redactApprovalSummary,
   rejectPendingApproval,
 } from "../services/approvals.js";
 
 /**
- * Human-in-the-loop inbox. Two kinds today:
- *
- *   * `routine` — cron tick for a routine marked `requiresApproval`
- *   * `lightning_payment` — Lightning payment over the Connection's
- *                            `requireApprovalAboveSats` threshold
- *
- * Approve dispatches to the right execute path in `services/approvals.ts`;
- * reject only stamps the row + writes a journal entry.
+ * Human-in-the-loop inbox. Decisions are browser-session-only, admin-level,
+ * recently authenticated actions. The service layer owns the atomic
+ * pending-to-terminal transition so duplicate requests never replay a side
+ * effect.
  */
 export const approvalsRouter = Router({ mergeParams: true });
 approvalsRouter.use(requireAuth);
 approvalsRouter.use(requireCompanyMember);
 
-// A privileged human decision, not a generic company write: a leaked API key
-// must not be enough to release a payment or guarded external action.
 const approvalDecisionGuards = [
   requireBrowserSession,
   requireCompanyRole("admin"),
@@ -51,7 +46,6 @@ function approvalResponse(approval: Approval) {
     kind: approval.kind,
     routineId: approval.routineId,
     employeeId: approval.employeeId,
-    // Legacy rows may predate creation-time sanitization.
     title: redactApprovalSummary(approval.title),
     summary: redactApprovalSummary(approval.summary),
     errorMessage: approval.errorMessage
@@ -62,6 +56,33 @@ function approvalResponse(approval: Approval) {
     decidedAt: approval.decidedAt,
     decidedByUserId: approval.decidedByUserId,
   };
+}
+
+function isVaultCaptureApproval(approval: Approval): boolean {
+  if (approval.kind !== "browser_action") return false;
+  try {
+    const payload = JSON.parse(approval.payloadJson || "{}") as { action?: unknown };
+    return payload.action === "vault_capture";
+  } catch {
+    return false;
+  }
+}
+
+function vaultCaptureApprovalExpired(approval: Approval): boolean {
+  if (!isVaultCaptureApproval(approval)) return false;
+  try {
+    const payload = readBrowserActionPayload(approval);
+    return typeof payload.expiresAt !== "string" || Date.parse(payload.expiresAt) <= Date.now();
+  } catch {
+    return true;
+  }
+}
+
+async function loadApproval(companyId: string, approvalId: string): Promise<Approval | null> {
+  return AppDataSource.getRepository(Approval).findOneBy({
+    id: approvalId,
+    companyId,
+  });
 }
 
 approvalsRouter.get(
@@ -76,44 +97,73 @@ approvalsRouter.get(
       take: 200,
     });
 
-    // Routine kind needs the routine name; both kinds need the employee
-    // name. Hydrate in two batched queries so the inbox renders without
-    // an N+1 round-trip.
     const routineIds = [
       ...new Set(
         approvals.filter((a) => a.kind === "routine" && a.routineId).map((a) => a.routineId),
       ),
     ];
-    const empIds = [...new Set(approvals.map((a) => a.employeeId).filter(Boolean))];
+    const employeeIds = [...new Set(approvals.map((a) => a.employeeId).filter(Boolean))];
     const routines = routineIds.length
-      ? await AppDataSource.getRepository(Routine).find({
-          where: { id: In(routineIds) },
-        })
+      ? await AppDataSource.getRepository(Routine).find({ where: { id: In(routineIds) } })
       : [];
-    const emps = empIds.length
-      ? await AppDataSource.getRepository(AIEmployee).find({
-          where: { id: In(empIds) },
-        })
+    const employees = employeeIds.length
+      ? await AppDataSource.getRepository(AIEmployee).find({ where: { id: In(employeeIds) } })
       : [];
-    const rById = new Map(routines.map((r) => [r.id, r]));
-    const eById = new Map(emps.map((e) => [e.id, e]));
+    const routineById = new Map(routines.map((routine) => [routine.id, routine]));
+    const employeeById = new Map(employees.map((employee) => [employee.id, employee]));
 
     res.json(
-      approvals.map((a) => {
-        const r = a.routineId ? (rById.get(a.routineId) ?? null) : null;
-        const e = a.employeeId ? (eById.get(a.employeeId) ?? null) : null;
-        return {
-          ...approvalResponse(a),
-          routine: r ? { id: r.id, name: r.name, slug: r.slug } : null,
-          employee: e ? { id: e.id, name: e.name, slug: e.slug } : null,
-        };
-      }),
+      approvals
+        .filter(
+          (approval) =>
+            !isVaultCaptureApproval(approval) ||
+            req.companyRole === "owner" ||
+            req.companyRole === "admin",
+        )
+        .map((approval) => {
+          const routine = approval.routineId
+            ? (routineById.get(approval.routineId) ?? null)
+            : null;
+          const employee = approval.employeeId
+            ? (employeeById.get(approval.employeeId) ?? null)
+            : null;
+          return {
+            ...approvalResponse(approval),
+            routine: routine
+              ? { id: routine.id, name: routine.name, slug: routine.slug }
+              : null,
+            employee: employee
+              ? { id: employee.id, name: employee.name, slug: employee.slug }
+              : null,
+          };
+        }),
     );
   },
 );
 
 approvalsRouter.post("/approvals/:id/approve", ...approvalDecisionGuards, async (req, res) => {
   const { cid, id } = req.params as Record<string, string>;
+  const approval = await loadApproval(cid, id);
+  if (!approval) return res.status(404).json({ error: "Not found" });
+  if (vaultCaptureApprovalExpired(approval)) {
+    if (approval.status === "pending") {
+      await AppDataSource.getRepository(Approval).update(
+        { id: approval.id, companyId: cid, status: "pending" },
+        { status: "expired" },
+      );
+    }
+    return res.status(409).json({ error: "Vault capture approval expired" });
+  }
+  if (
+    isVaultCaptureApproval(approval) &&
+    req.companyRole !== "owner" &&
+    req.companyRole !== "admin"
+  ) {
+    return res.status(403).json({
+      error: "Only a company owner or admin can approve saving a browser password to Vault",
+    });
+  }
+
   const result = await approvePendingApproval({
     companyId: cid,
     approvalId: id,
@@ -133,6 +183,18 @@ approvalsRouter.post("/approvals/:id/approve", ...approvalDecisionGuards, async 
 
 approvalsRouter.post("/approvals/:id/reject", ...approvalDecisionGuards, async (req, res) => {
   const { cid, id } = req.params as Record<string, string>;
+  const approval = await loadApproval(cid, id);
+  if (!approval) return res.status(404).json({ error: "Not found" });
+  if (
+    isVaultCaptureApproval(approval) &&
+    req.companyRole !== "owner" &&
+    req.companyRole !== "admin"
+  ) {
+    return res.status(403).json({
+      error: "Only a company owner or admin can decide a Vault capture request",
+    });
+  }
+
   const result = await rejectPendingApproval({
     companyId: cid,
     approvalId: id,

--- a/App/server/routes/browserRpc.ts
+++ b/App/server/routes/browserRpc.ts
@@ -3,8 +3,14 @@ import { z } from "zod";
 import { AppDataSource } from "../db/datasource.js";
 import { BrowserSession } from "../db/entities/BrowserSession.js";
 import { AIEmployee } from "../db/entities/AIEmployee.js";
+import type { VaultItemType } from "../db/entities/VaultItem.js";
 import { validateBody } from "../middleware/validate.js";
-import { resolveBrowserSessionToken, markSessionLive } from "../services/browserSessions.js";
+import {
+  resolveBrowserSessionToken,
+  markSessionLive,
+  registerBrowserSessionCleanup,
+  registerBrowserSensitiveValueListener,
+} from "../services/browserSessions.js";
 import {
   acquirePage,
   releasePage,
@@ -14,6 +20,24 @@ import {
   takeSessionNotices,
   awaitAdoption,
 } from "../services/browserChromium.js";
+import { recordAudit } from "../services/audit.js";
+import {
+  createVaultLoginForEmployee,
+  getVaultItemPayloadForEmployee,
+  VaultError,
+} from "../services/vault.js";
+import {
+  BrowserApprovalError,
+  claimBrowserActionApproval,
+  computeBrowserActionTargetFingerprint,
+  settleBrowserActionApproval,
+  type BrowserActionPayload,
+  type BrowserApprovalTargetDescriptor,
+} from "../services/approvals.js";
+import {
+  browserAccessEnabledForSession,
+  closeBrowserSessionForPolicy,
+} from "../services/browserAccess.js";
 
 /**
  * Internal HTTP surface called by the stripped-down `browser` MCP child.
@@ -69,6 +93,10 @@ const SETTLE_CAP_MS = 2_000;
 /** How long an action waits for a popup it opened to be adopted. Slightly
  *  above adoptPage's own 5s load wait so a just-loaded popup is reflected. */
 const ADOPTION_WAIT_MS = 5_500;
+const MAX_TRACKED_VAULT_VALUES_PER_SESSION = 64;
+const vaultSensitiveValuesBySession = new Map<string, Map<string, number>>();
+const vaultTaintedSessions = new Set<string>();
+const vaultSensitiveOverflowSessions = new Set<string>();
 
 async function requireBrowserSession(req: BrowserRpcReq, res: Response, next: NextFunction) {
   const header = req.headers.authorization ?? "";
@@ -84,6 +112,7 @@ async function requireBrowserSession(req: BrowserRpcReq, res: Response, next: Ne
   const row = await repo.findOneBy({ id: sessionId });
   if (!row) return res.status(404).json({ error: "Session not found" });
   if (row.status === "closed" || row.status === "expired") {
+    clearVaultSensitiveValuesForSession(sessionId);
     return res.status(410).json({ error: "Session is closed" });
   }
   if (row.mcpTokenExpiresAt.getTime() < Date.now()) {
@@ -91,6 +120,10 @@ async function requireBrowserSession(req: BrowserRpcReq, res: Response, next: Ne
   }
   const emp = await AppDataSource.getRepository(AIEmployee).findOneBy({ id: row.employeeId });
   if (!emp) return res.status(404).json({ error: "Employee not found" });
+  if (!(await browserAccessEnabledForSession(row, emp))) {
+    await closeBrowserSessionForPolicy(sessionId);
+    return res.status(403).json({ error: "Browser access is disabled for this AI Employee" });
+  }
   req.browserSession = row;
   req.browserEmployee = emp;
   next();
@@ -106,6 +139,10 @@ type Page = {
   goto: (url: string, opts: unknown) => Promise<unknown>;
   goBack: (opts: unknown) => Promise<unknown>;
   locator: (sel: string) => PageLocator;
+  frames: () => Array<{
+    locator: (sel: string) => PageLocator;
+    evaluate: <T>(fn: (() => T) | string) => Promise<T>;
+  }>;
   keyboard: { press: (key: string) => Promise<void> };
   mouse: { wheel: (dx: number, dy: number) => Promise<void> };
   waitForLoadState: (state: string, opts: unknown) => Promise<void>;
@@ -124,11 +161,494 @@ type Locator = {
   waitFor: (opts: unknown) => Promise<void>;
   click: (opts: unknown) => Promise<void>;
   fill: (value: string, opts: unknown) => Promise<void>;
+  inputValue: (opts?: unknown) => Promise<string>;
+  getAttribute: (name: string, opts?: unknown) => Promise<string | null>;
+  elementHandle: () => Promise<ElementHandle | null>;
   press: (key: string, opts: unknown) => Promise<void>;
   hover: (opts: unknown) => Promise<void>;
   selectOption: (values: unknown, opts: unknown) => Promise<string[]>;
   scrollIntoViewIfNeeded: (opts: unknown) => Promise<void>;
 };
+
+type ElementHandle = {
+  evaluate: <T, Arg = undefined>(fn: (element: Element, arg: Arg) => T, arg?: Arg) => Promise<T>;
+  click: (opts: unknown) => Promise<void>;
+  press: (key: string, opts: unknown) => Promise<void>;
+  fill: (value: string, opts: unknown) => Promise<void>;
+  getAttribute: (name: string) => Promise<string | null>;
+  inputValue: (opts?: unknown) => Promise<string>;
+};
+
+type BrowserApprovalTargetInspection = {
+  handle: ElementHandle;
+  descriptor: BrowserApprovalTargetDescriptor;
+  fingerprint: string;
+  /** Returned only inside this server process and never serialized. */
+  sensitiveValue: string | null;
+};
+
+function safeBrowserApprovalTargetUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "";
+  }
+}
+
+export function browserKeyMaySubmit(key: string): boolean {
+  const terminalKey = key
+    .split("+")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean)
+    .at(-1);
+  return (
+    terminalKey === "enter" ||
+    terminalKey === "numpadenter" ||
+    terminalKey === "space" ||
+    terminalKey === "spacebar"
+  );
+}
+
+/**
+ * `keyboard.press()` accepts Playwright modifier chords such as `Control+C`
+ * and `Meta+V`. Once a Vault password has been filled into the page, those
+ * chords would let the model move the value through the system clipboard and
+ * paste it into model-visible content. Keep the model-facing `/press` surface
+ * to the small set of plain keys needed for navigation and ordinary editing.
+ * Text entry belongs in `/fill`; submission remains governed separately.
+ */
+export const BROWSER_MODEL_PRESS_KEYS = [
+  "Enter",
+  "NumpadEnter",
+  "Tab",
+  "Escape",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Backspace",
+  "Delete",
+  "Space",
+  "Spacebar",
+] as const;
+
+const browserModelPressKeySet = new Set<string>(BROWSER_MODEL_PRESS_KEYS);
+
+export function browserModelPressKeyIsAllowed(key: string): boolean {
+  return browserModelPressKeySet.has(key);
+}
+
+export const browserModelPressKeySchema = z
+  .string()
+  .min(1)
+  .max(60)
+  .refine(browserModelPressKeyIsAllowed, {
+    message:
+      "Unsupported browser key. Modifier chords, clipboard shortcuts, and context-menu keys are not allowed.",
+  });
+
+export function browserClickMaySubmit(descriptor: BrowserApprovalTargetDescriptor): boolean {
+  return descriptor.submitsForm;
+}
+
+const INSTALL_BROWSER_SUBMIT_GUARD_SCRIPT = `(() => {
+  const key = "__genosynBrowserSubmitGuardV1";
+  const scope = window;
+  if (scope[key] && typeof scope[key].cleanup === "function") scope[key].cleanup();
+  const state = { blocked: false };
+  const prototype = HTMLFormElement.prototype;
+  const originalSubmit = prototype.submit;
+  const originalRequestSubmit = prototype.requestSubmit;
+  const onSubmit = (event) => {
+    state.blocked = true;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+  document.addEventListener("submit", onSubmit, true);
+  const guardedSubmit = function () { state.blocked = true; };
+  const guardedRequestSubmit = function () { state.blocked = true; };
+  prototype.submit = guardedSubmit;
+  prototype.requestSubmit = guardedRequestSubmit;
+  scope[key] = {
+    state,
+    cleanup() {
+      document.removeEventListener("submit", onSubmit, true);
+      if (prototype.submit === guardedSubmit) prototype.submit = originalSubmit;
+      if (prototype.requestSubmit === guardedRequestSubmit) {
+        prototype.requestSubmit = originalRequestSubmit;
+      }
+    },
+  };
+})()`;
+
+const REMOVE_BROWSER_SUBMIT_GUARD_SCRIPT = `(() => {
+  const key = "__genosynBrowserSubmitGuardV1";
+  const guard = window[key];
+  const blocked = Boolean(guard && guard.state && guard.state.blocked === true);
+  if (guard && typeof guard.cleanup === "function") guard.cleanup();
+  delete window[key];
+  return blocked;
+})()`;
+
+/**
+ * Block native `submit`, `requestSubmit`, and `form.submit()` while an
+ * unapproved click/key action runs. This catches framework buttons whose DOM
+ * type does not reveal that their handler submits a form. The guard lives in
+ * the page realm only for the duration of one RPC action.
+ */
+export async function armUnapprovedFormSubmitGuard(page: Page): Promise<void> {
+  await Promise.all(
+    page.frames().map((frame) => frame.evaluate<void>(INSTALL_BROWSER_SUBMIT_GUARD_SCRIPT)),
+  );
+}
+
+export async function disarmUnapprovedFormSubmitGuard(page: Page): Promise<boolean> {
+  const results = await Promise.all(
+    page
+      .frames()
+      .map((frame) =>
+        frame.evaluate<boolean>(REMOVE_BROWSER_SUBMIT_GUARD_SCRIPT).catch(() => false),
+      ),
+  );
+  return results.some(Boolean);
+}
+
+export async function inspectBrowserApprovalTarget(args: {
+  page: Page;
+  session: BrowserSession;
+  employee: AIEmployee;
+  action: BrowserActionPayload["action"];
+  selector: string;
+  key: string | null;
+  handle?: ElementHandle;
+}): Promise<BrowserApprovalTargetInspection> {
+  const handle =
+    args.handle ??
+    (await (async () => {
+      const locator = await locate(args.page, args.session.id, args.selector);
+      const resolved = await locator.elementHandle();
+      if (!resolved) throw new BrowserApprovalError("Browser target is no longer attached", 409);
+      return resolved;
+    })());
+  const inspected = await handle.evaluate(
+    (element, context) => {
+      const input = element instanceof HTMLInputElement ? element : null;
+      const button = element instanceof HTMLButtonElement ? element : null;
+      const tagName = element.tagName.toLowerCase();
+      const inputType = input
+        ? input.type.toLowerCase()
+        : button
+          ? button.type.toLowerCase()
+          : element.getAttribute("type")?.toLowerCase() || null;
+      const directForm = input?.form ?? button?.form ?? element.closest("form");
+      const nativeSubmitTarget = Boolean(
+        directForm &&
+        ((button && button.type.toLowerCase() === "submit") ||
+          (input && ["submit", "image"].includes(input.type.toLowerCase()))),
+      );
+      const terminalKey = context.key
+        ?.split("+")
+        .map((part) => part.trim().toLowerCase())
+        .filter(Boolean)
+        .at(-1);
+      const nativeClickSubmitter = Boolean(!context.key && nativeSubmitTarget);
+      const keyActivatesSubmitter = Boolean(
+        context.key &&
+        nativeSubmitTarget &&
+        ["enter", "numpadenter", "space", "spacebar"].includes(terminalKey ?? ""),
+      );
+      const enterMaySubmit = Boolean(
+        context.key &&
+        context.key
+          .split("+")
+          .map((part) => part.trim().toLowerCase())
+          .filter(Boolean)
+          .at(-1)
+          ?.match(/^(enter|numpadenter)$/) &&
+        directForm,
+      );
+      const buttonLikeClick = Boolean(
+        !context.key &&
+        (button ||
+          (input && ["button", "submit", "image"].includes(input.type.toLowerCase())) ||
+          element.getAttribute("role")?.toLowerCase() === "button"),
+      );
+      const submitsForm = Boolean(
+        nativeClickSubmitter || keyActivatesSubmitter || enterMaySubmit || buttonLikeClick,
+      );
+      const submitter =
+        nativeClickSubmitter || keyActivatesSubmitter
+          ? element
+          : enterMaySubmit && directForm
+            ? (Array.from(directForm.elements).find((candidate) => {
+                if (candidate instanceof HTMLButtonElement) {
+                  return !candidate.disabled && candidate.type.toLowerCase() === "submit";
+                }
+                return (
+                  candidate instanceof HTMLInputElement &&
+                  !candidate.disabled &&
+                  ["submit", "image"].includes(candidate.type.toLowerCase())
+                );
+              }) ?? null)
+            : null;
+      const submitterElement = submitter instanceof HTMLElement ? submitter : null;
+      const effectiveAction =
+        (submitterElement && "formAction" in submitterElement
+          ? String((submitterElement as HTMLButtonElement | HTMLInputElement).formAction || "")
+          : "") ||
+        directForm?.action ||
+        null;
+      const effectiveMethod =
+        (submitterElement && "formMethod" in submitterElement
+          ? String((submitterElement as HTMLButtonElement | HTMLInputElement).formMethod || "")
+          : "") ||
+        directForm?.method ||
+        null;
+      // Do not construct FormData here: that fires page-controlled `formdata`
+      // listeners before a human has approved anything. Native property reads
+      // capture the submitted state without dispatching DOM events.
+      const formFields = directForm
+        ? Array.from(directForm.elements).map((control) => {
+            if (control instanceof HTMLInputElement) {
+              return {
+                tag: "input",
+                type: control.type.toLowerCase(),
+                name: control.name,
+                disabled: control.disabled,
+                checked: control.checked,
+                value:
+                  control.type.toLowerCase() === "file"
+                    ? Array.from(control.files ?? []).map((file) => ({
+                        name: file.name,
+                        size: file.size,
+                        type: file.type,
+                      }))
+                    : control.value,
+              };
+            }
+            if (control instanceof HTMLTextAreaElement) {
+              return {
+                tag: "textarea",
+                name: control.name,
+                disabled: control.disabled,
+                value: control.value,
+              };
+            }
+            if (control instanceof HTMLSelectElement) {
+              return {
+                tag: "select",
+                name: control.name,
+                disabled: control.disabled,
+                values: Array.from(control.selectedOptions).map((option) => option.value),
+              };
+            }
+            if (control instanceof HTMLButtonElement) {
+              return {
+                tag: "button",
+                type: control.type.toLowerCase(),
+                name: control.name,
+                disabled: control.disabled,
+                value: control.value,
+              };
+            }
+            return {
+              tag: control.tagName.toLowerCase(),
+              name: control.getAttribute("name") ?? "",
+            };
+          })
+        : [];
+      const domPath: Array<{ tag: string; index: number }> = [];
+      let cursor: Element | null = element;
+      while (cursor && domPath.length < 32) {
+        const parent: Element | null = cursor.parentElement;
+        domPath.push({
+          tag: cursor.tagName.toLowerCase(),
+          index: parent ? Array.from(parent.children).indexOf(cursor) : 0,
+        });
+        cursor = parent;
+      }
+      const frameUrl =
+        element.ownerDocument.defaultView?.location.href ?? element.ownerDocument.URL;
+      return {
+        descriptor: {
+          tagName,
+          inputType,
+          frameUrl,
+          formAction: effectiveAction,
+          formMethod: effectiveMethod?.toUpperCase() ?? null,
+          submitsForm,
+        },
+        targetMaterial: {
+          frameUrl,
+          tagName,
+          inputType,
+          id: element.id,
+          name: element.getAttribute("name") ?? "",
+          role: element.getAttribute("role") ?? "",
+          domPath,
+          form: directForm
+            ? {
+                id: directForm.id,
+                name: directForm.getAttribute("name") ?? "",
+                action: effectiveAction,
+                method: effectiveMethod,
+                enctype: directForm.enctype,
+                target: directForm.target,
+                fields: formFields,
+              }
+            : null,
+          submitter: submitterElement
+            ? {
+                id: submitterElement.id,
+                name: submitterElement.getAttribute("name") ?? "",
+                value: submitterElement.getAttribute("value") ?? "",
+                formAction: effectiveAction,
+                formMethod: effectiveMethod,
+              }
+            : null,
+          capturedValue: context.action === "vault_capture" && input ? input.value : null,
+        },
+        sensitiveValue: context.action === "vault_capture" && input ? input.value : null,
+      };
+    },
+    { action: args.action, key: args.key },
+  );
+  const descriptor: BrowserApprovalTargetDescriptor = {
+    ...inspected.descriptor,
+    frameUrl: safeBrowserApprovalTargetUrl(inspected.descriptor.frameUrl),
+    formAction: inspected.descriptor.formAction
+      ? safeBrowserApprovalTargetUrl(inspected.descriptor.formAction)
+      : null,
+  };
+  const fingerprint = computeBrowserActionTargetFingerprint({
+    companyId: args.session.companyId,
+    employeeId: args.employee.id,
+    browserSessionId: args.session.id,
+    action: args.action,
+    selector: args.selector,
+    key: args.key,
+    pageUrl: args.page.url(),
+    targetMaterial: inspected.targetMaterial,
+  });
+  return { handle, descriptor, fingerprint, sensitiveValue: inspected.sensitiveValue };
+}
+
+/**
+ * Passwords are bound to an exact saved origin. Keeping this pure and
+ * exported makes the anti-phishing boundary straightforward to unit test.
+ */
+export function vaultWebsiteMatchesPage(websiteUrl: string, pageUrl: string): boolean {
+  try {
+    const website = new URL(websiteUrl);
+    const page = new URL(pageUrl);
+    if (!["http:", "https:"].includes(website.protocol)) return false;
+    if (!["http:", "https:"].includes(page.protocol)) return false;
+    return website.origin.toLowerCase() === page.origin.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+export function vaultFillTargetIsAllowed(
+  itemType: VaultItemType,
+  field: "username" | "secret",
+  inputType: string | null,
+): boolean {
+  if (field !== "secret") return true;
+  return itemType === "login" && inputType?.toLowerCase() === "password";
+}
+
+function rememberVaultSensitiveValue(sessionId: string, value: string): void {
+  if (!value) return;
+  vaultTaintedSessions.add(sessionId);
+  let values = vaultSensitiveValuesBySession.get(sessionId);
+  if (!values) {
+    values = new Map<string, number>();
+    vaultSensitiveValuesBySession.set(sessionId, values);
+  }
+  if (values.size >= MAX_TRACKED_VAULT_VALUES_PER_SESSION && !values.has(value)) {
+    // Never evict a known password: the page may reflect it later as generic
+    // text. Stop remembering new values and make all subsequent model-visible
+    // page/error output fail closed for this BrowserSession.
+    vaultSensitiveOverflowSessions.add(sessionId);
+    return;
+  }
+  // Keep the bounded value set for the whole BrowserSession. Password reveal
+  // controls can change an input to type=text long after the original fill;
+  // expiring the scrub value would then disclose it in a later snapshot.
+  values.set(value, Date.now());
+}
+
+export function clearVaultSensitiveValuesForSession(sessionId: string): void {
+  vaultSensitiveValuesBySession.delete(sessionId);
+  vaultTaintedSessions.delete(sessionId);
+  vaultSensitiveOverflowSessions.delete(sessionId);
+}
+
+registerBrowserSessionCleanup(clearVaultSensitiveValuesForSession);
+export function observeBrowserSensitiveValue(
+  sessionId: string,
+  value: string,
+  kind: "password-present" | "password-value" | "active-input-value",
+): void {
+  if (kind === "password-present") {
+    vaultTaintedSessions.add(sessionId);
+    return;
+  }
+  if (kind === "password-value" || vaultTaintedSessions.has(sessionId)) {
+    rememberVaultSensitiveValue(sessionId, value);
+  }
+}
+
+registerBrowserSensitiveValueListener(observeBrowserSensitiveValue);
+
+export function redactVaultSensitiveText(sessionId: string, text: string): string {
+  if (vaultSensitiveOverflowSessions.has(sessionId)) {
+    return "[redacted because this BrowserSession exceeded the sensitive-value safety limit]";
+  }
+  let redacted = text;
+  for (const value of vaultSensitiveValuesBySession.get(sessionId)?.keys() ?? []) {
+    const escaped = JSON.stringify(value).slice(1, -1);
+    for (const candidate of new Set([value, escaped])) {
+      if (candidate) redacted = redacted.split(candidate).join("[redacted Vault value]");
+    }
+  }
+  return redacted;
+}
+
+type VaultTargetDescriptor = {
+  frameUrl: string;
+  inputType: string | null;
+};
+
+async function resolveVaultTarget(locator: Locator): Promise<ElementHandle> {
+  const handle = await locator.elementHandle();
+  if (!handle) throw new VaultError("The selected Vault target is no longer attached", 409);
+  return handle;
+}
+
+async function describeVaultTarget(handle: ElementHandle): Promise<VaultTargetDescriptor> {
+  return handle.evaluate((element) => ({
+    frameUrl: element.ownerDocument.defaultView?.location.href ?? element.ownerDocument.URL,
+    inputType: element instanceof HTMLInputElement ? element.type : element.getAttribute("type"),
+  }));
+}
+
+function safeVaultWebsiteUrl(pageUrl: string): string {
+  const parsed = new URL(pageUrl);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new VaultError("Vault logins can only be saved from an http(s) page", 400);
+  }
+  // Deliberately discard path/query/hash: account setup links often carry
+  // bearer material in the URL, and the Vault only needs the origin/host.
+  return parsed.origin;
+}
 
 function parseAllowList(raw: string | null): string[] {
   if (!raw) return [];
@@ -166,7 +686,10 @@ function hostMatches(hostname: string, pattern: string): boolean {
   return new RegExp(`^${escaped}$`).test(h);
 }
 
-function urlAllowed(url: string, allowList: string[]): { ok: true } | { ok: false; reason: string } {
+function urlAllowed(
+  url: string,
+  allowList: string[],
+): { ok: true } | { ok: false; reason: string } {
   if (allowList.length === 0) return { ok: true };
   let host: string;
   try {
@@ -183,6 +706,17 @@ function urlAllowed(url: string, allowList: string[]): { ok: true } | { ok: fals
   };
 }
 
+export function vaultUrlAllowedForEmployee(url: string, rawAllowList: string | null): boolean {
+  return urlAllowed(url, parseAllowList(rawAllowList)).ok;
+}
+
+function assertVaultBrowserPolicy(employee: AIEmployee, ...urls: string[]): void {
+  const allowList = parseAllowList(employee.browserAllowedHosts);
+  if (urls.some((url) => !urlAllowed(url, allowList).ok)) {
+    throw new VaultError("Vault use is blocked by this AI Employee's Browser host policy", 403);
+  }
+}
+
 /** Byte-accurate UTF-8 truncation that never splits a code point. */
 function truncateUtf8(s: string, maxBytes: number): { text: string; truncated: boolean } {
   const buf = Buffer.from(s, "utf8");
@@ -193,12 +727,80 @@ function truncateUtf8(s: string, maxBytes: number): { text: string; truncated: b
   return { text, truncated: true };
 }
 
-async function pageSnapshot(p: Page, sessionId: string): Promise<string> {
-  const url = p.url();
-  const [title, tree] = await Promise.all([
+/**
+ * Playwright's AI aria snapshot includes textbox values, including password
+ * inputs. Resolve textbox refs back to their DOM elements and replace the
+ * entire rendered scalar for password fields. An unresolvable ref fails
+ * closed by hiding that textbox value as well.
+ */
+export async function redactPasswordInputsFromSnapshot(
+  page: Page,
+  sessionId: string,
+  tree: string,
+): Promise<string> {
+  const refs = Array.from(
+    new Set(Array.from(tree.matchAll(/\btextbox\b[^\n]*\[ref=([^\]]+)\]/g), (match) => match[1])),
+  );
+  if (refs.length === 0) return tree;
+
+  const states = new Map<string, "keep" | "redact">();
+  await Promise.all(
+    refs.map(async (ref) => {
+      try {
+        const locator = page.locator(`aria-ref=${ref}`).first();
+        const handle = await locator.elementHandle();
+        if (!handle) throw new Error("snapshot ref detached");
+        const inputType = (await handle.getAttribute("type"))?.toLowerCase();
+        if (inputType !== "password") {
+          states.set(ref, "keep");
+          return;
+        }
+        const value = await handle.inputValue().catch(() => "");
+        rememberVaultSensitiveValue(sessionId, value);
+        states.set(ref, "redact");
+      } catch {
+        states.set(ref, "redact");
+      }
+    }),
+  );
+
+  // Once any password field/value has existed, redact every textbox value.
+  // This fail-closed rule prevents a reveal control, DOM replacement, or the
+  // bounded exact-value cache from declassifying an older password while
+  // keeping element labels and refs usable for subsequent actions.
+  const redactAllTextboxValues = vaultTaintedSessions.has(sessionId);
+
+  return tree
+    .split("\n")
+    .map((line) => {
+      const match = /\btextbox\b[^\n]*\[ref=([^\]]+)\]/.exec(line);
+      if (!match || (!redactAllTextboxValues && states.get(match[1]) !== "redact")) {
+        return line;
+      }
+      const marker = `[ref=${match[1]}]`;
+      const markerEnd = line.indexOf(marker) + marker.length;
+      return `${line.slice(0, markerEnd)}: [redacted password]`;
+    })
+    .join("\n");
+}
+
+export async function pageSnapshot(p: Page, sessionId: string): Promise<string> {
+  const url = safeBrowserUrlForModel(p.url());
+  const [title, rawTree] = await Promise.all([
     p.title().catch(() => ""),
     p.ariaSnapshot({ mode: "ai", timeout: ARIA_SNAPSHOT_TIMEOUT_MS }).catch(() => ""),
   ]);
+  const tree = await redactPasswordInputsFromSnapshot(p, sessionId, rawTree);
+
+  if (vaultSensitiveOverflowSessions.has(sessionId)) {
+    return [
+      `URL: ${url}`,
+      "Title: [redacted]",
+      "",
+      "## Page snapshot",
+      "[redacted because this BrowserSession exceeded the sensitive-value safety limit]",
+    ].join("\n");
+  }
 
   const sections: string[] = [];
   for (const notice of takeSessionNotices(sessionId)) {
@@ -221,11 +823,20 @@ async function pageSnapshot(p: Page, sessionId: string): Promise<string> {
         `(outline capped at ${SNAPSHOT_MAX_LINES} of ${total} elements — deeper elements are omitted from this snapshot. This is a full-page outline, so scrolling will not reveal more; narrow down by interacting with a container here, or navigate to a more specific page/URL.)`,
       );
     }
-    return sections.join("\n");
+    return redactVaultSensitiveText(sessionId, sections.join("\n"));
   }
 
   // Aria snapshot came back empty (blank page, or a page still rendering).
   // Fall back to raw visible text so the model isn't left with nothing.
+  if (vaultTaintedSessions.has(sessionId)) {
+    return [
+      `URL: ${url}`,
+      "Title: [redacted]",
+      "",
+      "## Visible text",
+      "[redacted because this BrowserSession has contained a password]",
+    ].join("\n");
+  }
   let bodyText = "";
   try {
     bodyText = await p.evaluate(() => (document.body?.innerText ?? "").slice(0, 16_384));
@@ -239,7 +850,7 @@ async function pageSnapshot(p: Page, sessionId: string): Promise<string> {
       "(empty — the page may still be rendering; call browser_wait or browser_snapshot to retry)",
   );
   if (truncated) sections.push(`(truncated to first ${TEXT_MAX_BYTES} bytes)`);
-  return sections.join("\n");
+  return redactVaultSensitiveText(sessionId, sections.join("\n"));
 }
 
 /**
@@ -257,7 +868,7 @@ async function locate(p: Page, sessionId: string, selector: string): Promise<Loc
   } catch (err) {
     // Distinguish "nothing matched in time" from a malformed selector —
     // Playwright reports the latter with a parse error worth relaying.
-    const raw = errText(err);
+    const raw = safeBrowserError(sessionId, err);
     const timedOut = raw.includes("Timeout");
     let snap = "";
     try {
@@ -348,10 +959,42 @@ async function settle(p: Page): Promise<void> {
   }
 }
 
+export async function rememberCurrentPasswordValues(page: Page, sessionId: string): Promise<void> {
+  const observations = await Promise.all(
+    page.frames().map((frame) =>
+      frame
+        .evaluate(() => {
+          const inputs: HTMLInputElement[] = [];
+          const visit = (root: Document | ShadowRoot) => {
+            for (const element of root.querySelectorAll("*")) {
+              if (element instanceof HTMLInputElement && element.type === "password") {
+                inputs.push(element);
+              }
+              if (element.shadowRoot) visit(element.shadowRoot);
+            }
+          };
+          visit(document);
+          return { present: inputs.length > 0, values: inputs.map((input) => input.value) };
+        })
+        // Failure to inspect a frame must not make it safe to expose textbox
+        // values or screenshots. Taint the session and fail closed.
+        .catch(() => ({ present: true, values: [] as string[] })),
+    ),
+  );
+  for (const observation of observations) {
+    if (observation.present) vaultTaintedSessions.add(sessionId);
+    for (const value of observation.values) rememberVaultSensitiveValue(sessionId, value);
+  }
+}
+
 async function bumpAndAcquire(req: BrowserRpcReq): Promise<Page> {
   const session = req.browserSession!;
   markActivity(session.id);
   const page = (await acquirePage(session.id)) as Page;
+  // Observe password fields before any model action can click a reveal
+  // control or otherwise mutate their type/value. Values stay scrubbed for
+  // the lifetime of this BrowserSession.
+  await rememberCurrentPasswordValues(page, session.id);
   await markSessionLive(session.id);
   return page;
 }
@@ -368,6 +1011,24 @@ function currentPage(sessionId: string, fallback: Page): Page {
 
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function safeBrowserError(sessionId: string, err: unknown): string {
+  if (vaultSensitiveOverflowSessions.has(sessionId)) {
+    return "Browser action failed after sensitive page data was redacted";
+  }
+  return redactVaultSensitiveText(sessionId, errText(err));
+}
+
+/** Model-visible snapshots need origin context, not token-bearing URL details. */
+export function safeBrowserUrlForModel(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "(unavailable)";
+    return url.origin;
+  } catch {
+    return "(unavailable)";
+  }
 }
 
 // ---------- routes ----------
@@ -391,7 +1052,7 @@ browserRpcRouter.post("/open", validateBody(openSchema), async (req: BrowserRpcR
     await settle(page);
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -401,7 +1062,7 @@ browserRpcRouter.post("/snapshot", async (req: BrowserRpcReq, res) => {
     const page = await bumpAndAcquire(req);
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -420,22 +1081,174 @@ browserRpcRouter.post("/url", async (req: BrowserRpcReq, res) => {
   res.json({ url: session.pageUrl ?? "", title: session.pageTitle ?? null });
 });
 
-const clickSchema = z.object({ selector: z.string().min(1).max(500) });
+const describeApprovalTargetSchema = z
+  .object({
+    action: z.enum(["submit", "vault_capture"]),
+    selector: z.string().min(1).max(500),
+    key: browserModelPressKeySchema.nullable().optional(),
+  })
+  .strict();
+
+browserRpcRouter.post(
+  "/approval/describe-target",
+  validateBody(describeApprovalTargetSchema),
+  async (req: BrowserRpcReq, res) => {
+    const body = req.body as z.infer<typeof describeApprovalTargetSchema>;
+    const session = req.browserSession!;
+    const employee = req.browserEmployee!;
+    try {
+      const page = await bumpAndAcquire(req);
+      const target = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: body.action,
+        selector: body.selector,
+        key: body.key ?? null,
+      });
+      if (body.action === "vault_capture") {
+        if (
+          target.descriptor.inputType !== "password" ||
+          !vaultWebsiteMatchesPage(page.url(), target.descriptor.frameUrl)
+        ) {
+          throw new VaultError(
+            "Vault capture requires a same-origin input with type=password",
+            400,
+          );
+        }
+        assertVaultBrowserPolicy(employee, page.url(), target.descriptor.frameUrl);
+        if (!target.sensitiveValue) {
+          throw new VaultError("The selected password field is empty", 400);
+        }
+        if (target.sensitiveValue.length > 10_000) {
+          throw new VaultError("The selected password is too long", 400);
+        }
+      }
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        pageUrl: safeBrowserApprovalTargetUrl(page.url()),
+        targetFingerprint: target.fingerprint,
+        targetDescriptor: target.descriptor,
+      });
+    } catch (error) {
+      if (error instanceof VaultError || error instanceof BrowserApprovalError) {
+        return res.status(error.statusCode).json({ error: error.message });
+      }
+      res.status(500).json({ error: safeBrowserError(session.id, error) });
+    }
+  },
+);
+
+const clickSchema = z
+  .object({
+    selector: z.string().min(1).max(500),
+    approvalId: z.string().uuid().optional(),
+  })
+  .strict();
 browserRpcRouter.post("/click", validateBody(clickSchema), async (req: BrowserRpcReq, res) => {
   const body = req.body as z.infer<typeof clickSchema>;
-  const sessionId = req.browserSession!.id;
+  const session = req.browserSession!;
+  const employee = req.browserEmployee!;
+  let claimId: string | null = null;
+  let actionAttempted = false;
+  let guardedPage: Page | null = null;
   try {
     const page = await bumpAndAcquire(req);
-    const loc = await locate(page, sessionId, body.selector);
-    await loc.click({ timeout: ACTION_TIMEOUT_MS });
+    if (!employee.browserApprovalRequired && !body.approvalId) {
+      const loc = await locate(page, session.id, body.selector);
+      await loc.click({ timeout: ACTION_TIMEOUT_MS });
+    } else {
+      let target = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: "submit",
+        selector: body.selector,
+        key: null,
+      });
+      if (!body.approvalId && browserClickMaySubmit(target.descriptor)) {
+        throw new BrowserApprovalError(
+          "This click can submit a form and requires browser_submit approval",
+          409,
+        );
+      }
+      if (!body.approvalId) {
+        await armUnapprovedFormSubmitGuard(page);
+        guardedPage = page;
+      }
+      if (body.approvalId) {
+        const claimed = await claimBrowserActionApproval({
+          approvalId: body.approvalId,
+          companyId: session.companyId,
+          employeeId: employee.id,
+          browserSessionId: session.id,
+          action: "submit",
+          selector: body.selector,
+          key: null,
+          targetFingerprint: target.fingerprint,
+          targetDescriptor: target.descriptor,
+        });
+        claimId = claimed.claimId;
+        const revalidated = await inspectBrowserApprovalTarget({
+          page,
+          session,
+          employee,
+          action: "submit",
+          selector: body.selector,
+          key: null,
+          handle: target.handle,
+        });
+        if (
+          revalidated.fingerprint !== target.fingerprint ||
+          JSON.stringify(revalidated.descriptor) !== JSON.stringify(target.descriptor)
+        ) {
+          throw new BrowserApprovalError(
+            "Browser target changed while the approval was being claimed",
+            409,
+          );
+        }
+        target = revalidated;
+      }
+      if (claimId) actionAttempted = true;
+      await target.handle.click({ timeout: ACTION_TIMEOUT_MS });
+      if (body.approvalId && claimId) {
+        await settleBrowserActionApproval({
+          approvalId: body.approvalId,
+          claimId,
+          succeeded: true,
+        });
+        claimId = null;
+      }
+    }
     await settle(page);
+    if (guardedPage) {
+      const blocked = await disarmUnapprovedFormSubmitGuard(guardedPage);
+      guardedPage = null;
+      if (blocked) {
+        throw new BrowserApprovalError(
+          "This click attempted to submit a form and requires browser_submit approval",
+          409,
+        );
+      }
+    }
     // A click can open a new tab; wait for it to be adopted so we snapshot
     // the page the model will act on next, not the one it just left.
-    await awaitAdoption(sessionId, ADOPTION_WAIT_MS);
-    const p = currentPage(sessionId, page);
-    res.json({ snapshot: await pageSnapshot(p, sessionId) });
+    await awaitAdoption(session.id, ADOPTION_WAIT_MS);
+    const p = currentPage(session.id, page);
+    res.json({ snapshot: await pageSnapshot(p, session.id) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    if (guardedPage) await disarmUnapprovedFormSubmitGuard(guardedPage);
+    if (body.approvalId && claimId) {
+      await settleBrowserActionApproval({
+        approvalId: body.approvalId,
+        claimId,
+        succeeded: actionAttempted,
+      }).catch(() => undefined);
+    }
+    if (err instanceof BrowserApprovalError) {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+    res.status(500).json({ error: safeBrowserError(session.id, err) });
   }
 });
 
@@ -452,31 +1265,332 @@ browserRpcRouter.post("/fill", validateBody(fillSchema), async (req: BrowserRpcR
     await loc.fill(body.value, { timeout: ACTION_TIMEOUT_MS });
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
-const pressSchema = z.object({
-  key: z.string().min(1).max(60),
-  selector: z.string().max(500).optional(),
-});
+const vaultFillSchema = z
+  .object({
+    selector: z.string().min(1).max(500),
+    itemId: z.string().uuid(),
+    field: z.enum(["username", "secret"]),
+  })
+  .strict();
+
+browserRpcRouter.post(
+  "/vault/fill",
+  validateBody(vaultFillSchema),
+  async (req: BrowserRpcReq, res) => {
+    const body = req.body as z.infer<typeof vaultFillSchema>;
+    const session = req.browserSession!;
+    const employee = req.browserEmployee!;
+    try {
+      const page = await bumpAndAcquire(req);
+      const loc = await locate(page, session.id, body.selector);
+      const targetHandle = await resolveVaultTarget(loc);
+      await describeVaultTarget(targetHandle);
+      // Resolve the live Grant only after the target exists, then inspect the
+      // target again immediately before filling. A navigation detaches the
+      // locator or changes its frame URL and therefore fails closed.
+      const resolved = await getVaultItemPayloadForEmployee({
+        companyId: session.companyId,
+        employeeId: employee.id,
+        itemId: body.itemId,
+        required: "use",
+      });
+      const target = await describeVaultTarget(targetHandle);
+      if (
+        !vaultWebsiteMatchesPage(resolved.payload.websiteUrl, page.url()) ||
+        !vaultWebsiteMatchesPage(resolved.payload.websiteUrl, target.frameUrl)
+      ) {
+        throw new VaultError(
+          "Vault origin mismatch: this login can only be used in its exact saved origin",
+          403,
+        );
+      }
+      assertVaultBrowserPolicy(employee, page.url(), target.frameUrl);
+      if (!vaultFillTargetIsAllowed(resolved.item.type, body.field, target.inputType)) {
+        throw new VaultError(
+          body.field === "secret"
+            ? "Only a Vault login can fill its password into an input with type=password"
+            : "That Vault field cannot be filled into the selected element",
+          400,
+        );
+      }
+      const value = resolved.payload[body.field];
+      if (!value) throw new VaultError(`This Vault login has no ${body.field} saved`, 400);
+      if (body.field === "secret") rememberVaultSensitiveValue(session.id, value);
+      await targetHandle.fill(value, { timeout: ACTION_TIMEOUT_MS });
+      await recordAudit({
+        companyId: session.companyId,
+        actorEmployeeId: employee.id,
+        action: "vault.item.use",
+        targetType: "vault_item",
+        targetId: resolved.item.id,
+        targetLabel: "Vault item",
+        metadata: { field: body.field },
+      });
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        ok: true,
+        message: `Filled the ${body.field === "secret" ? "stored value" : "username"} field from Vault. The value was not revealed.`,
+      });
+    } catch (err) {
+      if (err instanceof VaultError) {
+        return res.status(err.statusCode).json({ error: err.message });
+      }
+      res.status(500).json({
+        error:
+          body.field === "secret"
+            ? "Vault password fill failed without revealing the stored value"
+            : safeBrowserError(session.id, err),
+      });
+    }
+  },
+);
+
+const vaultCaptureLoginSchema = z
+  .object({
+    approvalId: z.string().uuid(),
+    selector: z.string().min(1).max(500),
+    title: z.string().trim().min(1).max(255),
+    username: z.string().trim().max(500).default(""),
+    notes: z.string().trim().max(10_000).default(""),
+  })
+  .strict();
+
+browserRpcRouter.post(
+  "/vault/capture-login",
+  validateBody(vaultCaptureLoginSchema),
+  async (req: BrowserRpcReq, res) => {
+    const body = req.body as z.infer<typeof vaultCaptureLoginSchema>;
+    const session = req.browserSession!;
+    const employee = req.browserEmployee!;
+    let claimId: string | null = null;
+    let actionAttempted = false;
+    try {
+      const page = await bumpAndAcquire(req);
+      let target = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: "vault_capture",
+        selector: body.selector,
+        key: null,
+      });
+      if (
+        target.descriptor.inputType !== "password" ||
+        !vaultWebsiteMatchesPage(page.url(), target.descriptor.frameUrl)
+      ) {
+        throw new VaultError("Vault capture requires a same-origin input with type=password", 400);
+      }
+      assertVaultBrowserPolicy(employee, page.url(), target.descriptor.frameUrl);
+      const claimed = await claimBrowserActionApproval({
+        approvalId: body.approvalId,
+        companyId: session.companyId,
+        employeeId: employee.id,
+        browserSessionId: session.id,
+        action: "vault_capture",
+        selector: body.selector,
+        key: null,
+        targetFingerprint: target.fingerprint,
+        targetDescriptor: target.descriptor,
+        vaultTitle: body.title,
+        vaultUsername: body.username,
+        vaultNotes: body.notes,
+      });
+      claimId = claimed.claimId;
+      const revalidated = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: "vault_capture",
+        selector: body.selector,
+        key: null,
+        handle: target.handle,
+      });
+      if (
+        revalidated.fingerprint !== target.fingerprint ||
+        JSON.stringify(revalidated.descriptor) !== JSON.stringify(target.descriptor) ||
+        revalidated.descriptor.inputType !== "password" ||
+        !vaultWebsiteMatchesPage(page.url(), revalidated.descriptor.frameUrl)
+      ) {
+        throw new VaultError("The password target changed before it could be captured", 409);
+      }
+      target = revalidated;
+      assertVaultBrowserPolicy(employee, page.url(), target.descriptor.frameUrl);
+      const secret = target.sensitiveValue ?? "";
+      if (!secret) throw new VaultError("The selected password field is empty", 400);
+      if (secret.length > 10_000) throw new VaultError("The selected password is too long", 400);
+      rememberVaultSensitiveValue(session.id, secret);
+      actionAttempted = true;
+      const item = await createVaultLoginForEmployee({
+        companyId: session.companyId,
+        employeeId: employee.id,
+        title: body.title,
+        username: body.username,
+        secret,
+        websiteUrl: safeVaultWebsiteUrl(target.descriptor.frameUrl),
+        notes: body.notes,
+        visibility: "restricted",
+      });
+      await settleBrowserActionApproval({
+        approvalId: body.approvalId,
+        claimId,
+        succeeded: true,
+      });
+      claimId = null;
+      await recordAudit({
+        companyId: session.companyId,
+        actorEmployeeId: employee.id,
+        action: "vault.item.create",
+        targetType: "vault_item",
+        targetId: item.id,
+        targetLabel: "Vault item",
+        metadata: { via: "browser_capture" },
+      });
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        ok: true,
+        itemId: item.id,
+        message: `Saved "${item.title}" to Vault with a manage Grant. The captured password was not revealed.`,
+      });
+    } catch (err) {
+      if (claimId) {
+        await settleBrowserActionApproval({
+          approvalId: body.approvalId,
+          claimId,
+          succeeded: actionAttempted,
+        }).catch(() => undefined);
+      }
+      if (err instanceof VaultError) {
+        return res.status(err.statusCode).json({ error: err.message });
+      }
+      if (err instanceof BrowserApprovalError) {
+        return res.status(err.statusCode).json({ error: err.message });
+      }
+      res.status(500).json({
+        error: "Vault password capture failed without revealing the selected value",
+      });
+    }
+  },
+);
+
+const pressSchema = z
+  .object({
+    key: browserModelPressKeySchema,
+    selector: z.string().max(500).optional(),
+    approvalId: z.string().uuid().optional(),
+  })
+  .strict();
 browserRpcRouter.post("/press", validateBody(pressSchema), async (req: BrowserRpcReq, res) => {
   const body = req.body as z.infer<typeof pressSchema>;
-  const sessionId = req.browserSession!.id;
+  const session = req.browserSession!;
+  const employee = req.browserEmployee!;
+  let claimId: string | null = null;
+  let actionAttempted = false;
+  let guardedPage: Page | null = null;
   try {
     const page = await bumpAndAcquire(req);
-    if (body.selector && body.selector.length > 0) {
-      const loc = await locate(page, sessionId, body.selector);
-      await loc.press(body.key, { timeout: ACTION_TIMEOUT_MS });
+    if (employee.browserApprovalRequired && browserKeyMaySubmit(body.key) && !body.approvalId) {
+      throw new BrowserApprovalError(
+        "Pressing Enter or Space can submit a form and requires browser_submit approval",
+        409,
+      );
+    }
+    if (body.approvalId) {
+      if (!body.selector) {
+        throw new BrowserApprovalError(
+          "An approved browser key action must remain bound to its selector",
+          409,
+        );
+      }
+      let target = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: "submit",
+        selector: body.selector,
+        key: body.key,
+      });
+      const claimed = await claimBrowserActionApproval({
+        approvalId: body.approvalId,
+        companyId: session.companyId,
+        employeeId: employee.id,
+        browserSessionId: session.id,
+        action: "submit",
+        selector: body.selector,
+        key: body.key,
+        targetFingerprint: target.fingerprint,
+        targetDescriptor: target.descriptor,
+      });
+      claimId = claimed.claimId;
+      const revalidated = await inspectBrowserApprovalTarget({
+        page,
+        session,
+        employee,
+        action: "submit",
+        selector: body.selector,
+        key: body.key,
+        handle: target.handle,
+      });
+      if (
+        revalidated.fingerprint !== target.fingerprint ||
+        JSON.stringify(revalidated.descriptor) !== JSON.stringify(target.descriptor)
+      ) {
+        throw new BrowserApprovalError(
+          "Browser target changed while the approval was being claimed",
+          409,
+        );
+      }
+      target = revalidated;
+      actionAttempted = true;
+      await target.handle.press(body.key, { timeout: ACTION_TIMEOUT_MS });
+      await settleBrowserActionApproval({
+        approvalId: body.approvalId,
+        claimId,
+        succeeded: true,
+      });
+      claimId = null;
     } else {
-      await page.keyboard.press(body.key);
+      if (employee.browserApprovalRequired) {
+        await armUnapprovedFormSubmitGuard(page);
+        guardedPage = page;
+      }
+      if (body.selector && body.selector.length > 0) {
+        const loc = await locate(page, session.id, body.selector);
+        await loc.press(body.key, { timeout: ACTION_TIMEOUT_MS });
+      } else {
+        await page.keyboard.press(body.key);
+      }
     }
     await settle(page);
-    await awaitAdoption(sessionId, ADOPTION_WAIT_MS);
-    const p = currentPage(sessionId, page);
-    res.json({ snapshot: await pageSnapshot(p, sessionId) });
+    if (guardedPage) {
+      const blocked = await disarmUnapprovedFormSubmitGuard(guardedPage);
+      guardedPage = null;
+      if (blocked) {
+        throw new BrowserApprovalError(
+          "This key action attempted to submit a form and requires browser_submit approval",
+          409,
+        );
+      }
+    }
+    await awaitAdoption(session.id, ADOPTION_WAIT_MS);
+    const p = currentPage(session.id, page);
+    res.json({ snapshot: await pageSnapshot(p, session.id) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    if (guardedPage) await disarmUnapprovedFormSubmitGuard(guardedPage);
+    if (body.approvalId && claimId) {
+      await settleBrowserActionApproval({
+        approvalId: body.approvalId,
+        claimId,
+        succeeded: actionAttempted,
+      }).catch(() => undefined);
+    }
+    if (err instanceof BrowserApprovalError) {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+    res.status(500).json({ error: safeBrowserError(session.id, err) });
   }
 });
 
@@ -508,7 +1622,7 @@ browserRpcRouter.post("/select", validateBody(selectSchema), async (req: Browser
     await settle(page);
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -523,7 +1637,7 @@ browserRpcRouter.post("/hover", validateBody(hoverSchema), async (req: BrowserRp
     await settle(page);
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -547,7 +1661,7 @@ browserRpcRouter.post("/scroll", validateBody(scrollSchema), async (req: Browser
     await settle(page);
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -563,7 +1677,7 @@ browserRpcRouter.post("/back", async (req: BrowserRpcReq, res) => {
     }
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -585,19 +1699,42 @@ browserRpcRouter.post("/wait", validateBody(waitSchema), async (req: BrowserRpcR
     }
     res.json({ snapshot: await pageSnapshot(page, sessionId) });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
 browserRpcRouter.post("/screenshot", async (req: BrowserRpcReq, res) => {
+  const sessionId = req.browserSession!.id;
+  if (vaultTaintedSessions.has(sessionId)) {
+    return res.status(409).json({
+      error:
+        "Screenshot unavailable after a password is present in this browser session; use the redacted page snapshot instead",
+    });
+  }
   try {
     const page = await bumpAndAcquire(req);
+    if (vaultTaintedSessions.has(sessionId)) {
+      return res.status(409).json({
+        error:
+          "Screenshot unavailable after a password is present in this browser session; use the redacted page snapshot instead",
+      });
+    }
     // JPEG at the same quality as the live-view screencast — 3-5x smaller
     // than PNG in the model's context for visually identical content.
-    const buf = await page.screenshot({ type: "jpeg", quality: 60, fullPage: false });
+    // Mask every password input in every frame at capture time. This also
+    // protects a password typed by a human immediately before the first
+    // semantic snapshot has had a chance to observe and taint the session.
+    const passwordMasks = page.frames().map((frame) => frame.locator('input[type="password"]'));
+    const buf = await page.screenshot({
+      type: "jpeg",
+      quality: 60,
+      fullPage: false,
+      mask: passwordMasks,
+      maskColor: "#000000",
+    });
     res.json({ data: buf.toString("base64"), mimeType: "image/jpeg" });
   } catch (err) {
-    res.status(500).json({ error: errText(err) });
+    res.status(500).json({ error: safeBrowserError(req.browserSession!.id, err) });
   }
 });
 
@@ -607,10 +1744,14 @@ browserRpcRouter.post("/close", async (req: BrowserRpcReq, res) => {
   // panel shouldn't be stomped by a model that decides to call
   // browser_close at the end of its turn.
   const runtime = getRuntime(session.id);
-  if (!runtime) return res.json({ ok: true });
+  if (!runtime) {
+    clearVaultSensitiveValuesForSession(session.id);
+    return res.json({ ok: true });
+  }
   if (runtime.activeHolders > 0) {
     return res.json({ ok: true, kept: "viewer-active" });
   }
   await releasePage(session.id, "shutdown");
+  clearVaultSensitiveValuesForSession(session.id);
   res.json({ ok: true });
 });

--- a/App/server/routes/browserSessions.ts
+++ b/App/server/routes/browserSessions.ts
@@ -12,7 +12,7 @@ import {
   requireCompanyRole,
 } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
-import { mintWsToken } from "../services/realtime.js";
+import { mintBrowserViewerWsToken } from "../services/realtime.js";
 import { closeBrowserSession, getSessionSnapshot } from "../services/browserSessions.js";
 
 type ScopedParams = { cid: string; eid: string; id?: string };
@@ -30,6 +30,12 @@ browserSessionsRouter.use(requireAuth);
 browserSessionsRouter.use(requireCompanyMember);
 browserSessionsRouter.use(requireBrowserSession);
 browserSessionsRouter.use(requireCompanyRole("admin"));
+browserSessionsRouter.use((req, res, next) => {
+  if (req.apiKey) {
+    return res.status(403).json({ error: "A logged-in Member is required" });
+  }
+  next();
+});
 
 function serializeSession(row: BrowserSession) {
   const snap = getSessionSnapshot(row.id);
@@ -100,7 +106,7 @@ browserSessionsRouter.post("/:id/ws-token", async (req: ScopedReq, res) => {
   });
   if (!row) return res.status(404).json({ error: "Not found" });
   if (!req.userId) return res.status(401).json({ error: "Unauthorized" });
-  const token = await mintWsToken(req.userId, req.params.cid);
+  const token = await mintBrowserViewerWsToken(req.userId, req.params.cid, req.params.eid, row.id);
   res.json({ token });
 });
 

--- a/App/server/routes/browserVault.test.ts
+++ b/App/server/routes/browserVault.test.ts
@@ -1,0 +1,558 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { describe, it } from "node:test";
+import { chromium } from "playwright-core";
+
+import {
+  armUnapprovedFormSubmitGuard,
+  browserClickMaySubmit,
+  browserKeyMaySubmit,
+  browserModelPressKeyIsAllowed,
+  browserModelPressKeySchema,
+  clearVaultSensitiveValuesForSession,
+  disarmUnapprovedFormSubmitGuard,
+  inspectBrowserApprovalTarget,
+  observeBrowserSensitiveValue,
+  pageSnapshot,
+  redactPasswordInputsFromSnapshot,
+  redactVaultSensitiveText,
+  rememberCurrentPasswordValues,
+  safeBrowserUrlForModel,
+  vaultFillTargetIsAllowed,
+  vaultUrlAllowedForEmployee,
+  vaultWebsiteMatchesPage,
+} from "./browserRpc.js";
+
+function chromiumExecutablePath(): string | undefined {
+  return [
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    chromium.executablePath(),
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ]
+    .filter((value): value is string => Boolean(value))
+    .find((value) => existsSync(value));
+}
+
+describe("Vault browser hostname binding", () => {
+  it("allows the exact saved origin across paths", () => {
+    assert.equal(
+      vaultWebsiteMatchesPage(
+        "https://accounts.example.com/login",
+        "https://accounts.example.com/settings?next=1",
+      ),
+      true,
+    );
+  });
+
+  it("rejects scheme and port changes", () => {
+    assert.equal(
+      vaultWebsiteMatchesPage("http://accounts.example.com", "https://accounts.example.com"),
+      false,
+    );
+    assert.equal(
+      vaultWebsiteMatchesPage("https://accounts.example.com", "http://accounts.example.com"),
+      false,
+    );
+    assert.equal(
+      vaultWebsiteMatchesPage("https://accounts.example.com", "https://accounts.example.com:8443"),
+      false,
+    );
+  });
+
+  it("rejects sibling, parent and lookalike hosts", () => {
+    assert.equal(
+      vaultWebsiteMatchesPage("https://accounts.example.com", "https://example.com"),
+      false,
+    );
+    assert.equal(
+      vaultWebsiteMatchesPage("https://example.com", "https://accounts.example.com"),
+      false,
+    );
+    assert.equal(
+      vaultWebsiteMatchesPage("https://example.com", "https://example.com.attacker.test"),
+      false,
+    );
+  });
+
+  it("rejects non-http schemes and malformed URLs", () => {
+    assert.equal(vaultWebsiteMatchesPage("javascript:alert(1)", "https://example.com"), false);
+    assert.equal(vaultWebsiteMatchesPage("https://example.com", "not a url"), false);
+  });
+});
+
+describe("Vault browser fill target", () => {
+  it("only puts login passwords into password inputs", () => {
+    assert.equal(vaultFillTargetIsAllowed("login", "secret", "password"), true);
+    assert.equal(vaultFillTargetIsAllowed("login", "secret", "PASSWORD"), true);
+    assert.equal(vaultFillTargetIsAllowed("login", "secret", "text"), false);
+    assert.equal(vaultFillTargetIsAllowed("login", "secret", null), false);
+  });
+
+  it("allows usernames but rejects non-login secret targets", () => {
+    assert.equal(vaultFillTargetIsAllowed("login", "username", "email"), true);
+    assert.equal(vaultFillTargetIsAllowed("api_key", "secret", "text"), false);
+    assert.equal(vaultFillTargetIsAllowed("secure_note", "secret", "textarea"), false);
+  });
+
+  it("intersects Vault use with the AI Employee Browser host policy", () => {
+    assert.equal(vaultUrlAllowedForEmployee("https://accounts.example.com", null), true);
+    assert.equal(
+      vaultUrlAllowedForEmployee(
+        "https://accounts.example.com/login",
+        "accounts.example.com\nmail.example.com",
+      ),
+      true,
+    );
+    assert.equal(
+      vaultUrlAllowedForEmployee("https://accounts.example.com", "mail.example.com"),
+      false,
+    );
+  });
+});
+
+describe("Browser model-visible URL", () => {
+  it("omits userinfo, path, query, and fragment tokens", () => {
+    assert.equal(
+      safeBrowserUrlForModel(
+        "https://user:secret@example.com/reset/path-token?code=query-token#fragment-token",
+      ),
+      "https://example.com",
+    );
+  });
+});
+
+describe("Browser approval target binding", () => {
+  it("treats submit-capable keys and button semantics as approval-required", () => {
+    assert.equal(browserKeyMaySubmit("Enter"), true);
+    assert.equal(browserKeyMaySubmit("Control+NumpadEnter"), true);
+    assert.equal(browserKeyMaySubmit("Space"), true);
+    assert.equal(browserKeyMaySubmit("Tab"), false);
+    assert.equal(
+      browserClickMaySubmit({
+        tagName: "button",
+        inputType: "button",
+        frameUrl: "https://example.test/login",
+        formAction: null,
+        formMethod: null,
+        submitsForm: true,
+      }),
+      true,
+    );
+  });
+
+  it("allows only plain model keypresses and rejects clipboard or context-menu input", () => {
+    for (const key of [
+      "Enter",
+      "NumpadEnter",
+      "Tab",
+      "Escape",
+      "ArrowDown",
+      "ArrowUp",
+      "Home",
+      "End",
+      "Backspace",
+      "Delete",
+      "Space",
+    ]) {
+      assert.equal(browserModelPressKeyIsAllowed(key), true, key);
+      assert.equal(browserModelPressKeySchema.safeParse(key).success, true, key);
+    }
+
+    for (const key of [
+      "Control+C",
+      "Meta+C",
+      "Control+Insert",
+      "Shift+Insert",
+      "Control+Shift+V",
+      "ControlOrMeta+C",
+      "Copy",
+      "Cut",
+      "Paste",
+      "ContextMenu",
+      "Apps",
+      "Shift+F10",
+      "Control",
+      "Meta",
+      "F10",
+      "c",
+    ]) {
+      assert.equal(browserModelPressKeyIsAllowed(key), false, key);
+      assert.equal(browserModelPressKeySchema.safeParse(key).success, false, key);
+    }
+  });
+
+  it("blocks a clipboard chord before it reaches real Chromium while plain Tab still works", async (t) => {
+    const executablePath = chromiumExecutablePath();
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the keypress boundary test");
+      return;
+    }
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <input id="first">
+        <input id="secret" value="REAL_CHROMIUM_VAULT_PASSWORD">
+        <script>
+          window.clipboardChordEvents = 0;
+          document.addEventListener('keydown', (event) => {
+            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
+              window.clipboardChordEvents += 1;
+            }
+          });
+        </script>
+      `);
+      await page.locator("#first").focus();
+
+      const modelPress = async (key: string) => {
+        browserModelPressKeySchema.parse(key);
+        await page.keyboard.press(key);
+      };
+
+      await modelPress("Tab");
+      assert.equal(await page.evaluate(() => document.activeElement?.id), "secret");
+      await page.locator("#secret").selectText();
+      await assert.rejects(modelPress("Control+C"), /Modifier chords/);
+      assert.equal(
+        await page.evaluate(
+          () => (window as unknown as { clipboardChordEvents: number }).clipboardChordEvents,
+        ),
+        0,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("fingerprints form values without firing page-controlled formdata handlers", async (t) => {
+    const executablePath = chromiumExecutablePath();
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the approval target test");
+      return;
+    }
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.route("https://example.test/login", (route) =>
+        route.fulfill({
+          contentType: "text/html",
+          body: `
+            <form id="login" action="/sessions" method="post">
+              <input id="password" type="password" name="password" value="FIRST_PRIVATE_VALUE">
+              <button id="submit" type="submit" name="intent" value="login">Sign in</button>
+            </form>
+            <script>
+              window.formdataEvents = 0;
+              window.formdataNetworkAttempts = 0;
+              document.querySelector('#login').addEventListener('formdata', () => {
+                window.formdataEvents += 1;
+                window.formdataNetworkAttempts += 1;
+              });
+            </script>
+          `,
+        }),
+      );
+      await page.goto("https://example.test/login");
+      const handle = await page.locator("#submit").elementHandle();
+      assert.ok(handle);
+      const common = {
+        page: page as never,
+        session: {
+          id: "10000000-0000-4000-8000-000000000001",
+          companyId: "10000000-0000-4000-8000-000000000002",
+        } as never,
+        employee: { id: "10000000-0000-4000-8000-000000000003" } as never,
+        action: "submit" as const,
+        selector: "#submit",
+        key: null,
+        handle: handle as never,
+      };
+      const first = await inspectBrowserApprovalTarget(common);
+      assert.equal(first.descriptor.submitsForm, true);
+      assert.doesNotMatch(JSON.stringify(first), /FIRST_PRIVATE_VALUE/);
+      assert.deepEqual(
+        await page.evaluate(() => ({
+          formdataEvents: (window as unknown as { formdataEvents: number }).formdataEvents,
+          networkAttempts: (window as unknown as { formdataNetworkAttempts: number })
+            .formdataNetworkAttempts,
+        })),
+        { formdataEvents: 0, networkAttempts: 0 },
+      );
+
+      await page.locator("#password").fill("SECOND_PRIVATE_VALUE");
+      const second = await inspectBrowserApprovalTarget(common);
+      assert.notEqual(second.fingerprint, first.fingerprint);
+      assert.doesNotMatch(JSON.stringify(second), /SECOND_PRIVATE_VALUE/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("blocks requestSubmit inside an iframe while an unapproved action runs", async (t) => {
+    const executablePath = chromiumExecutablePath();
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the iframe submit-guard test");
+      return;
+    }
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <iframe srcdoc='<form id="f"><button id="go" type="button" onclick="this.form.requestSubmit()">Go</button></form>'></iframe>
+      `);
+      const frame = page.locator("iframe").contentFrame();
+      await frame.locator("#go").waitFor();
+      await armUnapprovedFormSubmitGuard(page as never);
+      await frame.locator("#go").click();
+      assert.equal(await disarmUnapprovedFormSubmitGuard(page as never), true);
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+describe("Browser snapshot password redaction", () => {
+  it("removes top-level and framed password values while retaining ordinary inputs", async () => {
+    const tree = [
+      "- generic [active] [ref=e1]:",
+      '  - textbox "Text" [ref=e2]: ordinary value',
+      '  - textbox "Password" [ref=e3]: TOP_PASSWORD_SECRET',
+      "  - iframe [ref=e4]:",
+      '    - textbox "Frame password" [ref=f1e2]: FRAME_PASSWORD_SECRET',
+    ].join("\n");
+    const fields: Record<string, { type: string; value: string }> = {
+      e2: { type: "text", value: "ordinary value" },
+      e3: { type: "password", value: "TOP_PASSWORD_SECRET" },
+      f1e2: { type: "password", value: "FRAME_PASSWORD_SECRET" },
+    };
+    const fakePage = {
+      locator(selector: string) {
+        const ref = selector.replace("aria-ref=", "");
+        const field = fields[ref];
+        return {
+          first: () => ({
+            elementHandle: async () =>
+              field
+                ? {
+                    getAttribute: async () => field.type,
+                    inputValue: async () => field.value,
+                  }
+                : null,
+          }),
+        };
+      },
+    };
+
+    const redacted = await redactPasswordInputsFromSnapshot(
+      fakePage as never,
+      "browser-redaction-test",
+      tree,
+    );
+    assert.doesNotMatch(redacted, /ordinary value/);
+    assert.doesNotMatch(redacted, /TOP_PASSWORD_SECRET|FRAME_PASSWORD_SECRET/);
+    assert.equal((redacted.match(/\[redacted password\]/g) ?? []).length, 3);
+
+    const laterOutput = redactVaultSensitiveText(
+      "browser-redaction-test",
+      'Playwright fill("TOP_PASSWORD_SECRET") and reflected FRAME_PASSWORD_SECRET',
+    );
+    assert.doesNotMatch(laterOutput, /TOP_PASSWORD_SECRET|FRAME_PASSWORD_SECRET/);
+    clearVaultSensitiveValuesForSession("browser-redaction-test");
+  });
+
+  it("fails closed when a textbox ref cannot be resolved", async () => {
+    const fakePage = {
+      locator: () => ({ first: () => ({ elementHandle: async () => null }) }),
+    };
+    const redacted = await redactPasswordInputsFromSnapshot(
+      fakePage as never,
+      "browser-detached-test",
+      '- textbox "Detached" [ref=e9]: MAYBE_SECRET',
+    );
+    assert.equal(redacted, '- textbox "Detached" [ref=e9]: [redacted password]');
+  });
+
+  it("does not use raw visible-text fallback after a password taints the session", async () => {
+    const sessionId = "browser-empty-aria-fallback-test";
+    observeBrowserSensitiveValue(sessionId, "", "password-present");
+    const snapshot = await pageSnapshot(
+      {
+        url: () => "https://example.com/reset?token=hidden",
+        title: async () => "Reset",
+        ariaSnapshot: async () => "",
+        evaluate: async () => "FALLBACK_PASSWORD_SECRET",
+      } as never,
+      sessionId,
+    );
+    assert.doesNotMatch(snapshot, /FALLBACK_PASSWORD_SECRET/);
+    assert.match(snapshot, /redacted because this BrowserSession has contained a password/);
+    clearVaultSensitiveValuesForSession(sessionId);
+  });
+
+  it("fails closed instead of evicting an older password from the redaction set", async () => {
+    const sessionId = "browser-sensitive-overflow-test";
+    const oldest = "OLDEST_REFLECTED_PASSWORD";
+    let overflowValue = "";
+    for (let index = 0; index < 65; index += 1) {
+      const value = index === 0 ? oldest : `later-password-${index}`;
+      overflowValue = value;
+      observeBrowserSensitiveValue(sessionId, value, "password-value");
+    }
+    const snapshot = await pageSnapshot(
+      {
+        url: () => "https://example.com",
+        title: async () => overflowValue,
+        ariaSnapshot: async () => `- text: ${oldest}`,
+        locator: () => ({ first: () => ({ elementHandle: async () => null }) }),
+      } as never,
+      sessionId,
+    );
+    assert.doesNotMatch(snapshot, /OLDEST_REFLECTED_PASSWORD/);
+    assert.doesNotMatch(snapshot, new RegExp(overflowValue));
+    assert.match(snapshot, /exceeded the sensitive-value safety limit/);
+    assert.doesNotMatch(
+      redactVaultSensitiveText(sessionId, `Playwright error contained ${overflowValue}`),
+      new RegExp(overflowValue),
+    );
+    clearVaultSensitiveValuesForSession(sessionId);
+  });
+
+  it("redacts password values from a real Playwright top page and iframe", async (t) => {
+    const candidates = [
+      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      chromium.executablePath(),
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+    ].filter((value): value is string => Boolean(value));
+    const executablePath = candidates.find((value) => existsSync(value));
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the real-browser redaction test");
+      return;
+    }
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <label>Ordinary <input value="ordinary value"></label>
+        <label>Secret <input type="password" value="TOP_REAL_PASSWORD"></label>
+        <iframe srcdoc='<label>Frame <input type="password" value="FRAME_REAL_PASSWORD"></label>'></iframe>
+      `);
+      await page.locator("iframe").contentFrame().locator("input").waitFor();
+      const raw = await page.locator("body").ariaSnapshot({ mode: "ai" });
+      assert.match(raw, /TOP_REAL_PASSWORD|FRAME_REAL_PASSWORD/);
+
+      const redacted = await redactPasswordInputsFromSnapshot(
+        page as never,
+        "real-browser-redaction-test",
+        raw,
+      );
+      assert.doesNotMatch(redacted, /ordinary value/);
+      assert.doesNotMatch(redacted, /TOP_REAL_PASSWORD|FRAME_REAL_PASSWORD/);
+
+      await page.getByLabel("Ordinary").click();
+      const nextRaw = await page.locator("body").ariaSnapshot({ mode: "ai" });
+      const next = await redactPasswordInputsFromSnapshot(
+        page as never,
+        "real-browser-redaction-test",
+        nextRaw,
+      );
+      assert.doesNotMatch(next, /TOP_REAL_PASSWORD|FRAME_REAL_PASSWORD/);
+      assert.doesNotMatch(
+        redactVaultSensitiveText(
+          "real-browser-redaction-test",
+          'locator.fill("TOP_REAL_PASSWORD") failed after FRAME_REAL_PASSWORD',
+        ),
+        /TOP_REAL_PASSWORD|FRAME_REAL_PASSWORD/,
+      );
+    } finally {
+      clearVaultSensitiveValuesForSession("real-browser-redaction-test");
+      await browser.close();
+    }
+  });
+
+  it("keeps a human-entered password redacted after a show-password toggle", async (t) => {
+    const candidates = [
+      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      chromium.executablePath(),
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+    ].filter((value): value is string => Boolean(value));
+    const executablePath = candidates.find((value) => existsSync(value));
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the real-browser redaction test");
+      return;
+    }
+    const sessionId = "real-browser-human-password-test";
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <label>Password <input id="secret" type="password"></label>
+        <button id="show" onclick="document.querySelector('#secret').type = 'text'">Show</button>
+      `);
+      await page.locator("#secret").fill("HUMAN_TAKEOVER_PASSWORD");
+      await rememberCurrentPasswordValues(page as never, sessionId);
+      await page.locator("#show").click();
+
+      const raw = await page.locator("body").ariaSnapshot({ mode: "ai" });
+      assert.match(raw, /HUMAN_TAKEOVER_PASSWORD/);
+      const semanticRedaction = await redactPasswordInputsFromSnapshot(
+        page as never,
+        sessionId,
+        raw,
+      );
+      const fullyRedacted = redactVaultSensitiveText(sessionId, semanticRedaction);
+      assert.doesNotMatch(fullyRedacted, /HUMAN_TAKEOVER_PASSWORD/);
+    } finally {
+      clearVaultSensitiveValuesForSession(sessionId);
+      await browser.close();
+    }
+  });
+
+  it("keeps a password redacted when a human reveals the empty field before typing", async (t) => {
+    const candidates = [
+      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      chromium.executablePath(),
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+    ].filter((value): value is string => Boolean(value));
+    const executablePath = candidates.find((value) => existsSync(value));
+    if (!executablePath) {
+      t.skip("No Chromium executable is available for the real-browser redaction test");
+      return;
+    }
+    const sessionId = "real-browser-reveal-before-type-test";
+    const browser = await chromium.launch({ headless: true, executablePath });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(`
+        <label>Password <input id="secret" type="password"></label>
+        <button id="show" onclick="document.querySelector('#secret').type = 'text'">Show</button>
+      `);
+      await rememberCurrentPasswordValues(page as never, sessionId);
+      await page.locator("#show").click();
+      await page.locator("#secret").fill("REVEALED_BEFORE_HUMAN_TYPED");
+      observeBrowserSensitiveValue(sessionId, "REVEALED_BEFORE_HUMAN_TYPED", "active-input-value");
+
+      const raw = await page.locator("body").ariaSnapshot({ mode: "ai" });
+      assert.match(raw, /REVEALED_BEFORE_HUMAN_TYPED/);
+      const semanticRedaction = await redactPasswordInputsFromSnapshot(
+        page as never,
+        sessionId,
+        raw,
+      );
+      assert.doesNotMatch(
+        redactVaultSensitiveText(sessionId, semanticRedaction),
+        /REVEALED_BEFORE_HUMAN_TYPED/,
+      );
+    } finally {
+      clearVaultSensitiveValuesForSession(sessionId);
+      await browser.close();
+    }
+  });
+});

--- a/App/server/routes/browserViewerAuth.test.ts
+++ b/App/server/routes/browserViewerAuth.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import crypto, { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import express from "express";
+import { WebSocket } from "ws";
+
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { ApiKey } from "../db/entities/ApiKey.js";
+import { BrowserSession } from "../db/entities/BrowserSession.js";
+import { Company } from "../db/entities/Company.js";
+import { Membership } from "../db/entities/Membership.js";
+import { User } from "../db/entities/User.js";
+import { AppDataSource } from "../db/datasource.js";
+import { ResourceChangeSubscriber } from "../db/subscribers/resourceChangeSubscriber.js";
+import { errorHandler } from "../middleware/error.js";
+import { hashApiToken } from "../middleware/auth.js";
+import { attachRealtime, mintBrowserViewerWsToken, mintWsToken } from "../services/realtime.js";
+import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
+import { browserSessionsRouter } from "./browserSessions.js";
+import { browserRpcRouter } from "./browserRpc.js";
+
+let server: Server;
+let baseUrl = "";
+let wsBaseUrl = "";
+let actingUserId: string | null = null;
+let company: Company;
+let owner: User;
+let member: User;
+let employee: AIEmployee;
+let browserSession: BrowserSession;
+
+before(async () => {
+  await initTestDb();
+  AppDataSource.subscribers.push(new ResourceChangeSubscriber());
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { session: unknown }).session = actingUserId
+      ? { userId: actingUserId, sessionVersion: 0 }
+      : null;
+    next();
+  });
+  app.use("/api/companies/:cid/employees/:eid/browser-sessions", browserSessionsRouter);
+  app.use("/api/internal/mcp/browser-sessions/:id", browserRpcRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  attachRealtime(server);
+  const port = (server.address() as AddressInfo).port;
+  baseUrl = `http://127.0.0.1:${port}`;
+  wsBaseUrl = `ws://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  [owner, member] = await Promise.all([
+    insert(User, {
+      email: `viewer-owner-${randomUUID()}@example.com`,
+      name: "Viewer Owner",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+    insert(User, {
+      email: `viewer-member-${randomUUID()}@example.com`,
+      name: "Viewer Member",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+  ]);
+  company = await insert(Company, {
+    name: "Browser Viewer Company",
+    slug: `browser-viewer-${randomUUID()}`,
+    ownerId: owner.id,
+  });
+  await Promise.all([
+    insert(Membership, { companyId: company.id, userId: owner.id, role: "owner" }),
+    insert(Membership, { companyId: company.id, userId: member.id, role: "member" }),
+  ]);
+  employee = await insert(AIEmployee, {
+    companyId: company.id,
+    name: "Browser Employee",
+    slug: `browser-employee-${randomUUID()}`,
+    role: "Operations",
+    browserEnabled: true,
+  });
+  browserSession = await insert(BrowserSession, {
+    companyId: company.id,
+    employeeId: employee.id,
+    conversationId: null,
+    runId: null,
+    mcpToken: crypto.randomBytes(32).toString("hex"),
+    mcpTokenExpiresAt: new Date(Date.now() + 60_000),
+    status: "pending",
+    closeReason: null,
+    pageUrl: "https://example.com",
+    pageTitle: "Example",
+    viewportWidth: 1280,
+    viewportHeight: 800,
+    startedAt: null,
+    closedAt: null,
+  });
+  actingUserId = owner.id;
+});
+
+function viewerPath(token: string): string {
+  return `${wsBaseUrl}/api/companies/${company.id}/employees/${employee.id}/browser-sessions/${browserSession.id}/ws?token=${encodeURIComponent(token)}`;
+}
+
+async function websocketStatus(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    let settled = false;
+    const finish = (status: number) => {
+      if (settled) return;
+      settled = true;
+      resolve(status);
+    };
+    ws.once("open", () => {
+      finish(101);
+      ws.close();
+    });
+    ws.once("unexpected-response", (_request, response) => {
+      response.resume();
+      finish(response.statusCode ?? 0);
+    });
+    ws.once("error", (error) => {
+      if (!settled) reject(error);
+    });
+  });
+}
+
+async function openWebSocket(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+describe("Browser viewer authorization", () => {
+  test("requires a logged-in admin and rejects general API keys", async () => {
+    const listPath = `${baseUrl}/api/companies/${company.id}/employees/${employee.id}/browser-sessions`;
+
+    actingUserId = member.id;
+    assert.equal((await fetch(listPath)).status, 403);
+
+    const tokenBody = crypto.randomBytes(32).toString("base64url");
+    await insert(ApiKey, {
+      companyId: company.id,
+      userId: owner.id,
+      name: "Browser viewer key",
+      prefix: tokenBody.slice(0, 8),
+      tokenHash: hashApiToken(tokenBody),
+    });
+    actingUserId = null;
+    assert.equal(
+      (
+        await fetch(listPath, {
+          headers: { authorization: `Bearer gen_${tokenBody}` },
+        })
+      ).status,
+      403,
+    );
+
+    actingUserId = owner.id;
+    assert.equal((await fetch(listPath)).status, 200);
+  });
+
+  test("accepts only an exact admin viewer token at the WebSocket upgrade", async () => {
+    const genericWorkspaceToken = await mintWsToken(owner.id, company.id);
+    assert.equal(await websocketStatus(viewerPath(genericWorkspaceToken)), 403);
+
+    const forgedMemberViewerToken = await mintBrowserViewerWsToken(
+      member.id,
+      company.id,
+      employee.id,
+      browserSession.id,
+    );
+    assert.equal(await websocketStatus(viewerPath(forgedMemberViewerToken)), 403);
+
+    const response = await fetch(
+      `${baseUrl}/api/companies/${company.id}/employees/${employee.id}/browser-sessions/${browserSession.id}/ws-token`,
+      { method: "POST" },
+    );
+    assert.equal(response.status, 200);
+    const { token } = (await response.json()) as { token: string };
+    assert.equal(await websocketStatus(viewerPath(token)), 101);
+  });
+
+  test("disconnects a live viewer as soon as its company role changes", async () => {
+    const response = await fetch(
+      `${baseUrl}/api/companies/${company.id}/employees/${employee.id}/browser-sessions/${browserSession.id}/ws-token`,
+      { method: "POST" },
+    );
+    const { token } = (await response.json()) as { token: string };
+    const ws = await openWebSocket(viewerPath(token));
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.once("close", (code, reason) => resolve({ code, reason: reason.toString("utf8") }));
+    });
+
+    const membership = await AppDataSource.getRepository(Membership).findOneByOrFail({
+      companyId: company.id,
+      userId: owner.id,
+    });
+    membership.role = "member";
+    await AppDataSource.getRepository(Membership).save(membership);
+
+    const result = await closed;
+    assert.equal(result.code, 1008);
+    assert.match(result.reason, /access changed/i);
+  });
+
+  test("rejects an active session immediately after Browser access is disabled", async () => {
+    employee.browserEnabled = false;
+    await AppDataSource.getRepository(AIEmployee).save(employee);
+    const response = await fetch(
+      `${baseUrl}/api/internal/mcp/browser-sessions/${browserSession.id}/snapshot`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${browserSession.mcpToken}` },
+      },
+    );
+    assert.equal(response.status, 403);
+    assert.match(JSON.stringify(await response.json()), /Browser access is disabled/);
+    assert.equal(
+      (
+        await AppDataSource.getRepository(BrowserSession).findOneByOrFail({
+          id: browserSession.id,
+        })
+      ).status,
+      "closed",
+    );
+  });
+});

--- a/App/server/routes/companies.test.ts
+++ b/App/server/routes/companies.test.ts
@@ -6,13 +6,21 @@ import express from "express";
 import type { Server } from "node:http";
 
 import { AppDataSource } from "../db/datasource.js";
+import { ApiKey } from "../db/entities/ApiKey.js";
 import { Company } from "../db/entities/Company.js";
+import { EmailLog } from "../db/entities/EmailLog.js";
+import { Invitation } from "../db/entities/Invitation.js";
 import { Membership, type Role } from "../db/entities/Membership.js";
 import { Notebook } from "../db/entities/Notebook.js";
 import { User } from "../db/entities/User.js";
+import { hashToken } from "../lib/token.js";
+import { hashApiToken } from "../middleware/auth.js";
 import { errorHandler } from "../middleware/error.js";
 import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
+import { authRouter } from "./auth.js";
 import { companiesRouter } from "./companies.js";
+import { emailLogsRouter } from "./emailLogs.js";
+import { invitationsRouter } from "./invitations.js";
 
 let server: Server;
 let baseUrl: string;
@@ -25,11 +33,18 @@ before(async () => {
   app.use(express.json());
   app.use((req, _res, next) => {
     (req as unknown as { session: unknown }).session = actingUserId
-      ? { userId: actingUserId, sessionVersion: 0 }
+      ? {
+          userId: actingUserId,
+          sessionVersion: 0,
+          authenticatedAt: Date.now(),
+        }
       : null;
     next();
   });
+  app.use("/api/auth", authRouter);
   app.use("/api/companies", companiesRouter);
+  app.use("/api/invitations", invitationsRouter);
+  app.use("/api/companies/:cid/email/logs", emailLogsRouter);
   app.use(errorHandler);
   await new Promise<void>((resolve) => {
     server = app.listen(0, resolve);
@@ -73,14 +88,46 @@ async function call<T = Record<string, unknown>>(
   method: string,
   path: string,
   body?: unknown,
+  headers: Record<string, string> = {},
 ): Promise<ApiResponse<T>> {
   const response = await fetch(`${baseUrl}/api/companies${path}`, {
     method,
-    headers: body === undefined ? {} : { "content-type": "application/json" },
+    headers: body === undefined ? headers : { ...headers, "content-type": "application/json" },
     body: body === undefined ? undefined : JSON.stringify(body),
   });
   const text = await response.text();
   return { status: response.status, body: (text ? JSON.parse(text) : {}) as T };
+}
+
+async function callAbsolute<T = Record<string, unknown>>(
+  method: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string>,
+): Promise<ApiResponse<T>> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { ...headers, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, body: (text ? JSON.parse(text) : {}) as T };
+}
+
+async function ownerApiKeyHeaders(): Promise<Record<string, string>> {
+  const tokenBody = "A".repeat(43);
+  await insert(ApiKey, {
+    companyId: company.id,
+    userId: company.ownerId,
+    name: "Owner automation",
+    prefix: tokenBody.slice(0, 8),
+    tokenHash: hashApiToken(tokenBody),
+    lastUsedAt: new Date(),
+    expiresAt: null,
+    revokedAt: null,
+  });
+  actingUserId = null;
+  return { authorization: `Bearer gen_${tokenBody}` };
 }
 
 describe("company routes", () => {
@@ -204,6 +251,279 @@ describe("company routes", () => {
     assert.equal(await AppDataSource.getRepository(Company).count(), companyCount);
     assert.equal(await AppDataSource.getRepository(Membership).count(), membershipCount);
     assert.equal(await AppDataSource.getRepository(Notebook).count(), notebookCount);
+  });
+
+  test("owner API keys cannot create a company and become an owner Member", async () => {
+    const companyCount = await AppDataSource.getRepository(Company).count();
+    const membershipCount = await AppDataSource.getRepository(Membership).count();
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await call("POST", "", { name: "API-key-owned company" }, headers);
+
+    assert.equal(response.status, 401);
+    assert.equal(await AppDataSource.getRepository(Company).count(), companyCount);
+    assert.equal(await AppDataSource.getRepository(Membership).count(), membershipCount);
+  });
+
+  test("owner API keys cannot invite a Member or receive an invitation token", async () => {
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await call(
+      "POST",
+      `/${company.id}/invitations`,
+      { email: "invitee@example.com" },
+      headers,
+    );
+
+    assert.equal(response.status, 403);
+    assert.equal(await AppDataSource.getRepository(Invitation).count(), 0);
+    assert.equal("token" in response.body, false);
+  });
+
+  test("invitation acceptance links are never exposed through Email Logs", async () => {
+    const invited = await call("POST", `/${company.id}/invitations`, {
+      email: "invitee@example.com",
+    });
+    assert.equal(invited.status, 200);
+    assert.equal("token" in invited.body, false);
+
+    const stored = await AppDataSource.getRepository(EmailLog).findOneByOrFail({
+      companyId: company.id,
+      purpose: "invitation",
+    });
+    assert.doesNotMatch(stored.bodyPreview, /\/invite\//);
+
+    const historicalToken = "historical-raw-invitation-token";
+    const historical = await insert(EmailLog, {
+      companyId: company.id,
+      providerId: null,
+      transport: "console",
+      purpose: "invitation",
+      toAddress: "old-invitee@example.com",
+      fromAddress: "noreply@example.com",
+      subject: "Old invitation",
+      bodyPreview: `Accept the invite: https://example.com/invite/${historicalToken}`,
+      status: "sent",
+      errorMessage: "",
+      messageId: "",
+      triggeredByUserId: company.ownerId,
+    });
+    const detail = await callAbsolute<{ bodyPreview: string }>(
+      "GET",
+      `/api/companies/${company.id}/email/logs/${historical.id}`,
+      undefined,
+      {},
+    );
+    assert.equal(detail.status, 200);
+    assert.doesNotMatch(detail.body.bodyPreview, new RegExp(historicalToken));
+  });
+
+  test("owner API keys cannot read Email Logs", async () => {
+    const rawToken = "raw-invitation-token-in-an-old-log";
+    await insert(EmailLog, {
+      companyId: company.id,
+      providerId: null,
+      transport: "console",
+      purpose: "invitation",
+      toAddress: "invitee@example.com",
+      fromAddress: "noreply@example.com",
+      subject: "Invitation",
+      bodyPreview: `Accept the invite: https://example.com/invite/${rawToken}`,
+      status: "sent",
+      errorMessage: "",
+      messageId: "",
+      triggeredByUserId: company.ownerId,
+    });
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await callAbsolute(
+      "GET",
+      `/api/companies/${company.id}/email/logs/`,
+      undefined,
+      headers,
+    );
+
+    assert.equal(response.status, 403);
+    assert.doesNotMatch(JSON.stringify(response.body), new RegExp(rawToken));
+  });
+
+  test("owner API keys cannot promote Members or change their finance authorization", async () => {
+    const member = await insert(User, {
+      email: "member@example.com",
+      name: "Member",
+      passwordHash: "x",
+      sessionVersion: 0,
+    });
+    await insert(Membership, {
+      companyId: company.id,
+      userId: member.id,
+      role: "member" as Role,
+      financeAccess: "read",
+    });
+    const headers = await ownerApiKeyHeaders();
+
+    const roleResponse = await call(
+      "PATCH",
+      `/${company.id}/members/${member.id}`,
+      { role: "admin" },
+      headers,
+    );
+    const financeResponse = await call(
+      "PATCH",
+      `/${company.id}/members/${member.id}/finance-access`,
+      { financeAccess: "full" },
+      headers,
+    );
+
+    assert.equal(roleResponse.status, 403);
+    assert.equal(financeResponse.status, 403);
+    const stored = await AppDataSource.getRepository(Membership).findOneByOrFail({
+      companyId: company.id,
+      userId: member.id,
+    });
+    assert.equal(stored.role, "member");
+    assert.equal(stored.financeAccess, "read");
+  });
+
+  test("owner API keys cannot remove a Member", async () => {
+    const member = await insert(User, {
+      email: "member@example.com",
+      name: "Member",
+      passwordHash: "x",
+      sessionVersion: 0,
+    });
+    await insert(Membership, {
+      companyId: company.id,
+      userId: member.id,
+      role: "member" as Role,
+    });
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await call(
+      "DELETE",
+      `/${company.id}/members/${member.id}`,
+      undefined,
+      headers,
+    );
+
+    assert.equal(response.status, 403);
+    assert.ok(
+      await AppDataSource.getRepository(Membership).findOneBy({
+        companyId: company.id,
+        userId: member.id,
+      }),
+    );
+  });
+
+  test("owner API keys cannot delete the company", async () => {
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await call("DELETE", `/${company.id}`, undefined, headers);
+
+    assert.equal(response.status, 403);
+    assert.ok(await AppDataSource.getRepository(Company).findOneBy({ id: company.id }));
+  });
+
+  test("API keys cannot accept invitations into another company", async () => {
+    const otherOwner = await insert(User, {
+      email: "other-owner@example.com",
+      name: "Other owner",
+      passwordHash: "x",
+      sessionVersion: 0,
+    });
+    const otherCompany = await insert(Company, {
+      name: "Other company",
+      slug: "other-company",
+      ownerId: otherOwner.id,
+      mission: "",
+      vision: "",
+    });
+    const rawToken = "invitation-token";
+    const invitation = await insert(Invitation, {
+      companyId: otherCompany.id,
+      email: "owner@example.com",
+      token: hashToken(rawToken),
+      expiresAt: new Date(Date.now() + 60_000),
+      acceptedAt: null,
+    });
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await callAbsolute(
+      "POST",
+      "/api/invitations/accept",
+      { token: rawToken },
+      headers,
+    );
+
+    assert.equal(response.status, 401);
+    assert.equal(
+      await AppDataSource.getRepository(Membership).countBy({
+        companyId: otherCompany.id,
+        userId: company.ownerId,
+      }),
+      0,
+    );
+    assert.equal(
+      (await AppDataSource.getRepository(Invitation).findOneByOrFail({ id: invitation.id }))
+        .acceptedAt,
+      null,
+    );
+  });
+
+  test("API keys cannot mutate account identity or turn a password change into a session", async () => {
+    const headers = await ownerApiKeyHeaders();
+
+    const emailResponse = await callAbsolute(
+      "PATCH",
+      "/api/auth/me",
+      { email: "attacker@example.com" },
+      headers,
+    );
+    const passwordResponse = await callAbsolute(
+      "POST",
+      "/api/auth/password",
+      { currentPassword: "irrelevant", newPassword: "a-new-long-password" },
+      headers,
+    );
+
+    assert.equal(emailResponse.status, 401);
+    assert.equal(passwordResponse.status, 401);
+    assert.equal(
+      (await AppDataSource.getRepository(User).findOneByOrFail({ id: company.ownerId })).email,
+      "owner@example.com",
+    );
+  });
+
+  test("ordinary scoped API-key access remains available", async () => {
+    const headers = await ownerApiKeyHeaders();
+
+    const detail = await call<{ id: string }>("GET", `/${company.id}`, undefined, headers);
+    const updated = await call<{ mission: string }>(
+      "PATCH",
+      `/${company.id}`,
+      { mission: "Updated by ordinary automation." },
+      headers,
+    );
+
+    assert.equal(detail.status, 200);
+    assert.equal(detail.body.id, company.id);
+    assert.equal(updated.status, 200);
+    assert.equal(updated.body.mission, "Updated by ordinary automation.");
+  });
+
+  test("API keys cannot weaken the company two-factor policy", async () => {
+    company.requireTwoFactor = true;
+    await AppDataSource.getRepository(Company).save(company);
+    const headers = await ownerApiKeyHeaders();
+
+    const response = await call("PATCH", `/${company.id}`, { requireTwoFactor: false }, headers);
+
+    assert.equal(response.status, 403);
+    assert.equal(
+      (await AppDataSource.getRepository(Company).findOneByOrFail({ id: company.id }))
+        .requireTwoFactor,
+      true,
+    );
   });
 
   test("updates either field independently and trims its value", async () => {

--- a/App/server/routes/companies.ts
+++ b/App/server/routes/companies.ts
@@ -31,6 +31,9 @@ import { ChannelMember } from "../db/entities/ChannelMember.js";
 import { Project } from "../db/entities/Project.js";
 import { ProjectMember } from "../db/entities/ProjectMember.js";
 import { Notification } from "../db/entities/Notification.js";
+import { VaultItem } from "../db/entities/VaultItem.js";
+import { VaultItemMemberAccess } from "../db/entities/VaultItemMemberAccess.js";
+import { emitMembershipAuthorizationChange } from "../services/resourceEvents.js";
 
 export const companiesRouter = Router();
 
@@ -352,6 +355,7 @@ companiesRouter.patch(
     const { role } = req.body as z.infer<typeof memberRoleSchema>;
     membership.role = role;
     await AppDataSource.getRepository(Membership).save(membership);
+    emitMembershipAuthorizationChange(cid);
     await recordAudit({
       companyId: cid,
       actorUserId: req.userId ?? null,
@@ -447,8 +451,16 @@ companiesRouter.delete(
         .getRepository(ApiKey)
         .update({ companyId: cid, userId: uid }, { revokedAt: new Date() });
       await manager.getRepository(Notification).delete({ companyId: cid, userId: uid });
+      await manager.getRepository(VaultItemMemberAccess).delete({ companyId: cid, userId: uid });
+      // Leaving a company must not let a later re-invite silently resurrect the
+      // creator's full Vault rights. Preserve the item for the company, but
+      // hand management to the remaining owners/admins.
+      await manager
+        .getRepository(VaultItem)
+        .update({ companyId: cid, createdByUserId: uid }, { createdByUserId: null });
       await manager.getRepository(Membership).delete({ companyId: cid, userId: uid });
     });
+    emitMembershipAuthorizationChange(cid);
     await recordAudit({
       companyId: cid,
       actorUserId: req.userId ?? null,

--- a/App/server/routes/emailLogs.ts
+++ b/App/server/routes/emailLogs.ts
@@ -2,7 +2,12 @@ import { Router } from "express";
 import { Brackets } from "typeorm";
 import { AppDataSource } from "../db/datasource.js";
 import { EmailLog } from "../db/entities/EmailLog.js";
-import { requireAuth, requireCompanyMember, requireCompanyRole } from "../middleware/auth.js";
+import {
+  requireAuth,
+  requireBrowserSession,
+  requireCompanyMember,
+  requireCompanyRole,
+} from "../middleware/auth.js";
 
 /**
  * Read-only email-delivery log per company. Mounted under
@@ -18,6 +23,7 @@ export const emailLogsRouter = Router({ mergeParams: true });
 emailLogsRouter.use(requireAuth);
 emailLogsRouter.use(requireCompanyMember);
 emailLogsRouter.use(requireCompanyRole("admin"));
+emailLogsRouter.use(requireBrowserSession);
 
 const PAGE_SIZE_DEFAULT = 50;
 const PAGE_SIZE_MAX = 200;

--- a/App/server/routes/employees.ts
+++ b/App/server/routes/employees.ts
@@ -22,6 +22,8 @@ import { RevenueDocument } from "../db/entities/RevenueDocument.js";
 import { RevenueImportBatch } from "../db/entities/RevenueImportBatch.js";
 import { EmployeeSigningGrant } from "../db/entities/EmployeeSigningGrant.js";
 import { SignatureEnvelope } from "../db/entities/SignatureEnvelope.js";
+import { EmployeeVaultGrant } from "../db/entities/EmployeeVaultGrant.js";
+import { VaultItem } from "../db/entities/VaultItem.js";
 import { validateBody, validateParams } from "../middleware/validate.js";
 import {
   requireAuth,
@@ -39,6 +41,12 @@ import { deleteEmployeeConversations } from "./employeeSurface.js";
 import { recordAudit } from "../services/audit.js";
 import { findTemplate } from "../services/templates.js";
 import { archiveEmployeeDirectMessages } from "../services/workspaceChat.js";
+import {
+  closeAllBrowserSessionsForEmployee,
+  revokeDisabledBrowserSessionsForEmployee,
+} from "../services/browserAccess.js";
+import { removeBrowserStorageForEmployee } from "../services/browserStorage.js";
+import { removeCodeRepoPrivateStateForEmployee } from "../services/codeRepoSshFiles.js";
 import {
   applyRoutineRecommendations,
   findRoutineRecommendationDefinition,
@@ -424,6 +432,9 @@ employeesRouter.patch("/:eid", validateBody(patchSchema), async (req, res) => {
     }
   }
   await repo.save(emp);
+  if (body.browserEnabled !== undefined) {
+    await revokeDisabledBrowserSessionsForEmployee(emp.id);
+  }
   await recordAudit({
     companyId: emp.companyId,
     actorUserId: req.userId ?? null,
@@ -448,6 +459,8 @@ employeesRouter.delete("/:eid", async (req, res) => {
   if (!emp) return res.status(404).json({ error: "Not found" });
   const co = await loadCompany((req.params as Record<string, string>).cid);
 
+  await closeAllBrowserSessionsForEmployee(emp.id);
+
   // Clear reporting lines that pointed at this employee so subordinates
   // don't carry a dangling manager reference.
   await empRepo.update({ reportsToEmployeeId: emp.id }, { reportsToEmployeeId: null });
@@ -461,6 +474,11 @@ employeesRouter.delete("/:eid", async (req, res) => {
   await archiveEmployeeDirectMessages(emp.id);
   await AppDataSource.getRepository(JournalEntry).delete({ employeeId: emp.id });
   await AppDataSource.getRepository(EmployeeSigningGrant).delete({ employeeId: emp.id });
+  await AppDataSource.getRepository(EmployeeVaultGrant).delete({ employeeId: emp.id });
+  await AppDataSource.getRepository(VaultItem).update(
+    { createdByEmployeeId: emp.id },
+    { createdByEmployeeId: null },
+  );
   await AppDataSource.getRepository(SignatureEnvelope).update(
     { createdByEmployeeId: emp.id },
     { createdByEmployeeId: null },
@@ -514,6 +532,8 @@ employeesRouter.delete("/:eid", async (req, res) => {
   await AppDataSource.getRepository(ProjectMember).delete({ employeeId: emp.id });
   await empRepo.delete({ id: emp.id });
 
+  await removeBrowserStorageForEmployee(emp.companyId, emp.id);
+  removeCodeRepoPrivateStateForEmployee(emp.companyId, emp.id);
   if (co) removeDir(employeeDir(co.slug, emp.slug));
   await recordAudit({
     companyId: emp.companyId,

--- a/App/server/routes/mcpInternal.ts
+++ b/App/server/routes/mcpInternal.ts
@@ -51,6 +51,7 @@ import {
   claimApprovedBrowserAction,
   completeClaimedBrowserAction,
   createBrowserActionApproval,
+  readBrowserActionPayload,
 } from "../services/approvals.js";
 import { createNotification } from "../services/notifications.js";
 import { dispatchTodoCreated } from "../services/pipelines/events.js";
@@ -167,6 +168,12 @@ import {
   voidSignatureEnvelope,
   type SignatureEnvelopeDetail,
 } from "../services/signing.js";
+import {
+  createVaultLoginForEmployee,
+  listVaultItemsForEmployee,
+  updateVaultLoginMetadataForEmployee,
+  VaultError,
+} from "../services/vault.js";
 import { EXPORT_FORMATS, exportResource, isExportFormat } from "../services/resourceExport.js";
 import {
   deleteTagAssignments,
@@ -10991,6 +10998,204 @@ mcpInternalRouter.post(
   },
 );
 
+// ----- Vault -----
+//
+// The model can discover safe metadata and create a server-generated login.
+// There is deliberately no plaintext read tool. Actual use goes through the
+// App-owned browser's `browser_fill_vault`, whose route resolves and fills the
+// value server-side after re-checking the item Grant and exact website origin.
+
+function safeVaultWebsiteForAi(value: string): { websiteUrl: string; websiteHost: string } {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return { websiteUrl: "", websiteHost: "" };
+    }
+    return { websiteUrl: url.origin, websiteHost: url.hostname };
+  } catch {
+    return { websiteUrl: "", websiteHost: "" };
+  }
+}
+
+const listVaultItemsSchema = z
+  .object({
+    type: z.enum(["login", "api_key", "secure_note"]).optional(),
+    query: z.string().trim().min(1).max(200).optional(),
+  })
+  .strict();
+
+mcpInternalRouter.post(
+  "/tools/list_vault_items",
+  validateBody(listVaultItemsSchema),
+  async (req: McpRequest, res) => {
+    const body = req.body as z.infer<typeof listVaultItemsSchema>;
+    const rows = await listVaultItemsForEmployee(req.mcpCompany!.id, req.mcpEmployee!.id);
+    const query = body.query?.toLocaleLowerCase();
+    const items = rows
+      .map((row) => ({
+        id: row.id,
+        type: row.type,
+        title: row.title,
+        username: row.username,
+        ...safeVaultWebsiteForAi(row.websiteUrl),
+        accessLevel: row.accessLevel,
+      }))
+      .filter((row) => !body.type || row.type === body.type)
+      .filter(
+        (row) =>
+          !query ||
+          [row.title, row.username, row.websiteUrl].join("\n").toLocaleLowerCase().includes(query),
+      );
+    res.setHeader("Cache-Control", "no-store");
+    res.json({
+      items,
+      note:
+        items.length > 0
+          ? "Stored values are intentionally omitted. Use browser_fill_vault on the exact saved website origin."
+          : "No matching Vault items are granted to you. Ask a Member who manages the item to add a Vault Grant.",
+    });
+  },
+);
+
+const createVaultLoginSchema = z
+  .object({
+    title: z.string().trim().min(1).max(255),
+    username: z.string().trim().max(500).default(""),
+    websiteUrl: z
+      .string()
+      .trim()
+      .url()
+      .max(2_000)
+      .refine((value) => {
+        const website = new URL(value);
+        return (
+          (website.protocol === "http:" || website.protocol === "https:") &&
+          !website.username &&
+          !website.password
+        );
+      }, "websiteUrl must use http or https and cannot embed credentials"),
+    notes: z.string().trim().max(10_000).default(""),
+    passwordLength: z.number().int().min(16).max(128).default(24),
+  })
+  .strict();
+
+mcpInternalRouter.post(
+  "/tools/create_vault_login",
+  validateBody(createVaultLoginSchema),
+  async (req: McpRequest, res) => {
+    const body = req.body as z.infer<typeof createVaultLoginSchema>;
+    const employee = req.mcpEmployee!;
+    try {
+      const item = await createVaultLoginForEmployee({
+        companyId: req.mcpCompany!.id,
+        employeeId: employee.id,
+        title: body.title,
+        username: body.username,
+        websiteUrl: body.websiteUrl,
+        notes: body.notes,
+        passwordLength: body.passwordLength,
+        visibility: "company",
+      });
+      await aiWriteTrail(req, {
+        action: "vault.item.create",
+        targetType: "vault_item",
+        targetId: item.id,
+        targetLabel: "Vault item",
+        journalTitle: `${employee.name} created a Vault login`,
+        journalBody:
+          "Generated and encrypted a new password inside Genosyn. The value was not returned to the model or transcript.",
+        metadata: {
+          via: "generated",
+          passwordLength: body.passwordLength,
+        },
+      });
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        item: {
+          id: item.id,
+          type: item.type,
+          title: item.title,
+          username: item.username,
+          ...safeVaultWebsiteForAi(item.websiteUrl),
+          visibility: item.visibility,
+          accessLevel: item.grantAccessLevel,
+        },
+        note: "Login created with a server-generated password. The value was not revealed; use browser_fill_vault on the exact saved website origin. Browser policy and the Login password-only sink still apply.",
+      });
+    } catch (error) {
+      if (error instanceof VaultError) {
+        return res.status(error.statusCode).json({ error: error.message });
+      }
+      throw error;
+    }
+  },
+);
+
+const updateVaultLoginSchema = z
+  .object({
+    itemId: z.string().uuid(),
+    title: z.string().trim().min(1).max(255).optional(),
+    username: z.string().trim().max(500).optional(),
+    notes: z.string().trim().max(10_000).optional(),
+  })
+  .strict()
+  .refine(
+    (body) => body.title !== undefined || body.username !== undefined || body.notes !== undefined,
+    { message: "Pass at least one metadata field to update" },
+  );
+
+mcpInternalRouter.post(
+  "/tools/update_vault_login",
+  validateBody(updateVaultLoginSchema),
+  async (req: McpRequest, res) => {
+    const body = req.body as z.infer<typeof updateVaultLoginSchema>;
+    const employee = req.mcpEmployee!;
+    try {
+      const item = await updateVaultLoginMetadataForEmployee({
+        companyId: req.mcpCompany!.id,
+        employeeId: employee.id,
+        itemId: body.itemId,
+        patch: {
+          title: body.title,
+          username: body.username,
+          notes: body.notes,
+        },
+      });
+      await aiWriteTrail(req, {
+        action: "vault.item.update",
+        targetType: "vault_item",
+        targetId: item.id,
+        targetLabel: "Vault item",
+        journalTitle: `${employee.name} updated Vault login metadata`,
+        journalBody: "Updated login metadata only; the encrypted password was preserved.",
+        metadata: {
+          fields: ["title", "username", "notes"].filter(
+            (field) => body[field as keyof typeof body] !== undefined,
+          ),
+        },
+      });
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        item: {
+          id: item.id,
+          type: item.type,
+          title: item.title,
+          username: item.username,
+          ...safeVaultWebsiteForAi(item.websiteUrl),
+          visibility: item.visibility,
+          accessLevel: item.accessLevel,
+        },
+        note: "Vault login metadata updated. The stored password was preserved and not revealed.",
+      });
+    } catch (error) {
+      if (error instanceof VaultError) {
+        return res.status(error.statusCode).json({ error: error.message });
+      }
+      throw error;
+    }
+  },
+);
+
 // ----- Document signing -----
 //
 // AI Employees can inspect, prepare and dispatch signature envelopes according
@@ -11409,18 +11614,41 @@ async function notifyTodoReviewByEmployee(args: {
 // `browser_resume(approvalId)` and the MCP re-fires the held action; the
 // server side never drives the browser itself.
 
-const queueBrowserApprovalSchema = z.object({
-  /** Free-text reason / target action shown to the approver. */
-  summary: z.string().trim().min(1).max(1000),
-  /** Page URL captured at queue time (best-effort; may be empty). */
-  pageUrl: z.string().max(2048).optional(),
-  /** Selector the MCP intends to act on. Capped at 500 to match the
-   *  click/press routes that `browser_resume` re-fires through — a longer
-   *  selector would queue fine but strand on execute. */
-  selector: z.string().min(1).max(500),
-  /** Optional key press (e.g. `Enter`) — null/undefined for a click. */
-  key: z.string().max(60).nullish(),
-});
+const queueBrowserApprovalSchema = z
+  .object({
+    action: z.enum(["submit", "vault_capture"]).default("submit"),
+    /** Free-text reason / target action shown to the approver. */
+    summary: z.string().trim().min(1).max(1000),
+    /** Page URL captured at queue time (best-effort; may be empty). */
+    pageUrl: z.string().max(2048).optional(),
+    browserSessionId: z.string().uuid(),
+    targetFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    targetDescriptor: z
+      .object({
+        tagName: z.string().min(1).max(32),
+        inputType: z.string().max(32).nullable(),
+        frameUrl: z.string().min(1).max(2048),
+        formAction: z.string().max(2048).nullable(),
+        formMethod: z.string().max(16).nullable(),
+        submitsForm: z.boolean(),
+      })
+      .strict(),
+    /** Selector the MCP intends to act on. Capped at 500 to match the
+     *  click/press routes that `browser_resume` re-fires through — a longer
+     *  selector would queue fine but strand on execute. */
+    selector: z.string().min(1).max(500),
+    /** Optional key press (e.g. `Enter`) — null/undefined for a click. */
+    key: z.string().max(60).nullish(),
+    vaultTitle: z.string().trim().min(1).max(255).optional(),
+    vaultUsername: z.string().trim().max(500).optional(),
+    vaultNotes: z.string().trim().max(10_000).optional(),
+  })
+  .superRefine((body, ctx) => {
+    if (body.action !== "vault_capture") return;
+    if (body.vaultTitle === undefined) {
+      ctx.addIssue({ code: "custom", message: "vaultTitle is required", path: ["vaultTitle"] });
+    }
+  });
 
 mcpInternalRouter.post(
   "/tools/queue_browser_approval",
@@ -11429,7 +11657,7 @@ mcpInternalRouter.post(
     const body = req.body as z.infer<typeof queueBrowserApprovalSchema>;
     const emp = req.mcpEmployee!;
     const co = req.mcpCompany!;
-    if (!emp.browserApprovalRequired) {
+    if (!emp.browserApprovalRequired && body.action !== "vault_capture") {
       return res.status(400).json({
         error:
           "browserApprovalRequired is off for this employee — queue rejected to avoid stranding the action",
@@ -11438,10 +11666,17 @@ mcpInternalRouter.post(
     const approval = await createBrowserActionApproval({
       companyId: co.id,
       employeeId: emp.id,
+      action: body.action,
       selector: body.selector,
       key: body.key ?? null,
       pageUrl: body.pageUrl ?? "",
+      browserSessionId: body.browserSessionId,
+      targetFingerprint: body.targetFingerprint,
+      targetDescriptor: body.targetDescriptor,
       summary: body.summary,
+      vaultTitle: body.vaultTitle,
+      vaultUsername: body.vaultUsername,
+      vaultNotes: body.vaultNotes,
     });
     res.json({ approvalId: approval.id, status: approval.status });
   },
@@ -11461,30 +11696,54 @@ mcpInternalRouter.get("/tools/check_browser_approval/:id", async (req: McpReques
   }
   // Return the held action alongside the status so `browser_resume` can
   // re-fire it even when the MCP child that queued it is long gone — the
-  // child is spawned per chat turn, and approvals usually land later. The
-  // `pageUrl` lets the child refuse to claim if the page has since changed.
-  // The check is informational only: the separate claim endpoint performs the
-  // atomic approved -> executing transition before the browser side effect.
-  let payload: { selector?: unknown; key?: unknown; pageUrl?: unknown } = {};
+  // child is spawned per chat turn, and approvals usually land later. Bound
+  // actions are consumed at the Browser RPC after its live target is
+  // revalidated. Legacy approvals retain the separate durable claim callback.
+  let payload: ReturnType<typeof readBrowserActionPayload>;
   try {
-    payload = JSON.parse(approval.payloadJson || "{}") as typeof payload;
+    payload = readBrowserActionPayload(approval);
   } catch {
-    // legacy/malformed payload — status alone still helps
+    return res.status(409).json({ error: "Browser approval payload is invalid" });
   }
+  const requestedBrowserSessionId =
+    typeof req.query.browserSessionId === "string" ? req.query.browserSessionId : "";
+  if (
+    typeof payload.browserSessionId === "string" &&
+    payload.browserSessionId !== requestedBrowserSessionId
+  ) {
+    return res.status(403).json({ error: "Approval belongs to another browser session" });
+  }
+  if (
+    payload.action === "vault_capture" &&
+    (typeof payload.expiresAt !== "string" || Date.parse(payload.expiresAt) <= Date.now())
+  ) {
+    if (approval.status === "pending") {
+      await AppDataSource.getRepository(Approval).update(
+        { id: approval.id, status: "pending" },
+        { status: "expired" },
+      );
+    }
+    return res.json({ status: "expired" });
+  }
+  const targetBound = typeof payload.browserSessionId === "string";
   res.json({
     status: approval.status,
+    action: payload.action === "vault_capture" ? "vault_capture" : "submit",
+    targetBound,
     selector: typeof payload.selector === "string" ? payload.selector : null,
     key: typeof payload.key === "string" ? payload.key : null,
     pageUrl: typeof payload.pageUrl === "string" ? payload.pageUrl : null,
+    vaultTitle: typeof payload.vaultTitle === "string" ? payload.vaultTitle : null,
+    vaultUsername: typeof payload.vaultUsername === "string" ? payload.vaultUsername : null,
+    vaultNotes: typeof payload.vaultNotes === "string" ? payload.vaultNotes : null,
+    executionState: payload.execution?.state ?? null,
     executed: browserApprovalWasExecuted(approval),
   });
 });
 
 /**
- * Consume a human-approved browser action before touching the live page. Only
- * one concurrent resume can move approved -> executing and receive a claim
- * token. If that child crashes, the executing row is intentionally never
- * replayed because the external outcome is unknowable.
+ * Consume a legacy human-approved browser action before touching the live
+ * page. New target-bound actions claim inside the Browser RPC instead.
  */
 mcpInternalRouter.post("/tools/claim_browser_approval/:id", async (req: McpRequest, res) => {
   const id = req.params.id;

--- a/App/server/routes/routines.ts
+++ b/App/server/routes/routines.ts
@@ -23,6 +23,7 @@ import { nextRunFor, registerRoutine } from "../services/cron.js";
 import { startRoutineRun, getLiveRunSnapshot, RUN_LOG_MAX_BYTES } from "../services/runner.js";
 import { cancelPendingRetry } from "../services/runRecovery.js";
 import { recordAudit } from "../services/audit.js";
+import { revokeDisabledBrowserSessionsForEmployee } from "../services/browserAccess.js";
 import {
   deleteTagAssignments,
   replaceResourceTags,
@@ -339,6 +340,9 @@ routinesRouter.patch("/routines/:rid", validateBody(patchSchema), async (req, re
   // was already waiting on.
   if (body.cronExpr !== undefined || body.enabled !== undefined) registerRoutine(r);
   await AppDataSource.getRepository(Routine).save(r);
+  if (body.browserEnabledOverride !== undefined) {
+    await revokeDisabledBrowserSessionsForEmployee(r.employeeId);
+  }
   const tags =
     body.tagIds !== undefined
       ? await replaceResourceTags(found.co.id, "routine", r.id, body.tagIds)

--- a/App/server/routes/unsubscribe.ts
+++ b/App/server/routes/unsubscribe.ts
@@ -3,20 +3,15 @@ import { In } from "typeorm";
 
 import { AppDataSource } from "../db/datasource.js";
 import { Company } from "../db/entities/Company.js";
-import {
-  SequenceEnrollment,
-  type EnrollmentStatus,
-} from "../db/entities/SequenceEnrollment.js";
+import { SequenceEnrollment, type EnrollmentStatus } from "../db/entities/SequenceEnrollment.js";
 import { Suppression } from "../db/entities/Suppression.js";
 import { addSuppression } from "../services/mail/suppression.js";
 import { recordActivity } from "../services/revenue/activities.js";
+import { findContactByEmail, markContactUnsubscribed } from "../services/revenue/contacts.js";
 import {
-  findContactByEmail,
-  markContactUnsubscribed,
-} from "../services/revenue/contacts.js";
-import {
-  unsubscribeSecret,
+  unsubscribeSecrets,
   verifyUnsubscribeToken,
+  type UnsubscribePayload,
 } from "../services/revenue/unsubscribeToken.js";
 
 /**
@@ -103,10 +98,14 @@ export type UnsubscribeResult =
  */
 export async function applyUnsubscribe(
   token: string | null | undefined,
-  secret: string = unsubscribeSecret(),
+  secret: string | readonly string[] = unsubscribeSecrets(),
   now: Date = new Date(),
 ): Promise<UnsubscribeResult> {
-  const payload = verifyUnsubscribeToken(token, secret);
+  const secrets = typeof secret === "string" ? [secret] : secret;
+  const payload = secrets.reduce<UnsubscribePayload | null>(
+    (match, candidate) => match ?? verifyUnsubscribeToken(token, candidate),
+    null,
+  );
   if (!payload) return { outcome: "invalid" };
 
   const { companyId, email } = payload;
@@ -177,10 +176,7 @@ export async function applyUnsubscribe(
  * Postgres driver do not agree on when it is populated, and the count is
  * reported back to the caller.
  */
-async function stopLiveEnrollments(
-  companyId: string,
-  contactIds: string[],
-): Promise<number> {
+async function stopLiveEnrollments(companyId: string, contactIds: string[]): Promise<number> {
   if (contactIds.length === 0) return 0;
   const repo = AppDataSource.getRepository(SequenceEnrollment);
   const live = await repo.find({
@@ -354,9 +350,7 @@ export async function unsubscribeHandler(req: Request, res: Response): Promise<v
     // Express 4 will not catch it. Log for the operator, apologise to the
     // visitor, let the mail client retry.
     // eslint-disable-next-line no-console
-    console.error(
-      `[unsubscribe] failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    console.error(`[unsubscribe] failed: ${err instanceof Error ? err.message : String(err)}`);
     try {
       sendHtml(res, 500, renderErrorPage());
     } catch {

--- a/App/server/routes/vault.test.ts
+++ b/App/server/routes/vault.test.ts
@@ -1,0 +1,910 @@
+import assert from "node:assert/strict";
+import crypto, { randomUUID } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import express from "express";
+
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { Approval } from "../db/entities/Approval.js";
+import { ApiKey } from "../db/entities/ApiKey.js";
+import { AuditEvent } from "../db/entities/AuditEvent.js";
+import { Company } from "../db/entities/Company.js";
+import { EmployeeVaultGrant } from "../db/entities/EmployeeVaultGrant.js";
+import { Membership, type Role } from "../db/entities/Membership.js";
+import { User } from "../db/entities/User.js";
+import { VaultItem } from "../db/entities/VaultItem.js";
+import { VaultItemMemberAccess } from "../db/entities/VaultItemMemberAccess.js";
+import { errorHandler } from "../middleware/error.js";
+import { hashApiToken } from "../middleware/auth.js";
+import {
+  createVaultLoginForEmployee,
+  generateVaultPassword,
+  getVaultFieldForEmployee,
+  listVaultItemsForEmployee,
+  updateVaultItem,
+  updateVaultLoginMetadataForEmployee,
+  VaultError,
+} from "../services/vault.js";
+import { deleteCompanyCascade } from "../services/companyDelete.js";
+import { deleteUserCascade } from "../services/userDelete.js";
+import {
+  AI_BROWSER_REQUEST_HEADER,
+  AI_BROWSER_REQUEST_VALUE,
+} from "../services/browserRequestBoundary.js";
+import {
+  BrowserApprovalError,
+  claimBrowserActionApproval,
+  createBrowserActionApproval,
+  settleBrowserActionApproval,
+  type BrowserApprovalTargetDescriptor,
+} from "../services/approvals.js";
+import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
+import { employeesRouter } from "./employees.js";
+import { approvalsRouter } from "./approvals.js";
+import { vaultRouter } from "./vault.js";
+
+let server: Server;
+let baseUrl = "";
+let actingUserId: string | null = null;
+let company: Company;
+let owner: User;
+let admin: User;
+let member: User;
+let secondMember: User;
+let employee: AIEmployee;
+let secondEmployee: AIEmployee;
+
+before(async () => {
+  await initTestDb();
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { session: unknown }).session = actingUserId
+      ? { userId: actingUserId, sessionVersion: 0 }
+      : null;
+    next();
+  });
+  app.use("/api/companies/:cid/vault", vaultRouter);
+  app.use("/api/companies/:cid/employees", employeesRouter);
+  app.use("/api/companies/:cid", approvalsRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  [owner, admin, member, secondMember] = await Promise.all([
+    insert(User, {
+      email: "vault-owner@example.com",
+      name: "Vault Owner",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+    insert(User, {
+      email: "vault-admin@example.com",
+      name: "Vault Admin",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+    insert(User, {
+      email: "vault-member@example.com",
+      name: "Vault Member",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+    insert(User, {
+      email: "vault-second@example.com",
+      name: "Second Member",
+      passwordHash: "x",
+      sessionVersion: 0,
+    }),
+  ]);
+  company = await insert(Company, {
+    name: "Vault Test Company",
+    slug: `vault-test-${randomUUID()}`,
+    ownerId: owner.id,
+  });
+  await Promise.all([
+    insert(Membership, { companyId: company.id, userId: owner.id, role: "owner" as Role }),
+    insert(Membership, { companyId: company.id, userId: admin.id, role: "admin" as Role }),
+    insert(Membership, { companyId: company.id, userId: member.id, role: "member" as Role }),
+    insert(Membership, {
+      companyId: company.id,
+      userId: secondMember.id,
+      role: "member" as Role,
+    }),
+  ]);
+  [employee, secondEmployee] = await Promise.all([
+    insert(AIEmployee, {
+      companyId: company.id,
+      name: "Vault Operator",
+      slug: "vault-operator",
+      role: "Operations",
+    }),
+    insert(AIEmployee, {
+      companyId: company.id,
+      name: "Untrusted Employee",
+      slug: "untrusted-employee",
+      role: "Research",
+    }),
+  ]);
+  actingUserId = owner.id;
+});
+
+type ApiResponse<T = Record<string, unknown>> = {
+  status: number;
+  body: T;
+  headers: Headers;
+};
+
+async function call<T = Record<string, unknown>>(
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<ApiResponse<T>> {
+  const response = await fetch(`${baseUrl}/api/companies/${company.id}/vault${path}`, {
+    method,
+    headers: {
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+      ...headers,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    body: (text ? JSON.parse(text) : {}) as T,
+    headers: response.headers,
+  };
+}
+
+async function createItem(
+  overrides: Partial<{
+    type: "login" | "api_key" | "secure_note";
+    visibility: "company" | "restricted";
+    title: string;
+    username: string;
+    secret: string;
+    websiteUrl: string;
+    notes: string;
+  }> = {},
+): Promise<Record<string, unknown> & { id: string }> {
+  const response = await call<{ item: Record<string, unknown> & { id: string } }>(
+    "POST",
+    "/items",
+    {
+      type: "login",
+      visibility: "restricted",
+      title: "Production login",
+      username: "ops@example.com",
+      secret: "correct horse battery staple",
+      websiteUrl: "https://accounts.example.com/login",
+      notes: "Production account",
+      ...overrides,
+    },
+  );
+  assert.equal(response.status, 201);
+  return response.body.item;
+}
+
+function assertSafeMetadata(value: Record<string, unknown>): void {
+  assert.equal(Object.hasOwn(value, "secret"), false);
+  assert.equal(Object.hasOwn(value, "encryptedPayload"), false);
+}
+
+describe("Vault human routes", () => {
+  test("encrypts the full payload and only returns a secret from audited no-store endpoints", async () => {
+    const created = await createItem();
+    assertSafeMetadata(created);
+    assert.equal(created.createdByUserId, owner.id);
+    assert.equal(created.createdByEmployeeId, null);
+
+    const stored = await AppDataSource.getRepository(VaultItem).findOneByOrFail({ id: created.id });
+    assert.doesNotMatch(stored.encryptedPayload, /Production login|ops@example|correct horse/);
+
+    const list = await call<{ items: Array<Record<string, unknown>> }>("GET", "/items");
+    assert.equal(list.status, 200);
+    assert.equal(list.body.items.length, 1);
+    assertSafeMetadata(list.body.items[0]);
+    const detail = await call<{ item: Record<string, unknown> }>("GET", `/items/${created.id}`);
+    assert.equal(detail.status, 200);
+    assertSafeMetadata(detail.body.item);
+
+    const reveal = await call<{ secret: string }>("POST", `/items/${created.id}/reveal`, {
+      purpose: "reveal",
+    });
+    assert.equal(reveal.status, 200);
+    assert.equal(reveal.body.secret, "correct horse battery staple");
+    assert.match(reveal.headers.get("cache-control") ?? "", /no-store/);
+
+    const copy = await call<{ secret: string }>("POST", `/items/${created.id}/reveal`, {
+      purpose: "copy",
+    });
+    assert.equal(copy.status, 200);
+
+    const rotated = await call<{ item: Record<string, unknown> }>("PATCH", `/items/${created.id}`, {
+      secret: "rotated-never-audited",
+      expectedVersion: created.version,
+    });
+    assert.equal(rotated.status, 200);
+    assertSafeMetadata(rotated.body.item);
+
+    const auditRows = await AppDataSource.getRepository(AuditEvent).find({
+      where: { companyId: company.id },
+    });
+    assert.deepEqual(
+      new Set(auditRows.map((row) => row.action)),
+      new Set(["vault.item.create", "vault.item.reveal", "vault.item.copy", "vault.item.rotate"]),
+    );
+    assert.equal(
+      auditRows.some((row) => row.metadataJson.includes("rotated-never-audited")),
+      false,
+    );
+  });
+
+  test("enforces company visibility, restricted Access, and manager-only sharing/deletion", async () => {
+    const restricted = await createItem();
+    const companyVisible = await createItem({
+      title: "Shared login",
+      visibility: "company",
+      secret: "shared-secret",
+    });
+
+    actingUserId = member.id;
+    assert.equal((await call("GET", `/items/${restricted.id}`)).status, 404);
+    assert.equal((await call("GET", `/items/${companyVisible.id}`)).status, 200);
+
+    actingUserId = owner.id;
+    const shared = await call<{
+      access: { id: string; accessLevel: string };
+    }>("POST", `/items/${restricted.id}/member-access`, {
+      userId: member.id,
+      accessLevel: "view",
+    });
+    assert.equal(shared.status, 200);
+
+    actingUserId = member.id;
+    const viewed = await call<{ item: { canEdit: boolean; canShare: boolean } }>(
+      "GET",
+      `/items/${restricted.id}`,
+    );
+    assert.equal(viewed.status, 200);
+    assert.equal(viewed.body.item.canEdit, false);
+    assert.equal(viewed.body.item.canShare, false);
+    assert.equal(
+      (
+        await call("PATCH", `/items/${restricted.id}`, {
+          title: "Denied",
+          expectedVersion: restricted.version,
+        })
+      ).status,
+      403,
+    );
+
+    actingUserId = owner.id;
+    assert.equal(
+      (
+        await call("PATCH", `/items/${restricted.id}/member-access/${shared.body.access.id}`, {
+          accessLevel: "edit",
+        })
+      ).status,
+      200,
+    );
+
+    actingUserId = member.id;
+    const edited = await call<{ item: { title: string; canEdit: boolean; canShare: boolean } }>(
+      "PATCH",
+      `/items/${restricted.id}`,
+      { title: "Edited by Member", expectedVersion: restricted.version },
+    );
+    assert.equal(edited.status, 200);
+    assert.equal(edited.body.item.canEdit, true);
+    assert.equal(edited.body.item.canShare, false);
+    assert.equal(
+      (
+        await call("POST", `/items/${restricted.id}/member-access`, {
+          userId: secondMember.id,
+          accessLevel: "view",
+        })
+      ).status,
+      403,
+    );
+    assert.equal((await call("DELETE", `/items/${restricted.id}`)).status, 403);
+
+    actingUserId = admin.id;
+    const adminView = await call<{ item: { canShare: boolean; canDelete: boolean } }>(
+      "GET",
+      `/items/${restricted.id}`,
+    );
+    assert.equal(adminView.status, 200);
+    assert.equal(adminView.body.item.canShare, true);
+    assert.equal(adminView.body.item.canDelete, true);
+
+    actingUserId = member.id;
+    const memberCreated = await createItem({ title: "Member-owned" });
+    assert.equal(memberCreated.canShare, true);
+    assert.equal(memberCreated.canDelete, true);
+  });
+
+  test("rejects a valid general REST API key even when its Member owns the item", async () => {
+    await createItem();
+    const tokenBody = crypto.randomBytes(32).toString("base64url");
+    await insert(ApiKey, {
+      companyId: company.id,
+      userId: owner.id,
+      name: "Leaked key",
+      prefix: tokenBody.slice(0, 8),
+      tokenHash: hashApiToken(tokenBody),
+    });
+    actingUserId = null;
+    const response = await call("GET", "/items", undefined, {
+      authorization: `Bearer gen_${tokenBody}`,
+    });
+    assert.equal(response.status, 403);
+    assert.match(String(response.body.error), /logged-in browser session/);
+  });
+
+  test("rejects the human Vault API inside an App-owned AI Browser", async () => {
+    const created = await createItem({ secret: "must-never-reach-the-ai-browser" });
+    const headers = { [AI_BROWSER_REQUEST_HEADER]: AI_BROWSER_REQUEST_VALUE };
+
+    const list = await call("GET", "/items", undefined, headers);
+    const reveal = await call(
+      "POST",
+      `/items/${created.id}/reveal`,
+      { purpose: "reveal" },
+      headers,
+    );
+
+    assert.equal(list.status, 403);
+    assert.equal(reveal.status, 403);
+    assert.match(String(reveal.body.error), /AI Browser/);
+    assert.doesNotMatch(JSON.stringify([list.body, reveal.body]), /must-never-reach/);
+  });
+
+  test("rejects stale whole-payload updates without restoring an older password", async () => {
+    const created = await createItem();
+    const originalVersion = Number(created.version);
+    const rotated = await call<{ item: { version: number } }>("PATCH", `/items/${created.id}`, {
+      secret: "newly-rotated-password",
+      expectedVersion: originalVersion,
+    });
+    assert.equal(rotated.status, 200);
+    assert.equal(rotated.body.item.version, originalVersion + 1);
+
+    const stale = await call("PATCH", `/items/${created.id}`, {
+      title: "Stale metadata edit",
+      expectedVersion: originalVersion,
+    });
+    assert.equal(stale.status, 409);
+
+    const reveal = await call<{ secret: string }>("POST", `/items/${created.id}/reveal`, {
+      purpose: "reveal",
+    });
+    assert.equal(reveal.body.secret, "newly-rotated-password");
+  });
+
+  test("rejects website URLs that embed credentials", async () => {
+    const response = await call("POST", "/items", {
+      type: "login",
+      visibility: "restricted",
+      title: "Unsafe URL",
+      username: "owner@example.com",
+      secret: "not-in-the-url",
+      websiteUrl: "https://embedded:credential@example.com/login",
+      notes: "",
+    });
+    assert.equal(response.status, 400);
+    assert.equal(await AppDataSource.getRepository(VaultItem).count(), 0);
+  });
+});
+
+describe("Vault capture approvals", () => {
+  const targetFingerprint = "a".repeat(64);
+  const targetDescriptor: BrowserApprovalTargetDescriptor = {
+    tagName: "input",
+    inputType: "password",
+    frameUrl: "https://example.com/signup",
+    formAction: "https://example.com/accounts",
+    formMethod: "POST",
+    submitsForm: false,
+  };
+
+  test("keeps capture details admin-only and rejects API-key decisions", async () => {
+    const browserSessionId = randomUUID();
+    const approval = await createBrowserActionApproval({
+      companyId: company.id,
+      employeeId: employee.id,
+      action: "vault_capture",
+      selector: "aria-ref=e7",
+      key: null,
+      pageUrl: "https://example.com/reset?token=QUERY_SECRET#FRAGMENT_SECRET",
+      browserSessionId,
+      targetFingerprint,
+      targetDescriptor,
+      summary: "Save a hidden password",
+      vaultTitle: "Private login title",
+      vaultUsername: "private@example.com",
+      vaultNotes: "Private notes",
+    });
+
+    actingUserId = member.id;
+    const memberList = await fetch(`${baseUrl}/api/companies/${company.id}/approvals`).then(
+      async (response) => ({ status: response.status, body: await response.json() }),
+    );
+    assert.equal(memberList.status, 403);
+    assert.equal(memberList.body.error, "admin company role required");
+
+    const memberReject = await fetch(
+      `${baseUrl}/api/companies/${company.id}/approvals/${approval.id}/reject`,
+      { method: "POST" },
+    );
+    assert.equal(memberReject.status, 403);
+    assert.equal(
+      (await AppDataSource.getRepository(Approval).findOneByOrFail({ id: approval.id })).status,
+      "pending",
+    );
+
+    actingUserId = owner.id;
+    const ownerList = (await fetch(`${baseUrl}/api/companies/${company.id}/approvals`).then(
+      (response) => response.json(),
+    )) as Array<Record<string, unknown>>;
+    assert.equal(ownerList.length, 1);
+    assert.equal(Object.hasOwn(ownerList[0], "payloadJson"), false);
+    assert.equal(Object.hasOwn(ownerList[0], "resultJson"), false);
+    assert.doesNotMatch(
+      JSON.stringify(ownerList),
+      /QUERY_SECRET|FRAGMENT_SECRET|private@example.com|Private notes/,
+    );
+    const storedApproval = await AppDataSource.getRepository(Approval).findOneByOrFail({
+      id: approval.id,
+    });
+    assert.doesNotMatch(
+      storedApproval.payloadJson || "",
+      /QUERY_SECRET|FRAGMENT_SECRET|private@example.com|Private notes|Private login title/,
+    );
+    assert.match(storedApproval.payloadJson || "", /encryptedVaultCapture/);
+
+    const tokenBody = crypto.randomBytes(32).toString("base64url");
+    await insert(ApiKey, {
+      companyId: company.id,
+      userId: owner.id,
+      name: "Non-human approval key",
+      prefix: tokenBody.slice(0, 8),
+      tokenHash: hashApiToken(tokenBody),
+    });
+    actingUserId = null;
+    const denied = await fetch(
+      `${baseUrl}/api/companies/${company.id}/approvals/${approval.id}/approve`,
+      { method: "POST", headers: { authorization: `Bearer gen_${tokenBody}` } },
+    );
+    assert.equal(denied.status, 403);
+    assert.equal(
+      (await AppDataSource.getRepository(Approval).findOneByOrFail({ id: approval.id })).status,
+      "pending",
+    );
+  });
+
+  test("claims capture approval once and binds it to employee, session, page, and action", async () => {
+    const browserSessionId = randomUUID();
+    const approval = await createBrowserActionApproval({
+      companyId: company.id,
+      employeeId: employee.id,
+      action: "vault_capture",
+      selector: "aria-ref=e9",
+      key: null,
+      pageUrl: "https://example.com/signup?invite=hidden",
+      browserSessionId,
+      targetFingerprint,
+      targetDescriptor,
+      summary: "Save a hidden password",
+      vaultTitle: "Approved title",
+      vaultUsername: "approved@example.com",
+      vaultNotes: "Approved note",
+    });
+    approval.status = "approved";
+    approval.decidedAt = new Date();
+    approval.decidedByUserId = owner.id;
+    await AppDataSource.getRepository(Approval).save(approval);
+
+    await assert.rejects(
+      claimBrowserActionApproval({
+        approvalId: approval.id,
+        companyId: company.id,
+        employeeId: employee.id,
+        browserSessionId: randomUUID(),
+        action: "vault_capture",
+        selector: "aria-ref=e9",
+        key: null,
+        targetFingerprint,
+        targetDescriptor,
+        vaultTitle: "Approved title",
+        vaultUsername: "approved@example.com",
+        vaultNotes: "Approved note",
+      }),
+      (error) => error instanceof BrowserApprovalError && error.statusCode === 409,
+    );
+
+    const exact = {
+      approvalId: approval.id,
+      companyId: company.id,
+      employeeId: employee.id,
+      browserSessionId,
+      action: "vault_capture" as const,
+      selector: "aria-ref=e9",
+      key: null,
+      targetFingerprint,
+      targetDescriptor,
+      vaultTitle: "Approved title",
+      vaultUsername: "approved@example.com",
+      vaultNotes: "Approved note",
+    };
+    const claimed = await claimBrowserActionApproval(exact);
+    const persisted = await AppDataSource.getRepository(Approval).findOneByOrFail({
+      id: approval.id,
+    });
+    assert.equal(
+      (JSON.parse(persisted.payloadJson || "{}") as { execution?: { state?: unknown } }).execution
+        ?.state,
+      "claimed",
+    );
+    await settleBrowserActionApproval({
+      approvalId: approval.id,
+      claimId: claimed.claimId,
+      succeeded: true,
+    });
+    await assert.rejects(
+      claimBrowserActionApproval(exact),
+      (error) => error instanceof BrowserApprovalError && error.statusCode === 409,
+    );
+  });
+
+  test("claims browser approvals atomically and permits only pre-dispatch failure recovery", async () => {
+    const browserSessionId = randomUUID();
+    const submitDescriptor: BrowserApprovalTargetDescriptor = {
+      ...targetDescriptor,
+      tagName: "button",
+      inputType: "submit",
+      submitsForm: true,
+    };
+    const approval = await createBrowserActionApproval({
+      companyId: company.id,
+      employeeId: employee.id,
+      action: "submit",
+      selector: "aria-ref=e12",
+      key: null,
+      pageUrl: "https://example.com/signup",
+      browserSessionId,
+      targetFingerprint,
+      targetDescriptor: submitDescriptor,
+      summary: "Create account",
+    });
+    approval.status = "approved";
+    approval.decidedAt = new Date();
+    approval.decidedByUserId = owner.id;
+    await AppDataSource.getRepository(Approval).save(approval);
+
+    const exact = {
+      approvalId: approval.id,
+      companyId: company.id,
+      employeeId: employee.id,
+      browserSessionId,
+      action: "submit" as const,
+      selector: "aria-ref=e12",
+      key: null,
+      targetFingerprint,
+      targetDescriptor: submitDescriptor,
+    };
+    const raced = await Promise.allSettled([
+      claimBrowserActionApproval(exact),
+      claimBrowserActionApproval(exact),
+    ]);
+    const fulfilled = raced.filter(
+      (
+        result,
+      ): result is PromiseFulfilledResult<Awaited<ReturnType<typeof claimBrowserActionApproval>>> =>
+        result.status === "fulfilled",
+    );
+    assert.equal(fulfilled.length, 1);
+    assert.equal(raced.filter((result) => result.status === "rejected").length, 1);
+
+    await settleBrowserActionApproval({
+      approvalId: approval.id,
+      claimId: fulfilled[0].value.claimId,
+      succeeded: false,
+    });
+    const retried = await claimBrowserActionApproval(exact);
+    await settleBrowserActionApproval({
+      approvalId: approval.id,
+      claimId: retried.claimId,
+      succeeded: true,
+    });
+    await assert.rejects(
+      claimBrowserActionApproval(exact),
+      (error) => error instanceof BrowserApprovalError && error.statusCode === 409,
+    );
+  });
+});
+
+describe("Vault AI service boundary", () => {
+  test("defaults to no Grant, returns safe metadata, and makes manage distinct from use", async () => {
+    const item = await createItem({ notes: "Do not expose this context" });
+    assert.deepEqual(await listVaultItemsForEmployee(company.id, employee.id), []);
+
+    const grantResponse = await call<{ grant: { id: string } }>(
+      "POST",
+      `/items/${item.id}/employee-grants`,
+      { employeeId: employee.id, accessLevel: "use" },
+    );
+    assert.equal(grantResponse.status, 200);
+    const listed = await listVaultItemsForEmployee(company.id, employee.id);
+    assert.equal(listed.length, 1);
+    assertSafeMetadata(listed[0] as unknown as Record<string, unknown>);
+    assert.equal(Object.hasOwn(listed[0], "notes"), false);
+    assert.equal(
+      await getVaultFieldForEmployee({
+        companyId: company.id,
+        employeeId: employee.id,
+        itemId: item.id,
+        field: "secret",
+      }),
+      "correct horse battery staple",
+    );
+    await assert.rejects(
+      updateVaultLoginMetadataForEmployee({
+        companyId: company.id,
+        employeeId: employee.id,
+        itemId: item.id,
+        patch: { title: "Use cannot manage" },
+      }),
+      (error) => error instanceof VaultError && error.statusCode === 403,
+    );
+
+    const upgraded = await call(
+      "PATCH",
+      `/items/${item.id}/employee-grants/${grantResponse.body.grant.id}`,
+      { accessLevel: "manage" },
+    );
+    assert.equal(upgraded.status, 200);
+    const updated = await updateVaultLoginMetadataForEmployee({
+      companyId: company.id,
+      employeeId: employee.id,
+      itemId: item.id,
+      patch: {
+        title: "Managed metadata",
+        notes: "Preserved internally but not returned",
+      },
+    });
+    assertSafeMetadata(updated as unknown as Record<string, unknown>);
+    assert.equal(Object.hasOwn(updated, "notes"), false);
+    assert.equal(updated.title, "Managed metadata");
+    await assert.rejects(
+      updateVaultLoginMetadataForEmployee({
+        companyId: company.id,
+        employeeId: employee.id,
+        itemId: item.id,
+        patch: {
+          websiteUrl: "https://attacker.example",
+        } as unknown as { title?: string; username?: string; notes?: string },
+      }),
+      (error) => error instanceof VaultError && error.statusCode === 403,
+    );
+    assert.equal(
+      await getVaultFieldForEmployee({
+        companyId: company.id,
+        employeeId: employee.id,
+        itemId: item.id,
+        field: "secret",
+      }),
+      "correct horse battery staple",
+    );
+
+    await assert.rejects(
+      getVaultFieldForEmployee({
+        companyId: company.id,
+        employeeId: secondEmployee.id,
+        itemId: item.id,
+        field: "secret",
+      }),
+      (error) => error instanceof VaultError && error.statusCode === 403,
+    );
+    const otherCompany = await insert(Company, {
+      name: "Other Company",
+      slug: `other-${randomUUID()}`,
+      ownerId: owner.id,
+    });
+    await assert.rejects(
+      listVaultItemsForEmployee(otherCompany.id, employee.id),
+      (error) => error instanceof VaultError && error.statusCode === 404,
+    );
+  });
+
+  test("generates exact-length strong passwords and stores AI logins without returning plaintext", async () => {
+    for (const length of [16, 24, 37, 128]) {
+      const password = generateVaultPassword(length);
+      assert.equal(password.length, length);
+      assert.match(password, /[A-Z]/);
+      assert.match(password, /[a-z]/);
+      assert.match(password, /[0-9]/);
+      assert.match(password, /[^A-Za-z0-9]/);
+    }
+    assert.throws(() => generateVaultPassword(15), VaultError);
+    assert.throws(() => generateVaultPassword(129), VaultError);
+
+    const generated = await createVaultLoginForEmployee({
+      companyId: company.id,
+      employeeId: employee.id,
+      title: "Generated login",
+      username: "generated@example.com",
+      websiteUrl: "https://generated.example.com",
+      notes: "Internal context",
+      passwordLength: 37,
+    });
+    assert.equal(generated.visibility, "company");
+    assert.equal(generated.grantAccessLevel, "manage");
+    assertSafeMetadata(generated as unknown as Record<string, unknown>);
+    assert.equal(Object.hasOwn(generated, "notes"), false);
+
+    actingUserId = member.id;
+    const reveal = await call<{ secret: string }>("POST", `/items/${generated.id}/reveal`, {
+      purpose: "reveal",
+    });
+    assert.equal(reveal.status, 200);
+    assert.equal(reveal.body.secret.length, 37);
+
+    const captured = await createVaultLoginForEmployee({
+      companyId: company.id,
+      employeeId: employee.id,
+      title: "Captured login",
+      secret: "captured-without-model-exposure",
+      websiteUrl: "https://captured.example.com",
+      visibility: "restricted",
+    });
+    assert.equal(captured.visibility, "restricted");
+    actingUserId = owner.id;
+    const capturedReveal = await call<{ secret: string }>("POST", `/items/${captured.id}/reveal`, {
+      purpose: "reveal",
+    });
+    assert.equal(capturedReveal.status, 200);
+    assert.equal(capturedReveal.body.secret, "captured-without-model-exposure");
+  });
+
+  test("an AI metadata race cannot restore the password a Member just rotated", async () => {
+    const item = await createItem();
+    await call("POST", `/items/${item.id}/employee-grants`, {
+      employeeId: employee.id,
+      accessLevel: "manage",
+    });
+
+    const repo = AppDataSource.getRepository(VaultItem);
+    const originalUpdate = repo.update.bind(repo);
+    let injectedRotation = false;
+    repo.update = (async (criteria, partial) => {
+      if (!injectedRotation) {
+        injectedRotation = true;
+        repo.update = originalUpdate as typeof repo.update;
+        await updateVaultItem({
+          companyId: company.id,
+          itemId: item.id,
+          actor: { userId: owner.id, role: "owner" },
+          expectedVersion: Number(item.version),
+          patch: { secret: "human-rotation-wins" },
+        });
+      }
+      return originalUpdate(criteria, partial);
+    }) as typeof repo.update;
+
+    try {
+      await assert.rejects(
+        updateVaultLoginMetadataForEmployee({
+          companyId: company.id,
+          employeeId: employee.id,
+          itemId: item.id,
+          patch: { title: "Racing AI metadata" },
+        }),
+        (error) => error instanceof VaultError && error.statusCode === 409,
+      );
+    } finally {
+      repo.update = originalUpdate as typeof repo.update;
+    }
+
+    const secret = await getVaultFieldForEmployee({
+      companyId: company.id,
+      employeeId: employee.id,
+      itemId: item.id,
+      field: "secret",
+    });
+    assert.equal(secret, "human-rotation-wins");
+  });
+
+  test("employee deletion removes Grants and clears AI provenance", async () => {
+    const created = await createVaultLoginForEmployee({
+      companyId: company.id,
+      employeeId: employee.id,
+      title: "Durable human recovery",
+      websiteUrl: "https://durable.example.com",
+    });
+    actingUserId = owner.id;
+    const response = await fetch(
+      `${baseUrl}/api/companies/${company.id}/employees/${employee.id}`,
+      { method: "DELETE" },
+    );
+    assert.equal(response.status, 200);
+    assert.equal(
+      await AppDataSource.getRepository(EmployeeVaultGrant).countBy({ employeeId: employee.id }),
+      0,
+    );
+    const remaining = await AppDataSource.getRepository(VaultItem).findOneByOrFail({
+      id: created.id,
+    });
+    assert.equal(remaining.createdByEmployeeId, null);
+    assert.equal(remaining.visibility, "company");
+  });
+
+  test("Member deletion removes explicit Access while preserving items and creator history", async () => {
+    const ownerItem = await createItem({ title: "Owner item" });
+    const shared = await call<{ access: { id: string } }>(
+      "POST",
+      `/items/${ownerItem.id}/member-access`,
+      { userId: member.id, accessLevel: "view" },
+    );
+    assert.equal(shared.status, 200);
+
+    actingUserId = member.id;
+    const memberItem = await createItem({ title: "Former Member item", visibility: "company" });
+    await deleteUserCascade({ userId: member.id });
+
+    assert.equal(
+      await AppDataSource.getRepository(VaultItemMemberAccess).countBy({ userId: member.id }),
+      0,
+    );
+    assert.equal(
+      (await AppDataSource.getRepository(VaultItem).findOneByOrFail({ id: memberItem.id }))
+        .createdByUserId,
+      null,
+    );
+    assert.ok(await AppDataSource.getRepository(VaultItem).findOneBy({ id: ownerItem.id }));
+    assert.equal(await AppDataSource.getRepository(User).findOneBy({ id: member.id }), null);
+  });
+
+  test("company deletion clears Vault items, Member Access, and AI Employee Grants", async () => {
+    const item = await createItem();
+    await call("POST", `/items/${item.id}/member-access`, {
+      userId: member.id,
+      accessLevel: "view",
+    });
+    await call("POST", `/items/${item.id}/employee-grants`, {
+      employeeId: employee.id,
+      accessLevel: "use",
+    });
+
+    await deleteCompanyCascade({ companyId: company.id, companySlug: company.slug });
+    assert.equal(
+      await AppDataSource.getRepository(VaultItem).countBy({ companyId: company.id }),
+      0,
+    );
+    assert.equal(
+      await AppDataSource.getRepository(VaultItemMemberAccess).countBy({ companyId: company.id }),
+      0,
+    );
+    assert.equal(
+      await AppDataSource.getRepository(EmployeeVaultGrant).countBy({ companyId: company.id }),
+      0,
+    );
+    assert.equal(await AppDataSource.getRepository(Company).findOneBy({ id: company.id }), null);
+  });
+});

--- a/App/server/routes/vault.ts
+++ b/App/server/routes/vault.ts
@@ -1,0 +1,539 @@
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from "express";
+import { z } from "zod";
+
+import type { EmployeeVaultAccessLevel } from "../db/entities/EmployeeVaultGrant.js";
+import type { VaultMemberAccessLevel } from "../db/entities/VaultItemMemberAccess.js";
+import { requireAuth, requireCompanyMember } from "../middleware/auth.js";
+import { validateBody, validateParams } from "../middleware/validate.js";
+import { recordAudit } from "../services/audit.js";
+import {
+  AI_BROWSER_REQUEST_HEADER,
+  AI_BROWSER_REQUEST_VALUE,
+} from "../services/browserRequestBoundary.js";
+import {
+  VaultError,
+  createVaultItem,
+  deleteEmployeeVaultGrant,
+  deleteVaultItem,
+  deleteVaultMemberAccess,
+  getVaultItem,
+  listEmployeeVaultGrantCandidates,
+  listEmployeeVaultGrants,
+  listVaultItems,
+  listVaultMemberAccess,
+  listVaultMemberAccessCandidates,
+  revealVaultItem,
+  updateEmployeeVaultGrant,
+  updateVaultItem,
+  updateVaultMemberAccess,
+  upsertEmployeeVaultGrant,
+  upsertVaultMemberAccess,
+  type VaultHumanActor,
+} from "../services/vault.js";
+
+/**
+ * Human-facing company Vault API. The legacy Settings → Secrets surface stays
+ * separate: Vault items are structured credentials with item-level human
+ * Access and AI Employee Grants, and are never injected wholesale into Runs.
+ */
+export const vaultRouter = Router({ mergeParams: true });
+
+vaultRouter.use((req, res, next) => {
+  if (req.get(AI_BROWSER_REQUEST_HEADER) === AI_BROWSER_REQUEST_VALUE) {
+    return res.status(403).json({
+      error:
+        "The human Vault API is unavailable inside an AI Browser. Use item-level Vault Grants and governed Browser autofill.",
+    });
+  }
+  next();
+});
+vaultRouter.use(requireAuth);
+vaultRouter.use(requireCompanyMember);
+vaultRouter.use((req, res, next) => {
+  if (req.apiKey) {
+    return res.status(403).json({
+      error: "Vault access requires a logged-in browser session",
+    });
+  }
+  // Decrypted metadata is sensitive too. This also covers every reveal error
+  // path, so proxies and browsers never cache a plaintext response.
+  res.set("Cache-Control", "no-store, max-age=0");
+  res.set("Pragma", "no-cache");
+  next();
+});
+
+type VaultRequest = Request & {
+  companyRole: NonNullable<Request["companyRole"]>;
+  userId: string;
+};
+
+type AsyncHandler = (req: VaultRequest, res: Response) => Promise<unknown>;
+
+function asyncHandler(handler: AsyncHandler): RequestHandler {
+  return (req, res, next) => {
+    void handler(req as VaultRequest, res).catch((error) => sendError(error, res, next));
+  };
+}
+
+function sendError(error: unknown, res: Response, next: NextFunction): void {
+  if (error instanceof VaultError) {
+    res.status(error.statusCode).json({ error: error.message });
+    return;
+  }
+  next(error);
+}
+
+function companyId(req: VaultRequest): string {
+  return req.params.cid;
+}
+
+function actor(req: VaultRequest): VaultHumanActor {
+  return { userId: req.userId, role: req.companyRole };
+}
+
+const companyParamsSchema = z.object({ cid: z.string().uuid() });
+const itemParamsSchema = z.object({
+  cid: z.string().uuid(),
+  itemId: z.string().uuid(),
+});
+const memberAccessParamsSchema = itemParamsSchema.extend({ accessId: z.string().uuid() });
+const employeeGrantParamsSchema = itemParamsSchema.extend({ grantId: z.string().uuid() });
+
+const itemTypeSchema = z.enum(["login", "api_key", "secure_note"]);
+const visibilitySchema = z.enum(["company", "restricted"]);
+const websiteUrlSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .refine((value) => {
+    if (!value) return true;
+    try {
+      const url = new URL(value);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") && !url.username && !url.password
+      );
+    } catch {
+      return false;
+    }
+  }, "Enter an absolute http(s) URL without embedded credentials");
+
+const createItemSchema = z
+  .object({
+    type: itemTypeSchema,
+    visibility: visibilitySchema.default("restricted"),
+    title: z.string().trim().min(1).max(200),
+    username: z.string().max(500).default(""),
+    secret: z.string().min(1).max(20_000),
+    websiteUrl: websiteUrlSchema.default(""),
+    notes: z.string().max(20_000).default(""),
+  })
+  .strict();
+
+const updateItemSchema = z
+  .object({
+    type: itemTypeSchema.optional(),
+    visibility: visibilitySchema.optional(),
+    title: z.string().trim().min(1).max(200).optional(),
+    username: z.string().max(500).optional(),
+    secret: z.string().min(1).max(20_000).optional(),
+    websiteUrl: websiteUrlSchema.optional(),
+    notes: z.string().max(20_000).optional(),
+    expectedVersion: z.number().int().positive(),
+  })
+  .strict()
+  .refine(
+    (body) => Object.keys(body).some((field) => field !== "expectedVersion"),
+    "Provide at least one field to update",
+  );
+
+const revealSchema = z
+  .object({
+    purpose: z.enum(["reveal", "copy"]),
+  })
+  .strict();
+
+const createMemberAccessSchema = z
+  .object({
+    userId: z.string().uuid(),
+    accessLevel: z.enum(["view", "edit"]),
+  })
+  .strict();
+const updateMemberAccessSchema = z.object({ accessLevel: z.enum(["view", "edit"]) }).strict();
+const createEmployeeGrantSchema = z
+  .object({
+    employeeId: z.string().uuid(),
+    accessLevel: z.enum(["use", "manage"]),
+  })
+  .strict();
+const updateEmployeeGrantSchema = z.object({ accessLevel: z.enum(["use", "manage"]) }).strict();
+
+vaultRouter.get(
+  "/items",
+  validateParams(companyParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({ items: await listVaultItems(companyId(req), actor(req)) });
+  }),
+);
+
+vaultRouter.post(
+  "/items",
+  validateParams(companyParamsSchema),
+  validateBody(createItemSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof createItemSchema>;
+    const item = await createVaultItem({
+      companyId: companyId(req),
+      actor: actor(req),
+      type: body.type,
+      visibility: body.visibility,
+      payload: {
+        title: body.title,
+        username: body.username,
+        secret: body.secret,
+        websiteUrl: body.websiteUrl,
+        notes: body.notes,
+      },
+    });
+    await recordAudit({
+      companyId: companyId(req),
+      actorUserId: req.userId,
+      action: "vault.item.create",
+      targetType: "vault_item",
+      targetId: item.id,
+      targetLabel: "Vault item",
+      metadata: { type: item.type, visibility: item.visibility },
+    });
+    res.status(201).json({ item });
+  }),
+);
+
+vaultRouter.get(
+  "/items/:itemId",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({ item: await getVaultItem(companyId(req), req.params.itemId, actor(req)) });
+  }),
+);
+
+vaultRouter.patch(
+  "/items/:itemId",
+  validateParams(itemParamsSchema),
+  validateBody(updateItemSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof updateItemSchema>;
+    const { expectedVersion, ...patch } = body;
+    const result = await updateVaultItem({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      actor: actor(req),
+      expectedVersion,
+      patch,
+    });
+    await recordAudit({
+      companyId: companyId(req),
+      actorUserId: req.userId,
+      action: patch.secret !== undefined ? "vault.item.rotate" : "vault.item.update",
+      targetType: "vault_item",
+      targetId: result.item.id,
+      targetLabel: "Vault item",
+      metadata: {
+        changedFields: Object.keys(patch),
+        previousType: result.before.type,
+        previousVisibility: result.before.visibility,
+        type: result.item.type,
+        visibility: result.item.visibility,
+      },
+    });
+    res.json({ item: result.item });
+  }),
+);
+
+vaultRouter.delete(
+  "/items/:itemId",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    const deleted = await deleteVaultItem({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      actor: actor(req),
+    });
+    await recordAudit({
+      companyId: companyId(req),
+      actorUserId: req.userId,
+      action: "vault.item.delete",
+      targetType: "vault_item",
+      targetId: deleted.id,
+      targetLabel: "Vault item",
+      metadata: { type: deleted.type },
+    });
+    res.json({ ok: true });
+  }),
+);
+
+vaultRouter.post(
+  "/items/:itemId/reveal",
+  validateParams(itemParamsSchema),
+  validateBody(revealSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof revealSchema>;
+    const revealed = await revealVaultItem({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      actor: actor(req),
+    });
+    await recordAudit({
+      companyId: companyId(req),
+      actorUserId: req.userId,
+      action: body.purpose === "copy" ? "vault.item.copy" : "vault.item.reveal",
+      targetType: "vault_item",
+      targetId: revealed.item.id,
+      targetLabel: "Vault item",
+      metadata: { purpose: body.purpose },
+    });
+    res.json({ secret: revealed.secret });
+  }),
+);
+
+vaultRouter.get(
+  "/items/:itemId/member-access",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({
+      access: await listVaultMemberAccess({
+        companyId: companyId(req),
+        itemId: req.params.itemId,
+        actor: actor(req),
+      }),
+    });
+  }),
+);
+
+vaultRouter.get(
+  "/items/:itemId/member-access-candidates",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({
+      candidates: await listVaultMemberAccessCandidates({
+        companyId: companyId(req),
+        itemId: req.params.itemId,
+        actor: actor(req),
+      }),
+    });
+  }),
+);
+
+vaultRouter.post(
+  "/items/:itemId/member-access",
+  validateParams(itemParamsSchema),
+  validateBody(createMemberAccessSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof createMemberAccessSchema>;
+    const access = await upsertVaultMemberAccess({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      actor: actor(req),
+      userId: body.userId,
+      accessLevel: body.accessLevel,
+    });
+    await auditMemberAccess(
+      req,
+      "upsert",
+      access.id,
+      access.userId,
+      access.accessLevel,
+      access.member.name,
+    );
+    res.json({ access });
+  }),
+);
+
+vaultRouter.patch(
+  "/items/:itemId/member-access/:accessId",
+  validateParams(memberAccessParamsSchema),
+  validateBody(updateMemberAccessSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof updateMemberAccessSchema>;
+    const access = await updateVaultMemberAccess({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      accessId: req.params.accessId,
+      actor: actor(req),
+      accessLevel: body.accessLevel,
+    });
+    await auditMemberAccess(
+      req,
+      "update",
+      access.id,
+      access.userId,
+      access.accessLevel,
+      access.member.name,
+    );
+    res.json({ access });
+  }),
+);
+
+vaultRouter.delete(
+  "/items/:itemId/member-access/:accessId",
+  validateParams(memberAccessParamsSchema),
+  asyncHandler(async (req, res) => {
+    const deleted = await deleteVaultMemberAccess({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      accessId: req.params.accessId,
+      actor: actor(req),
+    });
+    await auditMemberAccess(
+      req,
+      "delete",
+      deleted.id,
+      deleted.userId,
+      deleted.accessLevel,
+      deleted.userId,
+    );
+    res.json({ ok: true });
+  }),
+);
+
+vaultRouter.get(
+  "/items/:itemId/employee-grants",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({
+      grants: await listEmployeeVaultGrants({
+        companyId: companyId(req),
+        itemId: req.params.itemId,
+        actor: actor(req),
+      }),
+    });
+  }),
+);
+
+vaultRouter.get(
+  "/items/:itemId/employee-grant-candidates",
+  validateParams(itemParamsSchema),
+  asyncHandler(async (req, res) => {
+    res.json({
+      candidates: await listEmployeeVaultGrantCandidates({
+        companyId: companyId(req),
+        itemId: req.params.itemId,
+        actor: actor(req),
+      }),
+    });
+  }),
+);
+
+vaultRouter.post(
+  "/items/:itemId/employee-grants",
+  validateParams(itemParamsSchema),
+  validateBody(createEmployeeGrantSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof createEmployeeGrantSchema>;
+    const grant = await upsertEmployeeVaultGrant({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      actor: actor(req),
+      employeeId: body.employeeId,
+      accessLevel: body.accessLevel,
+    });
+    await auditEmployeeGrant(
+      req,
+      "upsert",
+      grant.id,
+      grant.employeeId,
+      grant.accessLevel,
+      grant.employee.name,
+    );
+    res.json({ grant });
+  }),
+);
+
+vaultRouter.patch(
+  "/items/:itemId/employee-grants/:grantId",
+  validateParams(employeeGrantParamsSchema),
+  validateBody(updateEmployeeGrantSchema),
+  asyncHandler(async (req, res) => {
+    const body = req.body as z.infer<typeof updateEmployeeGrantSchema>;
+    const grant = await updateEmployeeVaultGrant({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      grantId: req.params.grantId,
+      actor: actor(req),
+      accessLevel: body.accessLevel,
+    });
+    await auditEmployeeGrant(
+      req,
+      "update",
+      grant.id,
+      grant.employeeId,
+      grant.accessLevel,
+      grant.employee.name,
+    );
+    res.json({ grant });
+  }),
+);
+
+vaultRouter.delete(
+  "/items/:itemId/employee-grants/:grantId",
+  validateParams(employeeGrantParamsSchema),
+  asyncHandler(async (req, res) => {
+    const deleted = await deleteEmployeeVaultGrant({
+      companyId: companyId(req),
+      itemId: req.params.itemId,
+      grantId: req.params.grantId,
+      actor: actor(req),
+    });
+    await auditEmployeeGrant(
+      req,
+      "delete",
+      deleted.id,
+      deleted.employeeId,
+      deleted.accessLevel,
+      deleted.employeeId,
+    );
+    res.json({ ok: true });
+  }),
+);
+
+async function auditMemberAccess(
+  req: VaultRequest,
+  operation: "upsert" | "update" | "delete",
+  accessId: string,
+  userId: string,
+  accessLevel: VaultMemberAccessLevel,
+  label: string,
+): Promise<void> {
+  await recordAudit({
+    companyId: companyId(req),
+    actorUserId: req.userId,
+    action: `vault.member_access.${operation}`,
+    targetType: "vault_member_access",
+    targetId: accessId,
+    targetLabel: label,
+    metadata: { vaultItemId: req.params.itemId, userId, accessLevel },
+  });
+}
+
+async function auditEmployeeGrant(
+  req: VaultRequest,
+  operation: "upsert" | "update" | "delete",
+  grantId: string,
+  employeeId: string,
+  accessLevel: EmployeeVaultAccessLevel,
+  label: string,
+): Promise<void> {
+  await recordAudit({
+    companyId: companyId(req),
+    actorUserId: req.userId,
+    action: `vault.employee_grant.${operation}`,
+    targetType: "employee_vault_grant",
+    targetId: grantId,
+    targetLabel: label,
+    metadata: { vaultItemId: req.params.itemId, employeeId, accessLevel },
+  });
+}

--- a/App/server/services/agent/systemPrompt.ts
+++ b/App/server/services/agent/systemPrompt.ts
@@ -149,9 +149,9 @@ export function toolsBriefing(
     );
   } else if (codingToolsAvailable) {
     lines.push(
-      "- Coding: `bash`, `read_file`, `write_file`, `edit_file`, `list_dir`, `glob`, `grep`, " +
-        "rooted at your working directory (which holds any granted git repos under `repos/` and " +
-        "`code-repos/`).",
+      "- Coding: `read_file`, `write_file`, `edit_file`, `list_dir`, `glob`, and `grep`, " +
+        "confined to your working directory (which holds any granted git repos under `repos/` " +
+        "and `code-repos/`). Host execution never exposes an unrestricted shell.",
     );
   }
 
@@ -180,12 +180,22 @@ export function toolsBriefing(
     );
   }
 
-  lines.push("- Browser tools (when enabled) and any company-configured MCP server tools.", "");
+  lines.push(
+    "- Browser tools (when enabled) and any company-configured MCP server tools.",
+    "- Vault credentials are default-deny and item-granted. Never ask a teammate to paste a " +
+      "password into chat. Find `list_vault_items`, then use `browser_fill_vault` on the exact " +
+      "saved origin so the value stays out of model context and transcripts. Stored passwords " +
+      "only fill Login password inputs, and Browser policy still applies. Use " +
+      "`create_vault_login` for a server-generated company-visible password. " +
+      "`browser_save_vault_login` always requires owner/admin approval to capture a password " +
+      "already present in the browser into a restricted item; neither path returns the password.",
+    "",
+  );
 
   if (discovery) {
     lines.push(
       "### Reaching the rest",
-      "- Email, finance, Bases, notes, resources, charts, dashboards, workspace channels, " +
+      "- Email, finance, Vault, Bases, notes, resources, charts, dashboards, workspace channels, " +
         "handoffs and your company's integrations all live in the catalogue. Call `find_tools` " +
         'with what you are trying to do — "record a payment", "reply to that email", "read a ' +
         'spreadsheet" — and it returns the exact tools and their arguments.',
@@ -194,7 +204,7 @@ export function toolsBriefing(
     );
   } else {
     lines.push(
-      "- Email, finance, Bases, notes, resources, charts, dashboards, workspace channels, " +
+      "- Email, finance, Vault, Bases, notes, resources, charts, dashboards, workspace channels, " +
         "handoffs and your company's integrations are in your tool list too. Grants still apply — " +
         "if a tool denies access, say so plainly rather than working around it.",
     );

--- a/App/server/services/agent/tools/coding.test.ts
+++ b/App/server/services/agent/tools/coding.test.ts
@@ -270,6 +270,60 @@ describe("path confinement", () => {
     );
     assert.equal(await pathExists(futureTarget), false);
   });
+
+  test("blocks App-private state and Git control paths through direct, case, and symlink aliases", async (t) => {
+    if (process.platform === "win32") {
+      t.skip("symlink behavior is platform-specific");
+      return;
+    }
+    const { root } = await makeWorkspace(t);
+    const tools = toolset(root);
+    await fs.mkdir(path.join(root, ".git"));
+    await fs.mkdir(path.join(root, "code-repos", ".ssh"), { recursive: true });
+    await fs.writeFile(path.join(root, ".git", "config"), "SAFE_GIT_CONFIG");
+    await fs.writeFile(path.join(root, "code-repos", ".ssh", "deploy-key"), "PRIVATE_KEY");
+    await fs.writeFile(path.join(root, ".browser-state.json"), "BROWSER_COOKIE");
+    await fs.symlink(".browser-state.json", path.join(root, "state-link"));
+    await fs.symlink(".git", path.join(root, "git-link"));
+
+    const attempts = [
+      tools.read_file.run({ path: ".git/config" }),
+      tools.read_file.run({ path: ".GIT/config" }),
+      tools.write_file.run({ path: ".git/commondir", content: "../../outside" }),
+      tools.edit_file.run({
+        path: "code-repos/.ssh/deploy-key",
+        old_string: "PRIVATE_KEY",
+        new_string: "changed",
+      }),
+      tools.read_file.run({ path: ".browser-state.json" }),
+      tools.read_file.run({ path: ".BROWSER-STATE.JSON" }),
+      tools.read_file.run({ path: "state-link" }),
+      tools.write_file.run({ path: "git-link/commondir", content: "../../outside" }),
+      tools.list_dir.run({ path: ".ssh" }),
+      tools.glob.run({ pattern: "*", path: ".git" }),
+      tools.grep.run({ pattern: "COOKIE", path: "." }),
+    ];
+    const results = await Promise.all(attempts);
+    for (const [index, result] of results.entries()) {
+      if (index === results.length - 1) {
+        assert.equal(result.isError, undefined);
+        assert.doesNotMatch(result.content, /BROWSER_COOKIE|PRIVATE_KEY|SAFE_GIT_CONFIG/);
+      } else {
+        assertToolError(result, /(App-managed|reserved|no such)/i);
+        assert.doesNotMatch(result.content, /BROWSER_COOKIE|PRIVATE_KEY|SAFE_GIT_CONFIG/);
+      }
+    }
+
+    const listed = await tools.list_dir.run({ path: "." });
+    assert.equal(listed.isError, undefined);
+    assert.doesNotMatch(listed.content, /browser-state|state-link|git-link|\.git|\.ssh/);
+    assert.equal(await fs.readFile(path.join(root, ".git", "config"), "utf8"), "SAFE_GIT_CONFIG");
+    assert.equal(
+      await fs.readFile(path.join(root, "code-repos", ".ssh", "deploy-key"), "utf8"),
+      "PRIVATE_KEY",
+    );
+    await assert.rejects(fs.stat(path.join(root, ".git", "commondir")), /ENOENT/);
+  });
 });
 
 describe("read_file", () => {

--- a/App/server/services/agent/tools/codingFiles.ts
+++ b/App/server/services/agent/tools/codingFiles.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AgentTool } from "../types.js";
 import {
   fail,
+  isProtectedWorkspaceRelativePath,
   lstatIfPresent,
   MAX_FILE_BYTES,
   ok,
@@ -248,7 +249,11 @@ export function listDirTool(ctx: CodingToolContext): AgentTool {
         return fail(`No such directory: ${rel}`);
       }
       const lines = entries
-        .filter((entry) => entry.name !== "node_modules" && entry.name !== ".git")
+        .filter((entry) => {
+          if (entry.name === "node_modules" || entry.isSymbolicLink()) return false;
+          const relative = path.relative(ctx.cwd, path.join(resolved.path, entry.name));
+          return !isProtectedWorkspaceRelativePath(relative);
+        })
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name));
       const truncated = lines.length > MAX_LIST_RESULTS;

--- a/App/server/services/agent/tools/codingShared.ts
+++ b/App/server/services/agent/tools/codingShared.ts
@@ -7,7 +7,7 @@ import type { ToolResult } from "../types.js";
 export type CodingToolContext = {
   /** Absolute path the employee is confined to. */
   cwd: string;
-  /** Env for `bash` (company secrets + materialized repo vars merged in). */
+  /** Explicit env for `bash` (for example Environment secrets). */
   env: Record<string, string>;
   /** Hard ceiling for a single `bash` invocation. */
   bashTimeoutMs: number;
@@ -18,7 +18,8 @@ export type CodingToolContext = {
 
 export const MAX_FILE_BYTES = 400 * 1024;
 const FILE_TEMP_PREFIX = ".genosyn-write-";
-const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", ".cache"]);
+const SKIP_DIRS = new Set(["node_modules", ".git", ".ssh", "dist", "build", ".next", ".cache"]);
+const PROTECTED_WORKSPACE_COMPONENTS = new Set([".git", ".ssh"]);
 
 /** Resolve `p` under `cwd`, rejecting anything that escapes the sandbox. */
 export function resolveInside(cwd: string, p: string): { path: string } | { error: string } {
@@ -26,6 +27,10 @@ export function resolveInside(cwd: string, p: string): { path: string } | { erro
   const root = path.resolve(cwd);
   if (target !== root && !target.startsWith(root + path.sep)) {
     return { error: `Path escapes the working directory: ${p}` };
+  }
+  const relative = path.relative(root, target);
+  if (isProtectedWorkspaceRelativePath(relative)) {
+    return { error: `Path is reserved for App-managed workspace state: ${p}` };
   }
   try {
     const realRoot = fs.realpathSync(root);
@@ -43,16 +48,37 @@ export function resolveInside(cwd: string, p: string): { path: string } | { erro
     if (realExisting !== realRoot && !realExisting.startsWith(realRoot + path.sep)) {
       return { error: `Path traverses a symlink outside the working directory: ${p}` };
     }
+    if (isProtectedWorkspaceRelativePath(path.relative(realRoot, realExisting))) {
+      return { error: `Path resolves through App-managed workspace state: ${p}` };
+    }
     if (pathEntryExists(target)) {
       const realTarget = fs.realpathSync(target);
       if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
         return { error: `Path resolves outside the working directory: ${p}` };
+      }
+      if (isProtectedWorkspaceRelativePath(path.relative(realRoot, realTarget))) {
+        return { error: `Path resolves to App-managed workspace state: ${p}` };
       }
     }
   } catch {
     return { error: `Could not safely resolve path: ${p}` };
   }
   return { path: target };
+}
+
+/** Never expose App-managed credentials or Git control files to model tools. */
+export function isProtectedWorkspaceRelativePath(relativePath: string): boolean {
+  if (!relativePath || relativePath === ".") return false;
+  const components = relativePath
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .map((component) => component.toLowerCase());
+  return components.some(
+    (component) =>
+      PROTECTED_WORKSPACE_COMPONENTS.has(component) ||
+      component.startsWith(".browser-state.json") ||
+      component.startsWith(".genosyn-git-fetch-"),
+  );
 }
 
 function pathEntryExists(target: string): boolean {
@@ -215,12 +241,13 @@ export async function walk(
   for (const entry of entries) {
     if (signal?.aborted) return false;
     const absolute = path.join(dir, entry.name);
+    const relative = path.relative(root, absolute);
+    if (isProtectedWorkspaceRelativePath(relative)) continue;
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) continue;
       const keepGoing = await walk(absolute, root, visit, signal);
       if (!keepGoing) return false;
     } else if (entry.isFile()) {
-      const relative = path.relative(root, absolute);
       const keepGoing = await visit(relative, absolute);
       if (!keepGoing) return false;
     }

--- a/App/server/services/agent/tools/credentialIsolation.test.ts
+++ b/App/server/services/agent/tools/credentialIsolation.test.ts
@@ -5,7 +5,7 @@ import { filterCodingToolsForCredentialIsolation } from "./index.js";
 
 const tools = [{ name: "bash" }, { name: "read_file" }] as AgentTool[];
 
-test("bubblewrap deployments expose coding only through sandboxed bash for every turn", () => {
+test("only bubblewrap deployments expose bash to an AI Employee", () => {
   assert.deepEqual(
     filterCodingToolsForCredentialIsolation(tools, true, "host").map((tool) => tool.name),
     [],
@@ -16,7 +16,7 @@ test("bubblewrap deployments expose coding only through sandboxed bash for every
   );
   assert.deepEqual(
     filterCodingToolsForCredentialIsolation(tools, false, "host").map((tool) => tool.name),
-    ["bash", "read_file"],
+    ["read_file"],
   );
   assert.deepEqual(
     filterCodingToolsForCredentialIsolation(tools, false, "bubblewrap").map((tool) => tool.name),

--- a/App/server/services/agent/tools/genosynHelp.test.ts
+++ b/App/server/services/agent/tools/genosynHelp.test.ts
@@ -19,6 +19,17 @@ async function fixture(): Promise<string> {
   );
   await writeFile(path.join(root, ".env.production"), "SECRET=environment-secret\n");
   await writeFile(path.join(root, "App", "vite.config.ts"), "export default {};\n");
+  await writeFile(
+    path.join(root, ".genosyn-help-manifest"),
+    [
+      "App/server/feature.ts",
+      "App/config.ts",
+      "App/vite.config.ts",
+      ".env.production",
+      "ROADMAP.md",
+      "",
+    ].join("\n"),
+  );
   return root;
 }
 
@@ -80,7 +91,7 @@ describe("Genosyn Help source tools", () => {
     for (const secretPath of ["App/config.ts", ".env.production", "App/server/linked.ts"]) {
       const read = await byName.get("read_genosyn_source")!.run({ path: secretPath });
       assert.equal(read.isError, true);
-      assert.match(read.content, /unavailable/);
+      assert.match(read.content, /unavailable|public release snapshot/);
     }
 
     const searched = await byName
@@ -93,7 +104,42 @@ describe("Genosyn Help source tools", () => {
       .get("search_genosyn_source")!
       .run({ query: "secret", path: "App/config.ts" });
     assert.equal(directSearch.isError, true);
-    assert.match(directSearch.content, /unavailable/);
+    assert.match(directSearch.content, /unavailable|public release snapshot/);
+  });
+
+  test("never exposes data, live config, manifest, or unlisted files", async () => {
+    const root = await fixture();
+    await mkdir(path.join(root, "App", "data", "nested"), { recursive: true });
+    await writeFile(path.join(root, "App", "data", ".instance-secrets.json"), "ROOT_SECRET");
+    await writeFile(path.join(root, "App", "data", "nested", "token.txt"), "NESTED_SECRET");
+    await writeFile(path.join(root, "App", "config.ts"), "encryptionSecret: 'CONFIG_SECRET'");
+    await writeFile(path.join(root, "App", "server", "private.ts"), "UNTRACKED_SECRET");
+
+    const source = createGenosynHelpSource(root);
+    const byName = new Map(source.tools.map((tool) => [tool.name, tool]));
+    const read = byName.get("read_genosyn_source")!;
+    for (const requested of [
+      "App/data/.instance-secrets.json",
+      "App/data/nested/token.txt",
+      "App/config.ts",
+      ".genosyn-help-manifest",
+      "App/server/private.ts",
+    ]) {
+      const result = await read.run({ path: requested });
+      assert.equal(result.isError, true, requested);
+      assert.doesNotMatch(
+        result.content,
+        /ROOT_SECRET|NESTED_SECRET|CONFIG_SECRET|UNTRACKED_SECRET/,
+      );
+    }
+
+    const listed = await byName.get("list_genosyn_source")!.run({ path: "App" });
+    assert.equal(listed.isError, undefined);
+    assert.doesNotMatch(listed.content, /(^|\n)(?:data\/|config\.ts|private\.ts)($|\n)/);
+
+    const search = await byName.get("search_genosyn_source")!.run({ query: "SECRET", path: "App" });
+    assert.equal(search.isError, undefined);
+    assert.equal(search.content, "(no matches)");
   });
 
   test("returns explicit errors when the release has no source snapshot", async () => {

--- a/App/server/services/agent/tools/genosynHelp.ts
+++ b/App/server/services/agent/tools/genosynHelp.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
@@ -17,6 +18,7 @@ const MAX_READ_BYTES = 400 * 1024;
 const MAX_SEARCH_FILE_BYTES = 1024 * 1024;
 const MAX_SEARCH_MATCHES = 200;
 const MAX_WALK_FILES = 10_000;
+const SOURCE_MANIFEST = ".genosyn-help-manifest";
 const IGNORED_DIRECTORIES = new Set([
   ".git",
   ".claude",
@@ -29,6 +31,11 @@ const IGNORED_DIRECTORIES = new Set([
 ]);
 const DENIED_SOURCE_PATHS = new Set(["app/config.ts", "app/config.js"]);
 const DENIED_SOURCE_BASENAMES = new Set([".env", ".npmrc", ".netrc"]);
+const DENIED_FILES = new Set([
+  SOURCE_MANIFEST,
+  ".instance-secrets.json",
+  ".instance-secrets.required",
+]);
 
 type HelpSource = {
   root: string | null;
@@ -37,14 +44,25 @@ type HelpSource = {
 };
 
 export function createGenosynHelpSource(sourceRoot = resolveGenosynSourceRoot()): HelpSource {
-  const root = sourceRoot ? fs.realpathSync(path.resolve(sourceRoot)) : null;
-  const availability = root
+  let root: string | null = null;
+  try {
+    root = sourceRoot ? fs.realpathSync(path.resolve(sourceRoot)) : null;
+  } catch {
+    root = null;
+  }
+  const publicPaths = root ? resolvePublicSourcePaths(root) : null;
+  const safeRoot = root && publicPaths ? root : null;
+  const availability = safeRoot
     ? "The complete source snapshot for this running Genosyn release is available through the three read-only source tools below."
     : "This installation does not contain its Genosyn source snapshot. Explain that limitation plainly and answer from the product context below without inventing implementation details.";
 
   return {
-    root,
-    tools: [listSourceTool(root), searchSourceTool(root), readSourceTool(root)],
+    root: safeRoot,
+    tools: [
+      listSourceTool(safeRoot, publicPaths),
+      searchSourceTool(safeRoot, publicPaths),
+      readSourceTool(safeRoot, publicPaths),
+    ],
     prompt: [
       "",
       "## Genosyn Help",
@@ -58,6 +76,43 @@ export function createGenosynHelpSource(sourceRoot = resolveGenosynSourceRoot())
       "Do not guess about a source-level fact you can verify with the tools. Do not dump large files into the answer; inspect only the relevant slices and synthesize a concise response.",
     ].join("\n"),
   };
+}
+
+/**
+ * Build a strict public-source allowlist. Development reads only Git-tracked
+ * paths; production reads the immutable manifest generated into the Docker
+ * source snapshot. If neither authority exists, Help fails closed instead of
+ * walking an arbitrary live directory.
+ */
+export function resolvePublicSourcePaths(root: string): Set<string> | null {
+  const manifest = path.join(root, SOURCE_MANIFEST);
+  let candidates: string[];
+  try {
+    if (fs.existsSync(manifest)) {
+      candidates = fs.readFileSync(manifest, "utf8").split("\n");
+    } else if (fs.existsSync(path.join(root, ".git"))) {
+      const output = execFileSync("git", ["-C", root, "ls-files", "-z"], {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin" },
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      candidates = output.split("\0");
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  const allowed = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate.trim()) continue;
+    const normalized = normalizeSourcePath(candidate);
+    if (!normalized || normalized === "." || sourcePathDenied(normalized)) continue;
+    allowed.add(normalized);
+  }
+  return allowed.size > 0 ? allowed : null;
 }
 
 export function resolveGenosynSourceRoot(): string | null {
@@ -91,7 +146,7 @@ function unavailable(): ToolResult {
 }
 
 function isDeniedSourcePath(relativePath: string): boolean {
-  const normalized = relativePath.split(path.sep).join("/").toLocaleLowerCase();
+  const normalized = relativePath.split(path.sep).join("/").toLowerCase();
   if (DENIED_SOURCE_PATHS.has(normalized)) return true;
   const basename = path.posix.basename(normalized);
   return DENIED_SOURCE_BASENAMES.has(basename) || basename.startsWith(".env.");
@@ -100,34 +155,93 @@ function isDeniedSourcePath(relativePath: string): boolean {
 async function resolveExisting(
   root: string,
   requested: string,
+  publicPaths: Set<string>,
 ): Promise<{ path: string; relative: string } | { error: string }> {
-  const relative = requested.trim() || ".";
-  if (path.isAbsolute(relative)) {
+  const raw = requested.trim() || ".";
+  if (path.isAbsolute(raw)) {
     return { error: "Use a path relative to the Genosyn repository root." };
+  }
+  const normalized = normalizeSourcePath(raw);
+  if (!normalized) {
+    return { error: `Path escapes the Genosyn source snapshot: ${requested}` };
+  }
+  const relative = normalized;
+  if (sourcePathDenied(relative) || !sourcePathAllowed(relative, publicPaths)) {
+    return { error: `Source path is not part of the public release snapshot: ${requested}` };
   }
   const target = path.resolve(root, relative);
   if (target !== root && !target.startsWith(root + path.sep)) {
     return { error: `Path escapes the Genosyn source snapshot: ${requested}` };
   }
   try {
-    const [realRoot, realTarget] = await Promise.all([fsp.realpath(root), fsp.realpath(target)]);
+    const [realRoot, realTarget, targetStat] = await Promise.all([
+      fsp.realpath(root),
+      fsp.realpath(target),
+      fsp.lstat(target),
+    ]);
+    if (targetStat.isSymbolicLink()) {
+      return {
+        error: `Symbolic links are not exposed by the public source snapshot: ${requested}`,
+      };
+    }
     if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
       return { error: `Path resolves outside the Genosyn source snapshot: ${requested}` };
     }
-    const resolvedRelative = path.relative(realRoot, realTarget) || ".";
-    if (isDeniedSourcePath(resolvedRelative)) {
+    const realRelative = path.relative(realRoot, realTarget).split(path.sep).join("/") || ".";
+    if (realRelative !== relative) {
+      return {
+        error: `Symbolic paths are not exposed by the public source snapshot: ${requested}`,
+      };
+    }
+    if (sourcePathDenied(realRelative)) {
       return { error: "That source path is unavailable from Help." };
     }
     return {
       path: realTarget,
-      relative: resolvedRelative,
+      relative: realRelative,
     };
   } catch {
     return { error: `No such source path: ${requested}` };
   }
 }
 
-function listSourceTool(root: string | null): AgentTool {
+function normalizeSourcePath(value: string): string | null {
+  const normalized = path.posix.normalize(value.replaceAll("\\", "/")).replace(/^\.\//, "");
+  if (!normalized || normalized === ".") return normalized || ".";
+  if (normalized === ".." || normalized.startsWith("../") || normalized.startsWith("/")) {
+    return null;
+  }
+  return normalized;
+}
+
+function sourcePathDenied(relative: string): boolean {
+  if (relative === ".") return false;
+  // Operators edit App/config.ts directly and may put live encryption, SMTP,
+  // OAuth, or model credentials there. Environment and credential files are
+  // denied even when they remain Git-tracked.
+  if (isDeniedSourcePath(relative)) return true;
+  const components = relative.split("/");
+  if (
+    components.some((component) => IGNORED_DIRECTORIES.has(component.toLowerCase()))
+  ) {
+    return true;
+  }
+  const filename = (components.at(-1) ?? "").toLowerCase();
+  if (DENIED_FILES.has(filename) || filename.startsWith(".env")) return true;
+  return false;
+}
+
+function sourcePathAllowed(relative: string, publicPaths: Set<string>): boolean {
+  if (relative === ".") return true;
+  if (publicPaths.has(relative)) return true;
+  const prefix = relative.endsWith("/") ? relative : `${relative}/`;
+  for (const candidate of publicPaths) {
+    if (candidate.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function listSourceTool(root: string | null, publicPaths: Set<string> | null): AgentTool {
   return {
     name: "list_genosyn_source",
     description:
@@ -143,8 +257,8 @@ function listSourceTool(root: string | null): AgentTool {
       additionalProperties: false,
     },
     run: async (input) => {
-      if (!root) return unavailable();
-      const resolved = await resolveExisting(root, String(input.path ?? "."));
+      if (!root || !publicPaths) return unavailable();
+      const resolved = await resolveExisting(root, String(input.path ?? "."), publicPaths);
       if ("error" in resolved) return fail(resolved.error);
       let entries: fs.Dirent[];
       try {
@@ -153,13 +267,11 @@ function listSourceTool(root: string | null): AgentTool {
         return fail(`${resolved.relative} is not a directory.`);
       }
       const lines = entries
-        .filter((entry) => !IGNORED_DIRECTORIES.has(entry.name))
-        .filter(
-          (entry) =>
-            !isDeniedSourcePath(
-              resolved.relative === "." ? entry.name : path.join(resolved.relative, entry.name),
-            ),
-        )
+        .filter((entry) => {
+          const relative =
+            resolved.relative === "." ? entry.name : `${resolved.relative}/${entry.name}`;
+          return !sourcePathDenied(relative) && sourcePathAllowed(relative, publicPaths);
+        })
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name));
       return ok(lines.join("\n") || "(empty)");
@@ -167,7 +279,7 @@ function listSourceTool(root: string | null): AgentTool {
   };
 }
 
-function readSourceTool(root: string | null): AgentTool {
+function readSourceTool(root: string | null, publicPaths: Set<string> | null): AgentTool {
   return {
     name: "read_genosyn_source",
     description:
@@ -183,9 +295,9 @@ function readSourceTool(root: string | null): AgentTool {
       additionalProperties: false,
     },
     run: async (input) => {
-      if (!root) return unavailable();
+      if (!root || !publicPaths) return unavailable();
       const requested = String(input.path ?? "");
-      const resolved = await resolveExisting(root, requested);
+      const resolved = await resolveExisting(root, requested, publicPaths);
       if ("error" in resolved) return fail(resolved.error);
       let stat: fs.Stats;
       try {
@@ -219,7 +331,7 @@ function readSourceTool(root: string | null): AgentTool {
   };
 }
 
-function searchSourceTool(root: string | null): AgentTool {
+function searchSourceTool(root: string | null, publicPaths: Set<string> | null): AgentTool {
   return {
     name: "search_genosyn_source",
     description:
@@ -241,11 +353,11 @@ function searchSourceTool(root: string | null): AgentTool {
       additionalProperties: false,
     },
     run: async (input) => {
-      if (!root) return unavailable();
+      if (!root || !publicPaths) return unavailable();
       const query = String(input.query ?? "");
       if (!query.trim()) return fail("query is required.");
       if (query.length > 500) return fail("query must be 500 characters or fewer.");
-      const resolved = await resolveExisting(root, String(input.path ?? "."));
+      const resolved = await resolveExisting(root, String(input.path ?? "."), publicPaths);
       if ("error" in resolved) return fail(resolved.error);
       const caseSensitive = input.case_sensitive === true;
       const needle = caseSensitive ? query : query.toLocaleLowerCase();
@@ -262,8 +374,8 @@ function searchSourceTool(root: string | null): AgentTool {
           return;
         }
         if (!stat.isFile() || stat.size > MAX_SEARCH_FILE_BYTES) return;
-        const relative = path.relative(root, filePath);
-        if (isDeniedSourcePath(relative)) return;
+        const relative = path.relative(root, filePath).split(path.sep).join("/");
+        if (sourcePathDenied(relative) || !publicPaths.has(relative)) return;
         const comparablePath = caseSensitive ? relative : relative.toLocaleLowerCase();
         if (comparablePath.includes(needle)) matches.push(`${relative}: path match`);
         if (matches.length >= MAX_SEARCH_MATCHES) return;
@@ -303,9 +415,10 @@ function searchSourceTool(root: string | null): AgentTool {
         const entries = await fsp.readdir(target, { withFileTypes: true });
         for (const entry of entries) {
           if (matches.length >= MAX_SEARCH_MATCHES || visited >= MAX_WALK_FILES) return;
-          if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
           const child = path.join(target, entry.name);
-          if (isDeniedSourcePath(path.relative(root, child))) continue;
+          const relative = path.relative(root, child).split(path.sep).join("/");
+          if (sourcePathDenied(relative) || !sourcePathAllowed(relative, publicPaths)) continue;
+          if (entry.isSymbolicLink()) continue;
           await walk(child);
         }
       };

--- a/App/server/services/agent/tools/grantDead.ts
+++ b/App/server/services/agent/tools/grantDead.ts
@@ -10,6 +10,11 @@ import {
   SIGNING_ACCESS_RANK,
   type SigningAccessLevel,
 } from "../../../db/entities/EmployeeSigningGrant.js";
+import {
+  EMPLOYEE_VAULT_ACCESS_RANK,
+  EmployeeVaultGrant,
+  type EmployeeVaultAccessLevel,
+} from "../../../db/entities/EmployeeVaultGrant.js";
 import { EmployeeConnectionGrant } from "../../../db/entities/EmployeeConnectionGrant.js";
 import { IntegrationConnection } from "../../../db/entities/IntegrationConnection.js";
 import { EXPLORE_PROVIDERS } from "../../explore.js";
@@ -135,6 +140,14 @@ const SIGNING_TOOL_ACCESS: Record<string, SigningAccessLevel> = {
 
 const SIGNING_GATED_TOOLS = new Set(Object.keys(SIGNING_TOOL_ACCESS));
 
+/** Vault reads and metadata writes are item-granted. Creating a generated
+ * login stays live because it auto-grants its creator. */
+const VAULT_TOOL_ACCESS: Record<string, EmployeeVaultAccessLevel> = {
+  list_vault_items: "use",
+  update_vault_login: "manage",
+};
+const VAULT_GATED_TOOLS = new Set(Object.keys(VAULT_TOOL_ACCESS));
+
 /**
  * The revenue surface (Revenue section, M32): every tool — reads included —
  * answers to an `EmployeeRevenueGrant`. Same shape as finance: one grant row
@@ -241,6 +254,7 @@ export function assertGrantSetsResolve(): void {
     ...MAIL_GATED_TOOLS,
     ...FINANCE_GATED_TOOLS,
     ...SIGNING_GATED_TOOLS,
+    ...VAULT_GATED_TOOLS,
     ...REVENUE_GATED_TOOLS,
     ...EXPLORE_CONNECTION_GATED_TOOLS,
   ].filter((n) => !known.has(n));
@@ -297,6 +311,22 @@ export async function deadToolNames(employeeId: string): Promise<Set<string>> {
       where: { employeeId },
     });
     if (revenue === 0) for (const t of REVENUE_GATED_TOOLS) dead.add(t);
+    const vaultGrants = await AppDataSource.getRepository(EmployeeVaultGrant).find({
+      where: { employeeId },
+    });
+    if (vaultGrants.length === 0) {
+      for (const t of VAULT_GATED_TOOLS) dead.add(t);
+    } else {
+      const ranks = vaultGrants
+        .map((grant) => EMPLOYEE_VAULT_ACCESS_RANK[grant.accessLevel])
+        .filter((rank): rank is number => typeof rank === "number");
+      const best = ranks.length > 0 ? Math.max(...ranks) : undefined;
+      if (typeof best === "number") {
+        for (const [tool, required] of Object.entries(VAULT_TOOL_ACCESS)) {
+          if (best < EMPLOYEE_VAULT_ACCESS_RANK[required]) dead.add(tool);
+        }
+      }
+    }
     const connectionGrants = await AppDataSource.getRepository(EmployeeConnectionGrant).find({
       where: { employeeId },
       select: ["connectionId"],

--- a/App/server/services/agent/tools/index.ts
+++ b/App/server/services/agent/tools/index.ts
@@ -76,7 +76,7 @@ export async function gatherEmployeeTools(params: {
   cwd: string;
   /** Runtime-local tools (for example bounded parallel delegation). */
   localTools?: AgentTool[];
-  /** Env for the bash tool (company secrets + materialized repo vars). */
+  /** Explicit env for the coding runtime (for example Environment secrets). */
   toolEnv: Record<string, string>;
   bashTimeoutMs: number;
   /** Model-facing names a Skill's declared toolset asked to keep resident. */
@@ -336,7 +336,12 @@ export function filterCodingToolsForCredentialIsolation(
   // fail-closed branch even though the install-level availability gate rejects
   // the turn before the Codex credential is materialized.
   if (required) return [];
-  return tools;
+  // A host shell runs as the App's own OS user. A working-directory setting is
+  // not a filesystem boundary: it can read the database, managed encryption
+  // roots, or another Browser child's bearer token through /proc. Keep host
+  // mode useful through the path-confined file/search tools, but never expose
+  // an unrestricted same-UID shell to an AI Employee.
+  return tools.filter((tool) => tool.name !== "bash");
 }
 
 /**

--- a/App/server/services/agent/tools/mcpSources.ts
+++ b/App/server/services/agent/tools/mcpSources.ts
@@ -3,9 +3,13 @@ import { fileURLToPath } from "node:url";
 import { AppDataSource } from "../../../db/datasource.js";
 import { McpServer } from "../../../db/entities/McpServer.js";
 import { AIEmployee } from "../../../db/entities/AIEmployee.js";
+import { Company } from "../../../db/entities/Company.js";
 import { Routine } from "../../../db/entities/Routine.js";
 import { config } from "../../../../config.js";
 import { createBrowserSession } from "../../browserSessions.js";
+import { migrateLegacyBrowserStorage } from "../../browserStorage.js";
+import { purgeLegacyCodeRepoSshFiles } from "../../codeRepoSshFiles.js";
+import { employeeDir } from "../../paths.js";
 import { assertSafeOutboundUrl } from "../../../lib/outboundUrl.js";
 import type { McpServerSpec, McpToolGuard } from "./mcpBridge.js";
 
@@ -62,11 +66,17 @@ export async function loadBrowserConfig(
   employeeId: string,
   options: { routineId?: string; conversationId?: string; runId?: string },
 ): Promise<BrowserConfig> {
+  const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({ id: employeeId });
+  if (!employee) return BROWSER_DISABLED;
+  // This runs before the coding registry is assembled. An upgrade therefore
+  // removes the legacy workspace-visible cookie file before host file tools or
+  // bubblewrapped bash can observe the employee workspace.
+  await migrateLegacyBrowserStorage(employee.companyId, employee.id);
+  const company = await AppDataSource.getRepository(Company).findOneBy({ id: employee.companyId });
+  if (company) purgeLegacyCodeRepoSshFiles(employeeDir(company.slug, employee.slug));
   if (config.security.multiTenant && !config.agent.browserEnabledInMultiTenant) {
     return BROWSER_DISABLED;
   }
-  const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({ id: employeeId });
-  if (!employee) return BROWSER_DISABLED;
 
   let enabled = employee.browserEnabled;
   if (options.routineId) {
@@ -125,6 +135,7 @@ export function browserEnvFor(
   if (cfg.approvalRequired) env.GENOSYN_BROWSER_APPROVAL_REQUIRED = "1";
   if (cfg.sessionId && cfg.sessionToken) {
     env.GENOSYN_BROWSER_API = `${internalHttpBase()}/api/internal/browser/sessions/${cfg.sessionId}`;
+    env.GENOSYN_BROWSER_SESSION_ID = cfg.sessionId;
     env.GENOSYN_BROWSER_SESSION_TOKEN = cfg.sessionToken;
   }
   // The allow list is enforced server-side in browserRpc on every /open —

--- a/App/server/services/agent/tools/parallelDelegation.test.ts
+++ b/App/server/services/agent/tools/parallelDelegation.test.ts
@@ -72,6 +72,8 @@ test("chat and Routine briefings promise only tools the runtime offers", () => {
   }
   assert.match(toolsBriefing("routine", true), /explicitly asks to use subagents/);
   assert.doesNotMatch(toolsBriefing("chat", false, false), /`bash`/);
+  assert.doesNotMatch(toolsBriefing("chat", false, true, false), /`bash`/);
+  assert.match(toolsBriefing("chat", false, true, false), /`read_file`/);
   assert.match(toolsBriefing("chat", false, true, true), /isolated `bash`/);
   assert.doesNotMatch(toolsBriefing("chat", false, true, true), /`read_file`/);
   assert.match(toolsBriefing("chat", false, true, true), /bubblewrap deployment/);

--- a/App/server/services/agent/tools/toolIndex.ts
+++ b/App/server/services/agent/tools/toolIndex.ts
@@ -126,6 +126,12 @@ export const TOOL_DOMAINS: Record<string, ToolDomain> = {
       "delete_resource",
     ],
   },
+  vault: {
+    label: "Vault",
+    blurb:
+      "Use explicitly granted logins without putting stored passwords in model context; create generated logins safely.",
+    tools: ["list_vault_items", "create_vault_login", "update_vault_login"],
+  },
   signing: {
     label: "document signing",
     blurb:
@@ -930,6 +936,24 @@ export const TOOL_KEYWORDS: Record<string, string[]> = {
   create_resource: ["knowledge", "library", "ingest", "upload"],
   update_resource: ["knowledge", "library"],
   delete_resource: ["knowledge", "library"],
+
+  // Vault — password-manager and credential language should converge on the
+  // product surface without teaching the model to request plaintext.
+  list_vault_items: [
+    "password manager",
+    "credentials",
+    "login",
+    "sign in",
+    "api key",
+    "secure note",
+  ],
+  create_vault_login: [
+    "generate password",
+    "save login",
+    "new credentials",
+    "create account password",
+  ],
+  update_vault_login: ["rename login", "change username", "update login context"],
 
   // Signing — operators will usually say contract, agreement, e-signature,
   // or the incumbent product name rather than "signature envelope".

--- a/App/server/services/approvals.ts
+++ b/App/server/services/approvals.ts
@@ -22,6 +22,9 @@ import {
   approvalPageUrlPreview,
   redactApprovalSummary,
 } from "./approvalRedaction.js";
+import { decryptSecretWithStrongKeys, encryptSecret } from "../lib/secret.js";
+import { getEffectiveInstanceSecrets } from "../lib/instanceSecrets.js";
+import { Membership } from "../db/entities/Membership.js";
 
 export { approvalArgsPreview, redactApprovalSummary } from "./approvalRedaction.js";
 
@@ -88,7 +91,8 @@ function parsePaymentPayload(json: string | null): LightningPaymentPayload {
 
 /**
  * Captured by `browser_submit` when the employee's `browserApprovalRequired`
- * flag is on. The MCP child holds the live page state — the server only
+ * flag is on, and always by a sensitive Vault password capture. The MCP child
+ * holds the live page state — the server only
  * stores enough metadata for the approver to make an informed call. On
  * approve, the model retries via `browser_resume(approvalId)` and the MCP
  * re-executes the action against the still-live browser context.
@@ -97,12 +101,15 @@ function parsePaymentPayload(json: string | null): LightningPaymentPayload {
  * is a no-op because we don't have access to the browser session; the
  * model is the only thing that can drive it.
  */
-export type BrowserActionPayload = {
-  selector: string;
-  /** Optional key to press (e.g. "Enter") — null when the action is a click. */
-  key: string | null;
-  /** Page URL captured at queue time. Surfaced to the approver. */
-  pageUrl: string;
+export type BrowserApprovalTargetDescriptor = {
+  /** Safe DOM element category. No values or text content are persisted. */
+  tagName: string;
+  inputType: string | null;
+  /** Origin + path only; query, fragment, and userinfo are discarded. */
+  frameUrl: string;
+  formAction: string | null;
+  formMethod: string | null;
+  submitsForm: boolean;
 };
 
 type BrowserExecutionState = {
@@ -113,30 +120,247 @@ type BrowserExecutionState = {
   completedAt?: string;
 };
 
-function parseBrowserActionPayload(json: string | null): BrowserActionPayload {
-  if (!json) throw new Error("Approval payload is empty");
-  let value: unknown;
-  try {
-    value = JSON.parse(json);
-  } catch {
-    throw new Error("Approval payload is not valid JSON");
-  }
-  const payload = value as Partial<BrowserActionPayload> | null;
-  if (
-    !payload ||
-    typeof payload !== "object" ||
-    typeof payload.selector !== "string" ||
-    payload.selector.length === 0 ||
-    (payload.key !== null && typeof payload.key !== "string") ||
-    typeof payload.pageUrl !== "string"
+export type BrowserApprovalExecution = {
+  state: "claimed" | "failed" | "executed";
+  claimId: string;
+  browserSessionId: string;
+  claimedAt: string;
+  completedAt?: string;
+};
+
+export type BrowserActionPayload = {
+  action: "submit" | "vault_capture";
+  selector: string;
+  /** Optional key to press (e.g. "Enter") — null when the action is a click. */
+  key: string | null;
+  /** Page URL captured at queue time. Surfaced to the approver. */
+  pageUrl: string;
+  browserSessionId?: string;
+  /** Keyed proof of the exact live target; opaque outside the App process. */
+  targetFingerprint?: string;
+  targetDescriptor?: BrowserApprovalTargetDescriptor;
+  expiresAt?: string;
+  vaultTitle?: string;
+  vaultUsername?: string;
+  vaultNotes?: string;
+  execution?: BrowserApprovalExecution;
+};
+
+type StoredBrowserActionPayload = Partial<BrowserActionPayload> & {
+  action?: "submit" | "vault_capture";
+  encryptedVaultCapture?: string;
+  executedAt?: string;
+};
+
+export class BrowserApprovalError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
   ) {
-    throw new Error("Invalid browser action payload");
+    super(message);
+    this.name = "BrowserApprovalError";
+  }
+}
+
+function vaultCaptureApprovalScope(approval: Pick<Approval, "id" | "companyId">): string {
+  return `company:${approval.companyId}:vault-capture-approval:${approval.id}`;
+}
+
+function ciphertextHasScope(ciphertext: string, expectedScope: string): boolean {
+  const parts = ciphertext.split(".");
+  if (parts.length !== 5 || parts[0] !== "v2") return false;
+  try {
+    return Buffer.from(parts[1], "base64url").toString("utf8") === expectedScope;
+  } catch {
+    return false;
+  }
+}
+
+function parseStoredBrowserActionPayload(approval: Approval): StoredBrowserActionPayload {
+  let stored: StoredBrowserActionPayload;
+  try {
+    stored = JSON.parse(approval.payloadJson || "{}") as StoredBrowserActionPayload;
+  } catch {
+    throw new Error("Browser approval payload is not valid JSON");
+  }
+  if (!stored || typeof stored !== "object") {
+    throw new Error("Browser approval payload has an invalid shape");
+  }
+  return stored;
+}
+
+function validBrowserTargetDescriptor(value: unknown): value is BrowserApprovalTargetDescriptor {
+  if (!value || typeof value !== "object") return false;
+  const descriptor = value as Partial<BrowserApprovalTargetDescriptor>;
+  return (
+    typeof descriptor.tagName === "string" &&
+    descriptor.tagName.length > 0 &&
+    descriptor.tagName.length <= 32 &&
+    (descriptor.inputType === null ||
+      (typeof descriptor.inputType === "string" && descriptor.inputType.length <= 32)) &&
+    typeof descriptor.frameUrl === "string" &&
+    descriptor.frameUrl.length > 0 &&
+    descriptor.frameUrl === safeBrowserApprovalPageUrl(descriptor.frameUrl) &&
+    (descriptor.formAction === null ||
+      (typeof descriptor.formAction === "string" &&
+        descriptor.formAction.length > 0 &&
+        descriptor.formAction === safeBrowserApprovalPageUrl(descriptor.formAction))) &&
+    (descriptor.formMethod === null ||
+      (typeof descriptor.formMethod === "string" && descriptor.formMethod.length <= 16)) &&
+    typeof descriptor.submitsForm === "boolean"
+  );
+}
+
+function validBrowserApprovalExecution(value: unknown): value is BrowserApprovalExecution {
+  if (!value || typeof value !== "object") return false;
+  const execution = value as Partial<BrowserApprovalExecution>;
+  return (
+    (execution.state === "claimed" ||
+      execution.state === "failed" ||
+      execution.state === "executed") &&
+    typeof execution.claimId === "string" &&
+    /^[0-9a-f-]{36}$/i.test(execution.claimId) &&
+    typeof execution.browserSessionId === "string" &&
+    typeof execution.claimedAt === "string" &&
+    (execution.completedAt === undefined || typeof execution.completedAt === "string")
+  );
+}
+
+/**
+ * Produce an opaque proof of a live browser target. Sensitive values (most
+ * importantly a captured password) may be included in `targetMaterial`, but
+ * only the HMAC is returned or persisted. Company, employee, BrowserSession,
+ * selector, and action identity are all domain-separated into the proof.
+ */
+export function computeBrowserActionTargetFingerprint(args: {
+  companyId: string;
+  employeeId: string;
+  browserSessionId: string;
+  action: "submit" | "vault_capture";
+  selector: string;
+  key: string | null;
+  pageUrl: string;
+  targetMaterial: Record<string, unknown>;
+}): string {
+  const fingerprintKey = crypto
+    .createHmac("sha256", getEffectiveInstanceSecrets().encryptionSecret)
+    .update("genosyn/browser-approval-target/v1", "utf8")
+    .digest();
+  return crypto
+    .createHmac("sha256", fingerprintKey)
+    .update(
+      JSON.stringify({
+        companyId: args.companyId,
+        employeeId: args.employeeId,
+        browserSessionId: args.browserSessionId,
+        action: args.action,
+        selector: args.selector,
+        key: args.key,
+        pageUrl: args.pageUrl,
+        targetMaterial: args.targetMaterial,
+      }),
+      "utf8",
+    )
+    .digest("hex");
+}
+
+/** Decode a browser approval while keeping Vault-capture metadata encrypted at rest. */
+export function readBrowserActionPayload(approval: Approval): BrowserActionPayload {
+  const stored = parseStoredBrowserActionPayload(approval);
+  if (stored.action === undefined) {
+    if (
+      typeof stored.selector !== "string" ||
+      stored.selector.length === 0 ||
+      (stored.key !== null && typeof stored.key !== "string") ||
+      typeof stored.pageUrl !== "string"
+    ) {
+      throw new Error("Browser approval payload has an invalid legacy shape");
+    }
+    return {
+      action: "submit",
+      selector: stored.selector,
+      key: stored.key,
+      pageUrl: stored.pageUrl,
+    };
+  }
+  if (stored.action !== "submit" && stored.action !== "vault_capture") {
+    throw new Error("Browser approval payload has an invalid action");
+  }
+  if (
+    typeof stored.browserSessionId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(stored.targetFingerprint ?? "") ||
+    !validBrowserTargetDescriptor(stored.targetDescriptor) ||
+    (stored.execution !== undefined && !validBrowserApprovalExecution(stored.execution))
+  ) {
+    throw new Error("Browser approval payload has an invalid target binding");
+  }
+  if (stored.action !== "vault_capture") {
+    if (typeof stored.selector !== "string" || typeof stored.pageUrl !== "string") {
+      throw new Error("Browser approval payload has an invalid shape");
+    }
+    return stored as BrowserActionPayload;
+  }
+  if (
+    typeof stored.encryptedVaultCapture !== "string" ||
+    !ciphertextHasScope(stored.encryptedVaultCapture, vaultCaptureApprovalScope(approval))
+  ) {
+    throw new Error("Vault capture approval payload is invalid");
+  }
+  let details: BrowserActionPayload;
+  try {
+    details = JSON.parse(
+      decryptSecretWithStrongKeys(stored.encryptedVaultCapture),
+    ) as BrowserActionPayload;
+  } catch {
+    throw new Error("Vault capture approval payload could not be decrypted");
+  }
+  if (
+    details.action !== "vault_capture" ||
+    typeof details.selector !== "string" ||
+    typeof details.pageUrl !== "string" ||
+    typeof details.browserSessionId !== "string" ||
+    typeof details.expiresAt !== "string" ||
+    typeof details.vaultTitle !== "string" ||
+    typeof details.vaultUsername !== "string" ||
+    typeof details.vaultNotes !== "string"
+  ) {
+    throw new Error("Vault capture approval payload has an invalid shape");
   }
   return {
-    selector: payload.selector,
-    key: payload.key,
-    pageUrl: payload.pageUrl,
+    ...details,
+    browserSessionId: stored.browserSessionId,
+    targetFingerprint: stored.targetFingerprint!,
+    targetDescriptor: stored.targetDescriptor!,
+    execution: stored.execution,
   };
+}
+
+/**
+ * Approval rows are durable and company-visible. Persist only the URL parts
+ * needed to bind a resumed browser action, never userinfo, query parameters,
+ * or fragments that may contain reset tokens or OAuth codes.
+ */
+export function safeBrowserApprovalPageUrl(value: string): string {
+  if (!value) return "";
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "";
+  }
+}
+
+function browserApprovalPageLabel(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
 }
 
 function parseBrowserExecutionState(json: string | null): BrowserExecutionState | null {
@@ -171,10 +395,22 @@ function hasLegacyBrowserExecutionStamp(approval: Approval): boolean {
   }
 }
 
+function browserPayloadExecutionState(approval: Approval): BrowserApprovalExecution["state"] | null {
+  try {
+    const stored = parseStoredBrowserActionPayload(approval);
+    return validBrowserApprovalExecution(stored.execution) ? stored.execution.state : null;
+  } catch {
+    return null;
+  }
+}
+
 export function browserApprovalWasExecuted(approval: Approval): boolean {
+  const payloadState = browserPayloadExecutionState(approval);
   return (
     hasLegacyBrowserExecutionStamp(approval) ||
-    parseBrowserExecutionState(approval.resultJson)?.state === "executed"
+    parseBrowserExecutionState(approval.resultJson)?.state === "executed" ||
+    payloadState === "claimed" ||
+    payloadState === "executed"
   );
 }
 
@@ -191,12 +427,9 @@ export type BrowserApprovalClaimResult =
     };
 
 /**
- * Atomically consume an approved browser action before the browser can fire.
- *
- * The conditional `approved -> executing` update is the replay boundary. A
- * process crash, network loss, or browser timeout after this claim deliberately
- * leaves the row in `executing`: the outcome is ambiguous, so no later turn is
- * allowed to guess that it is safe to submit again.
+ * Preserve the durable claim protocol used by pre-bound browser approvals.
+ * New target-bound approvals are consumed at the Browser RPC boundary, where
+ * the live DOM target can be revalidated immediately before Chromium acts.
  */
 export async function claimApprovedBrowserAction(args: {
   companyId: string;
@@ -210,20 +443,30 @@ export async function claimApprovedBrowserAction(args: {
 
   let action: BrowserActionPayload;
   try {
-    action = parseBrowserActionPayload(approval.payloadJson);
+    action = readBrowserActionPayload(approval);
   } catch {
     return { outcome: "invalid_payload", approval };
   }
-  if (hasLegacyBrowserExecutionStamp(approval)) return { outcome: "conflict", approval };
+  // A bound payload must use claimBrowserActionApproval so target identity is
+  // checked against the live page. The legacy callback must never bypass it.
+  if (action.browserSessionId || action.targetFingerprint || action.targetDescriptor) {
+    return { outcome: "conflict", approval };
+  }
+  if (
+    hasLegacyBrowserExecutionStamp(approval) ||
+    browserPayloadExecutionState(approval) !== null
+  ) {
+    return { outcome: "conflict", approval };
+  }
 
   const claimToken = crypto.randomBytes(32).toString("base64url");
-  const claimedAt = new Date().toISOString();
   const claimState: BrowserExecutionState = {
     version: 1,
     state: "claimed",
     claimTokenHash: browserClaimTokenHash(claimToken),
-    claimedAt,
+    claimedAt: new Date().toISOString(),
   };
+  const previousPayloadJson = approval.payloadJson || "";
   const updated = await repo.update(
     {
       id: approval.id,
@@ -231,6 +474,7 @@ export async function claimApprovedBrowserAction(args: {
       employeeId: args.employeeId,
       kind: "browser_action",
       status: "approved",
+      payloadJson: previousPayloadJson,
       resultJson: IsNull(),
     },
     {
@@ -250,12 +494,6 @@ export type BrowserApprovalCompletionResult =
   | { outcome: "conflict"; approval: Approval }
   | { outcome: "completed" | "already_completed"; approval: Approval };
 
-/**
- * Finalize a claimed browser action. Completion is compare-and-set against the
- * exact claim receipt, so a different MCP child cannot finish another child's
- * claim. Failure is terminal; success returns to `approved` with an execution
- * receipt in `resultJson`, which prevents another claim.
- */
 export async function completeClaimedBrowserAction(args: {
   companyId: string;
   employeeId: string;
@@ -478,33 +716,295 @@ export async function createMcpToolApproval(args: {
 export async function createBrowserActionApproval(args: {
   companyId: string;
   employeeId: string;
+  action?: "submit" | "vault_capture";
   selector: string;
   key: string | null;
   pageUrl: string;
+  browserSessionId?: string;
+  targetFingerprint?: string;
+  targetDescriptor?: BrowserApprovalTargetDescriptor;
   summary: string;
+  vaultTitle?: string;
+  vaultUsername?: string;
+  vaultNotes?: string;
 }): Promise<Approval> {
   const repo = AppDataSource.getRepository(Approval);
-  const safeSummary = redactApprovalSummary(args.summary) ?? "Browser action";
+  const id = crypto.randomUUID();
+  const action = args.action ?? "submit";
+  const bindingValues = [args.browserSessionId, args.targetFingerprint, args.targetDescriptor];
+  const hasAnyBinding = bindingValues.some((value) => value !== undefined);
+  const hasCompleteBinding =
+    typeof args.browserSessionId === "string" &&
+    typeof args.targetFingerprint === "string" &&
+    args.targetDescriptor !== undefined;
+  if (hasAnyBinding && !hasCompleteBinding) {
+    throw new Error("Browser approval target binding is incomplete");
+  }
+  if (action === "vault_capture" && !hasCompleteBinding) {
+    throw new Error("Vault capture approvals require a bound Browser target");
+  }
+
+  const rawSummary =
+    action === "vault_capture"
+      ? "Save the current password field as a restricted Vault login"
+      : args.summary;
+  const safeSummary = redactApprovalSummary(rawSummary) ?? "Browser action";
   const title = safeSummary.length > 80 ? safeSummary.slice(0, 77) + "..." : safeSummary;
+  let summary: string;
+  let payload: StoredBrowserActionPayload;
+
+  if (hasCompleteBinding) {
+    const browserSessionId = args.browserSessionId!;
+    const targetFingerprint = args.targetFingerprint!;
+    const suppliedDescriptor = args.targetDescriptor!;
+    const pageUrl = safeBrowserApprovalPageUrl(args.pageUrl);
+    if (!browserSessionId || !/^[0-9a-f]{64}$/.test(targetFingerprint)) {
+      throw new Error("Browser approvals require a BrowserSession and target fingerprint");
+    }
+    const targetDescriptor: BrowserApprovalTargetDescriptor = {
+      tagName: suppliedDescriptor.tagName.toLowerCase(),
+      inputType: suppliedDescriptor.inputType?.toLowerCase() ?? null,
+      frameUrl: safeBrowserApprovalPageUrl(suppliedDescriptor.frameUrl),
+      formAction: suppliedDescriptor.formAction
+        ? safeBrowserApprovalPageUrl(suppliedDescriptor.formAction)
+        : null,
+      formMethod: suppliedDescriptor.formMethod?.toUpperCase() ?? null,
+      submitsForm: suppliedDescriptor.submitsForm,
+    };
+    if (!validBrowserTargetDescriptor(targetDescriptor)) {
+      throw new Error("Browser approval target descriptor is invalid");
+    }
+    if (action === "vault_capture" && !args.vaultTitle) {
+      throw new Error("Vault capture approvals require a title");
+    }
+    const expiresAt =
+      action === "vault_capture"
+        ? new Date(Date.now() + 15 * 60 * 1000).toISOString()
+        : undefined;
+    payload =
+      action === "vault_capture"
+        ? {
+            action,
+            browserSessionId,
+            targetFingerprint,
+            targetDescriptor,
+            encryptedVaultCapture: encryptSecret(
+              JSON.stringify({
+                action,
+                selector: args.selector,
+                key: args.key,
+                pageUrl,
+                browserSessionId,
+                expiresAt,
+                vaultTitle: args.vaultTitle ?? "",
+                vaultUsername: args.vaultUsername ?? "",
+                vaultNotes: args.vaultNotes ?? "",
+              }),
+              vaultCaptureApprovalScope({ id, companyId: args.companyId }),
+            ),
+          }
+        : {
+            action,
+            selector: args.selector,
+            key: args.key,
+            pageUrl,
+            browserSessionId,
+            targetFingerprint,
+            targetDescriptor,
+          };
+    const pageLabel = browserApprovalPageLabel(pageUrl);
+    summary = pageLabel ? `${safeSummary}  ·  ${pageLabel}` : safeSummary;
+  } else {
+    payload = {
+      selector: args.selector,
+      key: args.key,
+      pageUrl: args.pageUrl,
+    };
+    summary = args.pageUrl
+      ? `${safeSummary}  ·  ${approvalPageUrlPreview(args.pageUrl)}`
+      : safeSummary;
+  }
+
   const approval = repo.create({
+    id,
     companyId: args.companyId,
     kind: "browser_action",
     routineId: "",
     employeeId: args.employeeId,
     status: "pending",
     title,
-    summary: args.pageUrl
-      ? `${safeSummary}  ·  ${approvalPageUrlPreview(args.pageUrl)}`
-      : safeSummary,
-    payloadJson: JSON.stringify({
-      selector: args.selector,
-      key: args.key,
-      pageUrl: args.pageUrl,
-    } satisfies BrowserActionPayload),
+    summary,
+    payloadJson: JSON.stringify(payload),
   });
   const saved = await repo.save(approval);
   notifyPending(saved);
   return saved;
+}
+
+function browserFingerprintsMatch(left: string, right: string): boolean {
+  if (!/^[0-9a-f]{64}$/.test(left) || !/^[0-9a-f]{64}$/.test(right)) return false;
+  return crypto.timingSafeEqual(Buffer.from(left, "hex"), Buffer.from(right, "hex"));
+}
+
+export type ClaimBrowserActionApprovalArgs = {
+  approvalId: string;
+  companyId: string;
+  employeeId: string;
+  browserSessionId: string;
+  action: "submit" | "vault_capture";
+  selector: string;
+  key: string | null;
+  targetFingerprint: string;
+  targetDescriptor: BrowserApprovalTargetDescriptor;
+  vaultTitle?: string;
+  vaultUsername?: string;
+  vaultNotes?: string;
+};
+
+/**
+ * Atomically reserve an approved browser action immediately before the App
+ * drives Chromium. The exact previous payload is part of the UPDATE predicate,
+ * so concurrent resumes cannot both claim the same approval on SQLite or
+ * Postgres. A caught execution failure can be settled as `failed` and retried;
+ * a process crash remains `claimed` and therefore fails closed.
+ */
+export async function claimBrowserActionApproval(
+  args: ClaimBrowserActionApprovalArgs,
+): Promise<{ claimId: string; payload: BrowserActionPayload }> {
+  const repo = AppDataSource.getRepository(Approval);
+  const approval = await repo.findOneBy({ id: args.approvalId });
+  if (
+    !approval ||
+    approval.kind !== "browser_action" ||
+    approval.companyId !== args.companyId ||
+    approval.employeeId !== args.employeeId
+  ) {
+    throw new BrowserApprovalError("Browser approval not found", 404);
+  }
+  if (approval.status !== "approved" || !approval.decidedByUserId) {
+    throw new BrowserApprovalError("Browser action has not been approved", 403);
+  }
+
+  let payload: BrowserActionPayload;
+  let stored: StoredBrowserActionPayload;
+  try {
+    stored = parseStoredBrowserActionPayload(approval);
+    payload = readBrowserActionPayload(approval);
+  } catch {
+    throw new BrowserApprovalError("Browser approval payload is invalid", 409);
+  }
+  if (
+    approval.resultJson !== null ||
+    payload.execution?.state === "executed" ||
+    payload.execution?.state === "claimed"
+  ) {
+    throw new BrowserApprovalError("This browser approval has already been used", 409);
+  }
+  if (payload.expiresAt && Date.parse(payload.expiresAt) <= Date.now()) {
+    throw new BrowserApprovalError("Browser approval has expired", 409);
+  }
+  const normalizedDescriptor: BrowserApprovalTargetDescriptor = {
+    tagName: args.targetDescriptor.tagName.toLowerCase(),
+    inputType: args.targetDescriptor.inputType?.toLowerCase() ?? null,
+    frameUrl: safeBrowserApprovalPageUrl(args.targetDescriptor.frameUrl),
+    formAction: args.targetDescriptor.formAction
+      ? safeBrowserApprovalPageUrl(args.targetDescriptor.formAction)
+      : null,
+    formMethod: args.targetDescriptor.formMethod?.toUpperCase() ?? null,
+    submitsForm: args.targetDescriptor.submitsForm,
+  };
+  const actionMatches =
+    payload.action === args.action &&
+    payload.browserSessionId === args.browserSessionId &&
+    payload.selector === args.selector &&
+    (payload.key ?? null) === args.key &&
+    typeof payload.targetFingerprint === "string" &&
+    browserFingerprintsMatch(payload.targetFingerprint, args.targetFingerprint) &&
+    payload.targetDescriptor !== undefined &&
+    JSON.stringify(payload.targetDescriptor) === JSON.stringify(normalizedDescriptor) &&
+    (payload.action !== "vault_capture" ||
+      (payload.vaultTitle === (args.vaultTitle ?? "") &&
+        payload.vaultUsername === (args.vaultUsername ?? "") &&
+        payload.vaultNotes === (args.vaultNotes ?? "")));
+  if (!actionMatches) {
+    throw new BrowserApprovalError("Browser target no longer matches the approved action", 409);
+  }
+  if (payload.action === "vault_capture") {
+    const approver = await AppDataSource.getRepository(Membership).findOneBy({
+      companyId: args.companyId,
+      userId: approval.decidedByUserId,
+    });
+    if (!approver || (approver.role !== "owner" && approver.role !== "admin")) {
+      throw new BrowserApprovalError("Vault capture requires owner or admin approval", 403);
+    }
+  }
+
+  const claimId = crypto.randomUUID();
+  const execution: BrowserApprovalExecution = {
+    state: "claimed",
+    claimId,
+    browserSessionId: args.browserSessionId,
+    claimedAt: new Date().toISOString(),
+  };
+  const previousPayloadJson = approval.payloadJson || "";
+  const nextPayloadJson = JSON.stringify({ ...stored, execution });
+  const updated = await repo
+    .createQueryBuilder()
+    .update(Approval)
+    .set({ payloadJson: nextPayloadJson })
+    .where("id = :id", { id: approval.id })
+    .andWhere("status = :status", { status: "approved" })
+    .andWhere('"resultJson" IS NULL')
+    .andWhere('"payloadJson" = :previousPayloadJson', { previousPayloadJson })
+    .execute();
+  if (updated.affected !== 1) {
+    throw new BrowserApprovalError("This browser approval was claimed concurrently", 409);
+  }
+  return { claimId, payload: { ...payload, execution } };
+}
+
+/** Settle only the matching live claim. Failed actions may be reclaimed. */
+export async function settleBrowserActionApproval(args: {
+  approvalId: string;
+  claimId: string;
+  succeeded: boolean;
+}): Promise<void> {
+  const repo = AppDataSource.getRepository(Approval);
+  const approval = await repo.findOneBy({ id: args.approvalId });
+  if (!approval || approval.kind !== "browser_action") {
+    throw new BrowserApprovalError("Browser approval not found", 404);
+  }
+  let stored: StoredBrowserActionPayload;
+  try {
+    stored = parseStoredBrowserActionPayload(approval);
+  } catch {
+    throw new BrowserApprovalError("Browser approval payload is invalid", 409);
+  }
+  if (
+    !validBrowserApprovalExecution(stored.execution) ||
+    stored.execution.state !== "claimed" ||
+    stored.execution.claimId !== args.claimId
+  ) {
+    throw new BrowserApprovalError("Browser approval claim is no longer active", 409);
+  }
+  const execution: BrowserApprovalExecution = {
+    ...stored.execution,
+    state: args.succeeded ? "executed" : "failed",
+    completedAt: new Date().toISOString(),
+  };
+  const previousPayloadJson = approval.payloadJson || "";
+  const updated = await repo
+    .createQueryBuilder()
+    .update(Approval)
+    .set({ payloadJson: JSON.stringify({ ...stored, execution }) })
+    .where("id = :id", { id: approval.id })
+    .andWhere("status = :status", { status: "approved" })
+    .andWhere('"resultJson" IS NULL')
+    .andWhere('"payloadJson" = :previousPayloadJson', { previousPayloadJson })
+    .execute();
+  if (updated.affected !== 1) {
+    throw new BrowserApprovalError("Browser approval claim changed concurrently", 409);
+  }
 }
 
 export async function createPaymentApproval(args: {

--- a/App/server/services/backupDestinations.ts
+++ b/App/server/services/backupDestinations.ts
@@ -137,14 +137,11 @@ function buildConfig(
       username: (input.username ?? prevSmb?.username ?? "").trim(),
       encrypt: input.encrypt ?? prevSmb?.encrypt ?? true,
     };
-    cfg.password = input.password && input.password.length > 0
-      ? input.password
-      : prevSmb?.password;
+    cfg.password = input.password && input.password.length > 0 ? input.password : prevSmb?.password;
     return cfg;
   }
   const prev = (existing as SftpConfig) ?? null;
-  const authMode: SftpAuthMode =
-    input.authMode ?? prev?.authMode ?? "password";
+  const authMode: SftpAuthMode = input.authMode ?? prev?.authMode ?? "password";
   const cfg: SftpConfig = {
     host: (input.host ?? prev?.host ?? "").trim(),
     port: input.port ?? prev?.port ?? 22,
@@ -153,16 +150,12 @@ function buildConfig(
     authMode,
   };
   if (authMode === "password") {
-    cfg.password = input.password && input.password.length > 0
-      ? input.password
-      : prev?.password;
+    cfg.password = input.password && input.password.length > 0 ? input.password : prev?.password;
   } else {
-    cfg.privateKey = input.privateKey && input.privateKey.length > 0
-      ? input.privateKey
-      : prev?.privateKey;
-    const pass = input.passphrase && input.passphrase.length > 0
-      ? input.passphrase
-      : prev?.passphrase;
+    cfg.privateKey =
+      input.privateKey && input.privateKey.length > 0 ? input.privateKey : prev?.privateKey;
+    const pass =
+      input.passphrase && input.passphrase.length > 0 ? input.passphrase : prev?.passphrase;
     if (pass) cfg.passphrase = pass;
   }
   return cfg;
@@ -174,9 +167,7 @@ export async function listDestinations(): Promise<BackupDestination[]> {
   });
 }
 
-export async function getDestination(
-  id: string,
-): Promise<BackupDestination | null> {
+export async function getDestination(id: string): Promise<BackupDestination | null> {
   return AppDataSource.getRepository(BackupDestination).findOneBy({ id });
 }
 
@@ -208,8 +199,7 @@ export async function updateDestination(
   const repo = AppDataSource.getRepository(BackupDestination);
   const row = await repo.findOneBy({ id });
   if (!row) return null;
-  if (typeof input.name === "string" && input.name.trim())
-    row.name = input.name.trim();
+  if (typeof input.name === "string" && input.name.trim()) row.name = input.name.trim();
   if (typeof input.enabled === "boolean") row.enabled = input.enabled;
   // Kind is immutable — rebuild the config within the row's existing kind,
   // merging any provided fields over what's stored (secrets preserved).
@@ -233,9 +223,7 @@ export async function deleteDestination(id: string): Promise<boolean> {
  * directory exists and is writable by creating and deleting a tiny marker
  * file. Records the outcome on the row so History reflects the last check.
  */
-export async function testDestination(
-  id: string,
-): Promise<{ ok: boolean; message: string }> {
+export async function testDestination(id: string): Promise<{ ok: boolean; message: string }> {
   const repo = AppDataSource.getRepository(BackupDestination);
   const row = await repo.findOneBy({ id });
   if (!row) return { ok: false, message: "Destination not found" };
@@ -279,10 +267,7 @@ async function probeSftp(cfg: SftpConfig): Promise<void> {
     await client.connect(sftpConnectOptions(cfg));
     await client.mkdir(cfg.remoteDir, true);
     const probe = joinRemote(cfg.remoteDir, PROBE_NAME);
-    await client.put(
-      Buffer.from("genosyn backup destination test\n"),
-      probe,
-    );
+    await client.put(Buffer.from("genosyn backup destination test\n"), probe);
     await client.delete(probe, true);
   } finally {
     await safeEnd(client);
@@ -312,10 +297,7 @@ export async function deliverBackupToDestinations(
  * "Send to destinations" action in History). Throws if the source file is
  * gone; per-destination failures come back inside the result list.
  */
-export async function deliverArchive(
-  filename: string,
-  absPath: string,
-): Promise<DeliveryResult[]> {
+export async function deliverArchive(filename: string, absPath: string): Promise<DeliveryResult[]> {
   if (!fs.existsSync(absPath)) {
     throw new Error("Backup archive is missing on disk");
   }
@@ -360,22 +342,16 @@ async function deliverOne(
   }
 }
 
-async function copyLocal(
-  cfg: LocalConfig,
-  filename: string,
-  absPath: string,
-): Promise<void> {
+async function copyLocal(cfg: LocalConfig, filename: string, absPath: string): Promise<void> {
   const dir = cfg.path?.trim();
   if (!dir) throw new Error("No path configured");
   await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.copyFile(absPath, path.join(dir, filename));
+  const destination = path.join(dir, filename);
+  await fs.promises.copyFile(absPath, destination);
+  await fs.promises.chmod(destination, 0o600);
 }
 
-async function copySftp(
-  cfg: SftpConfig,
-  filename: string,
-  absPath: string,
-): Promise<void> {
+async function copySftp(cfg: SftpConfig, filename: string, absPath: string): Promise<void> {
   const client = new SftpClient();
   try {
     await client.connect(sftpConnectOptions(cfg));
@@ -432,7 +408,10 @@ const SMB_UNSAFE_SEGMENT = /[\\/:*?"<>|;\x00-\x1f]/;
 
 /** Accept backslashes (what a Windows user will paste) and trim edge slashes. */
 function normalizeSmbDir(dir: string): string {
-  return dir.trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  return dir
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "");
 }
 
 function assertSafeSmbSegment(value: string, label: string): void {
@@ -506,11 +485,7 @@ async function withSmbAuthFile<T>(
  * but it can't create anything, which is why the mkdir chain goes through
  * `--command` at all.
  */
-async function runSmbClient(
-  cfg: SmbConfig,
-  commands: string[],
-  timeout: number,
-): Promise<void> {
+async function runSmbClient(cfg: SmbConfig, commands: string[], timeout: number): Promise<void> {
   if (!cfg.host.trim()) throw new Error("No host configured");
   assertSafeSmbSegment(cfg.share, "Share");
 
@@ -593,9 +568,7 @@ function smbErrorMessage(err: unknown, cfg: SmbConfig): string {
  * non-zero exit from the same invocation.
  */
 function smbMkdirChain(segments: string[]): string[] {
-  return segments.map(
-    (_seg, i) => `mkdir "${segments.slice(0, i + 1).join("/")}"`,
-  );
+  return segments.map((_seg, i) => `mkdir "${segments.slice(0, i + 1).join("/")}"`);
 }
 
 /** Path of `name` inside the destination's remote dir, for smbclient's `-c`. */
@@ -612,11 +585,7 @@ async function probeSmb(cfg: SmbConfig): Promise<void> {
   try {
     await runSmbClient(
       cfg,
-      [
-        ...smbMkdirChain(segments),
-        `put "${localProbe}" "${probe}"`,
-        `del "${probe}"`,
-      ],
+      [...smbMkdirChain(segments), `put "${localProbe}" "${probe}"`, `del "${probe}"`],
       SMB_PROBE_TIMEOUT_MS,
     );
   } finally {
@@ -624,19 +593,12 @@ async function probeSmb(cfg: SmbConfig): Promise<void> {
   }
 }
 
-async function copySmb(
-  cfg: SmbConfig,
-  filename: string,
-  absPath: string,
-): Promise<void> {
+async function copySmb(cfg: SmbConfig, filename: string, absPath: string): Promise<void> {
   assertSafeSmbSegment(filename, "Backup filename");
   const segments = smbDirSegments(cfg.remoteDir);
   await runSmbClient(
     cfg,
-    [
-      ...smbMkdirChain(segments),
-      `put "${absPath}" "${smbRemotePath(segments, filename)}"`,
-    ],
+    [...smbMkdirChain(segments), `put "${absPath}" "${smbRemotePath(segments, filename)}"`],
     SMB_DELIVER_TIMEOUT_MS,
   );
 }

--- a/App/server/services/backups.test.ts
+++ b/App/server/services/backups.test.ts
@@ -6,6 +6,12 @@ import { after, before, beforeEach, describe, test } from "node:test";
 import unzipper from "unzipper";
 import { config } from "../../config.js";
 import { closeTestDb, initTestDb, resetTestDb } from "../test/dbHarness.js";
+import {
+  INSTANCE_SECRETS_FILENAME,
+  INSTANCE_SECRETS_SENTINEL_FILENAME,
+  getEffectiveInstanceSecrets,
+  resetInstanceSecretsCacheForTests,
+} from "../lib/instanceSecrets.js";
 import { backupFilePath, runBackup } from "./backups.js";
 
 type MutableConfig = {
@@ -26,6 +32,7 @@ before(async () => {
   mutable.dataDir = tempDir;
   // The test DB is in-memory, so there is no SQLite file to snapshot.
   mutable.db.driver = "postgres";
+  resetInstanceSecretsCacheForTests();
 });
 
 beforeEach(async () => {
@@ -39,6 +46,7 @@ beforeEach(async () => {
 after(async () => {
   mutable.dataDir = originalDataDir;
   mutable.db.driver = originalDriver;
+  resetInstanceSecretsCacheForTests();
   await closeTestDb();
   await fs.rm(tempDir, { recursive: true, force: true });
 });
@@ -48,19 +56,24 @@ describe("backup archive generation", () => {
     const markerPath = path.join(tempDir, "companies", "release-lab", "marker.txt");
     await fs.writeFile(markerPath, "release proof");
 
+    getEffectiveInstanceSecrets();
     const backup = await runBackup("manual");
     assert.equal(backup.status, "completed");
     assert.ok(backup.sizeBytes > 0);
 
     const archivePath = backupFilePath(backup.filename);
+    assert.equal((await fs.stat(archivePath)).mode & 0o777, 0o600);
     const archive = await unzipper.Open.file(archivePath);
     const names = archive.files.map((entry) => entry.path);
     assert.ok(names.includes("companies/release-lab/marker.txt"));
-    assert.equal(names.some((name) => name.startsWith("Backup/")), false);
-
-    const marker = archive.files.find(
-      (entry) => entry.path === "companies/release-lab/marker.txt",
+    assert.ok(names.includes(INSTANCE_SECRETS_FILENAME));
+    assert.ok(names.includes(INSTANCE_SECRETS_SENTINEL_FILENAME));
+    assert.equal(
+      names.some((name) => name.startsWith("Backup/")),
+      false,
     );
+
+    const marker = archive.files.find((entry) => entry.path === "companies/release-lab/marker.txt");
     assert.equal((await marker?.buffer())?.toString("utf8"), "release proof");
   });
 });

--- a/App/server/services/backups.ts
+++ b/App/server/services/backups.ts
@@ -19,10 +19,15 @@ import {
   DeliveryResult,
 } from "./backupDestinations.js";
 import { withSchedulerLease } from "./schedulerLeases.js";
+import { bootDurableChatTurnRecovery, stopDurableChatTurnRecovery } from "./durableChatTurns.js";
 import {
-  bootDurableChatTurnRecovery,
-  stopDurableChatTurnRecovery,
-} from "./durableChatTurns.js";
+  INSTANCE_SECRETS_FILENAME,
+  INSTANCE_SECRETS_SENTINEL_FILENAME,
+  reloadEffectiveInstanceSecrets,
+  restoreManagedInstanceSecretsIfMissing,
+  snapshotManagedInstanceSecrets,
+} from "../lib/instanceSecrets.js";
+import { bindInstanceSecretsToDatabase } from "./instanceSecretsDatabase.js";
 
 /**
  * Install-wide backup service. Each backup zips `<dataDir>` (excluding the
@@ -100,6 +105,7 @@ export function backupFilePath(filename: string): string {
 
 function ensureBackupDir(): void {
   fs.mkdirSync(backupDir(), { recursive: true });
+  fs.chmodSync(backupDir(), 0o700);
 }
 
 /**
@@ -579,7 +585,7 @@ async function snapshotSqlite(dest: string): Promise<void> {
 function writeZip(outPath: string, sqliteSnapshot: string | null): Promise<void> {
   return new Promise((resolve, reject) => {
     const partPath = `${outPath}${PART_SUFFIX}`;
-    const output = createWriteStream(partPath);
+    const output = createWriteStream(partPath, { mode: 0o600 });
     const archive = new ZipArchive({ zlib: { level: 9 } });
 
     let failed = false;
@@ -594,6 +600,7 @@ function writeZip(outPath: string, sqliteSnapshot: string | null): Promise<void>
       if (failed) return;
       try {
         fs.renameSync(partPath, outPath);
+        fs.chmodSync(outPath, 0o600);
       } catch (err) {
         fail(err as Error);
         return;
@@ -746,7 +753,7 @@ export async function ingestUploadedArchive(req: IncomingMessage): Promise<Backu
       }
     });
 
-    await pipeline(req, createWriteStream(partPath));
+    await pipeline(req, createWriteStream(partPath, { mode: 0o600 }));
 
     // Open the archive rather than peeking at its `PK\x03\x04` header: a
     // signature check passes a file that was cut off in transit, and the
@@ -758,6 +765,7 @@ export async function ingestUploadedArchive(req: IncomingMessage): Promise<Backu
     }
 
     fs.renameSync(partPath, outPath);
+    fs.chmodSync(outPath, 0o600);
     const size = fs.statSync(outPath).size;
     row.sizeBytes = size;
     row.status = "completed";
@@ -828,6 +836,10 @@ export async function restoreFromBackup(id: string): Promise<{
     // shows up in History — tagged `manual` because the user initiated the
     // restore that triggered it.
     const safety = await runBackup("manual");
+    // `wipeDataExceptBackup` removes the managed identity too. Hold it only in
+    // memory so a pre-managed archive cannot silently rotate the encryption
+    // root; an archive that contains its own identity still wins below.
+    const instanceSecretsSnapshot = snapshotManagedInstanceSecrets();
 
     if (scheduledTask) {
       scheduledTask.stop();
@@ -859,9 +871,20 @@ export async function restoreFromBackup(id: string): Promise<{
 
     wipeDataExceptBackup();
     await extractZipIntoDataRoot(zipPath);
+    restoreManagedInstanceSecretsIfMissing(instanceSecretsSnapshot, {
+      // An archive without managed state predates this feature (or omitted its
+      // hidden files). Keep the current identity, but retain decrypt-only
+      // access to ciphertext written under the former stock placeholders.
+      enablePlaceholderCompatibility: true,
+    });
+    // Every secret consumer resolves dynamically. Reload before opening the
+    // restored DB so cross-instance archives use their own encryption root;
+    // the next browser request also rebuilds cookie-session with its signer.
+    reloadEffectiveInstanceSecrets();
 
     await AppDataSource.initialize();
     await AppDataSource.runMigrations();
+    await bindInstanceSecretsToDatabase();
 
     // After the restored DB comes back online it has no row for the safety
     // snapshot (or any other archive written since the restored zip was
@@ -915,6 +938,7 @@ async function reconcileBackupHistory(): Promise<void> {
   // may still hold a truncated `.zip` under a real filename — the salvage loop
   // below leaves those `running` rather than promoting them.)
   for (const entry of fs.readdirSync(dir)) {
+    if (entry.endsWith(".zip")) fs.chmodSync(path.join(dir, entry), 0o600);
     if (!entry.endsWith(PART_SUFFIX)) continue;
     try {
       fs.unlinkSync(path.join(dir, entry));
@@ -994,7 +1018,13 @@ async function extractZipIntoDataRoot(zipPath: string): Promise<void> {
       throw new Error(`Refusing to extract outside data root: ${entry.path}`);
     }
     fs.mkdirSync(path.dirname(abs), { recursive: true });
-    await pipeline(entry.stream(), createWriteStream(abs));
+    const managedSecretState =
+      rel === INSTANCE_SECRETS_FILENAME || rel === INSTANCE_SECRETS_SENTINEL_FILENAME;
+    await pipeline(
+      entry.stream(),
+      createWriteStream(abs, managedSecretState ? { mode: 0o600 } : undefined),
+    );
+    if (managedSecretState) fs.chmodSync(abs, 0o600);
   }
 }
 

--- a/App/server/services/browserAccess.ts
+++ b/App/server/services/browserAccess.ts
@@ -1,0 +1,55 @@
+import { In } from "typeorm";
+
+import { config } from "../../config.js";
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { BrowserSession } from "../db/entities/BrowserSession.js";
+import { Run } from "../db/entities/Run.js";
+import { Routine } from "../db/entities/Routine.js";
+import { releasePage } from "./browserChromium.js";
+import { closeBrowserSession } from "./browserSessions.js";
+
+/** Re-evaluate the live Browser policy behind an already-minted session. */
+export async function browserAccessEnabledForSession(
+  session: BrowserSession,
+  employee: AIEmployee,
+): Promise<boolean> {
+  if (config.security.multiTenant && !config.agent.browserEnabledInMultiTenant) return false;
+  if (!session.runId) return employee.browserEnabled;
+  const run = await AppDataSource.getRepository(Run).findOneBy({ id: session.runId });
+  if (!run) return false;
+  const routine = await AppDataSource.getRepository(Routine).findOneBy({
+    id: run.routineId,
+    employeeId: employee.id,
+  });
+  if (!routine) return false;
+  return routine.browserEnabledOverride ?? employee.browserEnabled;
+}
+
+export async function closeBrowserSessionForPolicy(sessionId: string): Promise<void> {
+  await releasePage(sessionId, "manual");
+  // releasePage closes rows that own a runtime. Pending/restored sessions may
+  // have no process-local runtime, so close the durable row explicitly too.
+  await closeBrowserSession(sessionId, "manual");
+}
+
+/** Close every active session whose current employee/Routine policy now denies Browser. */
+export async function revokeDisabledBrowserSessionsForEmployee(employeeId: string): Promise<void> {
+  const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({ id: employeeId });
+  if (!employee) return;
+  const sessions = await AppDataSource.getRepository(BrowserSession).find({
+    where: { employeeId, status: In(["pending", "live"]) },
+  });
+  for (const session of sessions) {
+    if (!(await browserAccessEnabledForSession(session, employee))) {
+      await closeBrowserSessionForPolicy(session.id);
+    }
+  }
+}
+
+export async function closeAllBrowserSessionsForEmployee(employeeId: string): Promise<void> {
+  const sessions = await AppDataSource.getRepository(BrowserSession).find({
+    where: { employeeId, status: In(["pending", "live"]) },
+  });
+  for (const session of sessions) await closeBrowserSessionForPolicy(session.id);
+}

--- a/App/server/services/browserChromium.ts
+++ b/App/server/services/browserChromium.ts
@@ -1,6 +1,7 @@
 import { AppDataSource } from "../db/datasource.js";
 import { BrowserSession } from "../db/entities/BrowserSession.js";
 import { closeBrowserSession } from "./browserSessions.js";
+import { markAiBrowserSessionRequestHeaders } from "./browserRequestBoundary.js";
 import { loadStorageState, saveStorageState } from "./browserStorage.js";
 
 /**
@@ -93,11 +94,15 @@ type SessionRuntime = {
 const runtimes = new Map<string, SessionRuntime>();
 let playwrightModule: { chromium: { launch: (opts: unknown) => Promise<unknown> } } | null = null;
 
-async function getPlaywright(): Promise<typeof playwrightModule extends infer T ? NonNullable<T> : never> {
+async function getPlaywright(): Promise<
+  typeof playwrightModule extends infer T ? NonNullable<T> : never
+> {
   if (!playwrightModule) {
     try {
       const mod = await import("playwright-core");
-      playwrightModule = { chromium: mod.chromium as unknown as { launch: (opts: unknown) => Promise<unknown> } };
+      playwrightModule = {
+        chromium: mod.chromium as unknown as { launch: (opts: unknown) => Promise<unknown> },
+      };
     } catch (err) {
       throw new Error(
         `playwright-core is not installed: ${
@@ -163,13 +168,19 @@ export async function acquirePage(sessionId: string): Promise<unknown> {
       "--disable-blink-features=AutomationControlled",
     ],
   });
-  const context = await (browser as {
-    newContext: (opts: unknown) => Promise<unknown>;
-  }).newContext({
+  const context = await (
+    browser as {
+      newContext: (opts: unknown) => Promise<unknown>;
+    }
+  ).newContext({
     viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
     userAgent: CHROME_USER_AGENT,
     locale: "en-US",
     timezoneId: "America/Los_Angeles",
+    // Context routing is the security boundary that marks a Member session
+    // used inside App-owned Chromium. Service workers can bypass Playwright
+    // routes, so they are disabled in this governed Browser context.
+    serviceWorkers: "block",
     extraHTTPHeaders: {
       "sec-ch-ua": CHROME_SEC_CH_UA,
       "sec-ch-ua-mobile": "?0",
@@ -177,9 +188,25 @@ export async function acquirePage(sessionId: string): Promise<unknown> {
     },
     storageState,
   });
-  await (context as {
-    addInitScript: (script: { content: string }) => Promise<void>;
-  }).addInitScript({ content: chromeMaskInitScript() });
+  await (
+    context as {
+      route: (
+        url: string,
+        handler: (route: {
+          request: () => { allHeaders: () => Promise<Record<string, string>> };
+          continue: (options: { headers: Record<string, string> }) => Promise<void>;
+        }) => Promise<void>,
+      ) => Promise<void>;
+    }
+  ).route("**/*", async (route) => {
+    const headers = await route.request().allHeaders();
+    await route.continue({ headers: markAiBrowserSessionRequestHeaders(headers) });
+  });
+  await (
+    context as {
+      addInitScript: (script: { content: string }) => Promise<void>;
+    }
+  ).addInitScript({ content: chromeMaskInitScript() });
   const page = await (context as { newPage: () => Promise<unknown> }).newPage();
   const cdp = await attachCdp(page);
 
@@ -208,23 +235,20 @@ export async function acquirePage(sessionId: string): Promise<unknown> {
   // tools would otherwise never see — it would keep driving the old tab
   // forever. Follow the newest page instead, like a human would. The action
   // that triggered the popup waits on `pendingAdoption` before snapshotting.
-  (context as { on: (ev: string, cb: (p: unknown) => void) => void }).on(
-    "page",
-    (newPage) => {
-      const r = runtimes.get(sessionId);
-      if (!r) return;
-      const prev = r.pendingAdoption ?? Promise.resolve();
-      r.pendingAdoption = prev
-        .then(() => adoptPage(sessionId, newPage))
-        .catch(() => {
-          // best-effort — worst case the agent stays on the old tab
-        })
-        .finally(() => {
-          const cur = runtimes.get(sessionId);
-          if (cur && cur.pendingAdoption === r.pendingAdoption) cur.pendingAdoption = null;
-        });
-    },
-  );
+  (context as { on: (ev: string, cb: (p: unknown) => void) => void }).on("page", (newPage) => {
+    const r = runtimes.get(sessionId);
+    if (!r) return;
+    const prev = r.pendingAdoption ?? Promise.resolve();
+    r.pendingAdoption = prev
+      .then(() => adoptPage(sessionId, newPage))
+      .catch(() => {
+        // best-effort — worst case the agent stays on the old tab
+      })
+      .finally(() => {
+        const cur = runtimes.get(sessionId);
+        if (cur && cur.pendingAdoption === r.pendingAdoption) cur.pendingAdoption = null;
+      });
+  });
 
   return page;
 }
@@ -325,9 +349,7 @@ async function adoptPage(sessionId: string, newPage: unknown): Promise<void> {
   pushSessionNotice(
     sessionId,
     `A new tab opened and is now the active page: ${np.url()}. ` +
-      (previousUrl
-        ? `To return to the previous page, call browser_open with ${previousUrl}.`
-        : ""),
+      (previousUrl ? `To return to the previous page, call browser_open with ${previousUrl}.` : ""),
   );
   scheduleNavMirror(r);
   // Stop the dead page's screencast and move the live view to the new tab.
@@ -362,7 +384,9 @@ async function detachAndRewireCast(sessionId: string, oldCdp: unknown): Promise<
 }
 
 async function attachCdp(page: unknown): Promise<unknown> {
-  const ctx = (page as { context: () => { newCDPSession: (p: unknown) => Promise<unknown> } }).context();
+  const ctx = (
+    page as { context: () => { newCDPSession: (p: unknown) => Promise<unknown> } }
+  ).context();
   return ctx.newCDPSession(page);
 }
 

--- a/App/server/services/browserRequestBoundary.test.ts
+++ b/App/server/services/browserRequestBoundary.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { createServer } from "node:http";
+import test from "node:test";
+import { chromium } from "playwright-core";
+import express from "express";
+import {
+  AI_BROWSER_REQUEST_HEADER,
+  AI_BROWSER_REQUEST_VALUE,
+  markAiBrowserSessionRequestHeaders,
+  rejectAiBrowserAppRequests,
+} from "./browserRequestBoundary.js";
+
+test("marks App-owned Browser requests that carry a Genosyn Member session", () => {
+  const marked = markAiBrowserSessionRequestHeaders({
+    Cookie: "theme=dark; genosyn.sid=s%3Asession; genosyn.sid.sig=signature",
+    [AI_BROWSER_REQUEST_HEADER]: "page-cannot-clear-this",
+  });
+  assert.equal(marked[AI_BROWSER_REQUEST_HEADER], AI_BROWSER_REQUEST_VALUE);
+  assert.match(marked.Cookie, /genosyn\.sid=/);
+});
+
+test("leaves unrelated website requests unmarked", () => {
+  const headers = { cookie: "external_session=value", accept: "text/html" };
+  assert.strictEqual(markAiBrowserSessionRequestHeaders(headers), headers);
+  assert.equal(AI_BROWSER_REQUEST_HEADER in headers, false);
+});
+
+test("rejects every App API centrally when the AI Browser marker is present", async () => {
+  const app = express();
+  app.use("/api", rejectAiBrowserAppRequests);
+  app.get("/api/settings/api-keys", (_req, res) => res.json({ token: "must-not-return" }));
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${(server.address() as AddressInfo).port}/api/settings/api-keys`,
+      { headers: { [AI_BROWSER_REQUEST_HEADER]: AI_BROWSER_REQUEST_VALUE } },
+    );
+    assert.equal(response.status, 403);
+    assert.doesNotMatch(await response.text(), /must-not-return/);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("marks a real Chromium request carrying the HttpOnly Genosyn session cookie", async (t) => {
+  const executablePath = [
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    chromium.executablePath(),
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/chromium",
+  ]
+    .filter((value): value is string => Boolean(value))
+    .find((value) => existsSync(value));
+  if (!executablePath) {
+    t.skip("No Chromium executable is available for the Browser request-boundary test");
+    return;
+  }
+
+  const server = createServer((req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(req.headers));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  const browser = await chromium.launch({ headless: true, executablePath });
+  try {
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    await context.addCookies([
+      {
+        name: "genosyn.sid",
+        value: "member-session",
+        url: origin,
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+    await context.route("**/*", async (route) => {
+      const headers = await route.request().allHeaders();
+      await route.continue({ headers: markAiBrowserSessionRequestHeaders(headers) });
+    });
+    const page = await context.newPage();
+    await page.goto(origin);
+    const received = JSON.parse(await page.locator("body").innerText()) as Record<string, string>;
+    assert.equal(received[AI_BROWSER_REQUEST_HEADER], AI_BROWSER_REQUEST_VALUE);
+  } finally {
+    await browser.close();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/App/server/services/browserRequestBoundary.ts
+++ b/App/server/services/browserRequestBoundary.ts
@@ -1,0 +1,32 @@
+import type { RequestHandler } from "express";
+
+export const AI_BROWSER_REQUEST_HEADER = "x-genosyn-ai-browser";
+export const AI_BROWSER_REQUEST_VALUE = "1";
+
+const SESSION_COOKIE_PATTERN = /(?:^|;\s*)genosyn\.sid=/;
+
+/**
+ * Mark requests that carry a Genosyn Member session inside App-owned Chromium.
+ * The marker is added after page/service-worker code chooses its headers, so a
+ * self-origin page cannot remove it. Requests to unrelated sites remain
+ * untouched unless that site independently uses Genosyn's cookie name.
+ */
+export function markAiBrowserSessionRequestHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const cookie = Object.entries(headers).find(([name]) => name.toLowerCase() === "cookie")?.[1];
+  if (!cookie || !SESSION_COOKIE_PATTERN.test(cookie)) return headers;
+  return { ...headers, [AI_BROWSER_REQUEST_HEADER]: AI_BROWSER_REQUEST_VALUE };
+}
+
+/** Global `/api` gate installed after cookie-session parsing. */
+export const rejectAiBrowserAppRequests: RequestHandler = (req, res, next) => {
+  if (req.get(AI_BROWSER_REQUEST_HEADER) === AI_BROWSER_REQUEST_VALUE) {
+    res.status(403).json({
+      error:
+        "Genosyn App APIs are unavailable inside an AI Browser. Use governed AI Employee tools.",
+    });
+    return;
+  }
+  next();
+};

--- a/App/server/services/browserSessions.ts
+++ b/App/server/services/browserSessions.ts
@@ -4,6 +4,7 @@ import { AppDataSource } from "../db/datasource.js";
 import { BrowserSession, type BrowserSessionCloseReason } from "../db/entities/BrowserSession.js";
 import { getRuntime, holdRuntime, releaseRuntime, markActivity } from "./browserChromium.js";
 import { withSchedulerLease } from "./schedulerLeases.js";
+import { registerMembershipAuthorizationChangeSink } from "./resourceEvents.js";
 
 /**
  * Browser-session lifecycle + in-memory fanout hub.
@@ -35,6 +36,25 @@ import { withSchedulerLease } from "./schedulerLeases.js";
 // a longer TTL doesn't keep real browsers alive any longer.
 const MCP_TOKEN_TTL_MS = 7 * 60 * 60 * 1000; // 7h
 const EXPIRE_GRACE_MS = 30_000;
+const cleanupListeners = new Set<(sessionId: string) => void>();
+type SensitiveObservationKind = "password-present" | "password-value" | "active-input-value";
+const sensitiveValueListeners = new Set<
+  (sessionId: string, value: string, kind: SensitiveObservationKind) => void
+>();
+
+/** Register process-local cleanup owned by a browser RPC extension. */
+export function registerBrowserSessionCleanup(listener: (sessionId: string) => void): () => void {
+  cleanupListeners.add(listener);
+  return () => cleanupListeners.delete(listener);
+}
+
+/** Let the browser RPC boundary retain password values before human input can reveal them. */
+export function registerBrowserSensitiveValueListener(
+  listener: (sessionId: string, value: string, kind: SensitiveObservationKind) => void,
+): () => void {
+  sensitiveValueListeners.add(listener);
+  return () => sensitiveValueListeners.delete(listener);
+}
 
 /**
  * Outbound message shape, used for both viewer-side WS and the
@@ -121,6 +141,19 @@ type SessionState = {
 const sessions = new Map<string, SessionState>();
 /** Index used by the WS upgrade handler to resolve a token to a session. */
 const tokenToSessionId = new Map<string, string>();
+
+registerMembershipAuthorizationChangeSink((companyId) => {
+  for (const state of sessions.values()) {
+    if (state.companyId !== companyId) continue;
+    for (const viewer of state.viewers) {
+      try {
+        viewer.ws.close(1008, "Browser viewer access changed");
+      } catch {
+        // The close handler removes the viewer; a dead socket needs no work.
+      }
+    }
+  }
+});
 
 // ---------- token / lifecycle ----------
 
@@ -237,6 +270,13 @@ export async function closeBrowserSession(
 }
 
 function teardown(sessionId: string): void {
+  for (const listener of cleanupListeners) {
+    try {
+      listener(sessionId);
+    } catch {
+      // Teardown must continue even if an extension's memory cleanup fails.
+    }
+  }
   sessions.delete(sessionId);
 }
 
@@ -257,6 +297,7 @@ export async function sweepExpiredBrowserSessions(): Promise<void> {
     row.closedAt = new Date();
     await repo.save(row);
     tokenToSessionId.delete(row.mcpToken);
+    teardown(row.id);
   }
 }
 
@@ -391,11 +432,15 @@ const cdpListenerAttached = new Set<string>();
 
 export function attachViewerSocket(args: {
   sessionId: string;
+  companyId: string;
+  employeeId: string;
   ws: WebSocket;
   userId: string;
 }): void {
-  const { sessionId, ws, userId } = args;
+  const { sessionId, companyId, employeeId, ws, userId } = args;
   const state = ensureState(sessionId);
+  state.companyId = companyId;
+  state.employeeId = employeeId;
   const viewer: ViewerSocket = { ws, userId, takeover: false };
   const wasEmpty = state.viewers.size === 0;
   state.viewers.add(viewer);
@@ -484,6 +529,10 @@ async function handleViewerMessage(
     if (!runtime) return;
     const cdp = runtime.cdp as { send: (m: string, p?: unknown) => Promise<unknown> } | null;
     if (!cdp) return;
+    // Capture every current password value before a human click can toggle a
+    // field to plain text. The browser RPC layer keeps these values redacted
+    // for the full session and clears them through the teardown hook above.
+    await observeRuntimePasswordValues(state.id);
     if (msg.type === "input.mouse") {
       try {
         await cdp.send("Input.dispatchMouseEvent", {
@@ -497,6 +546,7 @@ async function handleViewerMessage(
           deltaY: msg.deltaY ?? 0,
           modifiers: msg.modifiers ?? 0,
         });
+        await observeRuntimePasswordValues(state.id);
       } catch {
         /* ignore */
       }
@@ -511,11 +561,75 @@ async function handleViewerMessage(
           modifiers: msg.modifiers ?? 0,
           windowsVirtualKeyCode: msg.windowsVirtualKeyCode,
         });
+        // Key input may have changed the focused password field. Capture the
+        // resulting full value, not only the individual key event text.
+        await observeRuntimePasswordValues(state.id);
       } catch {
         /* ignore */
       }
     }
     return;
+  }
+}
+
+async function observeRuntimePasswordValues(sessionId: string): Promise<void> {
+  if (sensitiveValueListeners.size === 0) return;
+  const runtime = getRuntime(sessionId);
+  const page = runtime?.page as
+    | {
+        frames: () => Array<{
+          evaluate: <T>(fn: () => T) => Promise<T>;
+        }>;
+      }
+    | null
+    | undefined;
+  if (!page) return;
+  const observations = await Promise.all(
+    page.frames().map((frame) =>
+      frame
+        .evaluate(() => {
+          const passwordInputs: HTMLInputElement[] = [];
+          const visit = (root: Document | ShadowRoot) => {
+            for (const element of root.querySelectorAll("*")) {
+              if (element instanceof HTMLInputElement && element.type === "password") {
+                passwordInputs.push(element);
+              }
+              if (element.shadowRoot) visit(element.shadowRoot);
+            }
+          };
+          visit(document);
+          let active = document.activeElement;
+          while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+          return {
+            passwordPresent: passwordInputs.length > 0,
+            passwordValues: passwordInputs.map((input) => input.value).filter(Boolean),
+            activeInputValue:
+              active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+                ? active.value
+                : null,
+          };
+        })
+        .catch(() => ({
+          passwordPresent: true,
+          passwordValues: [] as string[],
+          activeInputValue: null as string | null,
+        })),
+    ),
+  );
+  for (const observation of observations) {
+    for (const listener of sensitiveValueListeners) {
+      try {
+        if (observation.passwordPresent) listener(sessionId, "", "password-present");
+        for (const value of observation.passwordValues) {
+          listener(sessionId, value, "password-value");
+        }
+        if (observation.activeInputValue) {
+          listener(sessionId, observation.activeInputValue, "active-input-value");
+        }
+      } catch {
+        // Human input must continue even if a redaction extension failed.
+      }
+    }
   }
 }
 

--- a/App/server/services/browserStorage.test.ts
+++ b/App/server/services/browserStorage.test.ts
@@ -8,8 +8,12 @@ import { config } from "../../config.js";
 import { AIEmployee } from "../db/entities/AIEmployee.js";
 import { Company } from "../db/entities/Company.js";
 import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
-import { loadStorageState, saveStorageState } from "./browserStorage.js";
-import { employeeBrowserStateFile } from "./paths.js";
+import {
+  loadStorageState,
+  migrateLegacyBrowserStorage,
+  saveStorageState,
+} from "./browserStorage.js";
+import { employeeBrowserStateFile, employeeDir, legacyEmployeeBrowserStateFile } from "./paths.js";
 
 const originalDataDir = config.dataDir;
 const mutableConfig = config as unknown as { dataDir: string };
@@ -23,7 +27,10 @@ before(async () => {
 
 beforeEach(async () => {
   await resetTestDb();
-  await fs.rm(path.join(tempDir, "companies"), { recursive: true, force: true });
+  await Promise.all([
+    fs.rm(path.join(tempDir, "companies"), { recursive: true, force: true }),
+    fs.rm(path.join(tempDir, ".private"), { recursive: true, force: true }),
+  ]);
 });
 
 after(async () => {
@@ -32,10 +39,7 @@ after(async () => {
   await fs.rm(tempDir, { recursive: true, force: true });
 });
 
-async function identity(
-  companyId = "company",
-  employeeId = "employee",
-): Promise<void> {
+async function identity(companyId = "company", employeeId = "employee"): Promise<void> {
   await insert(Company, {
     id: companyId,
     name: "Test Company",
@@ -68,17 +72,19 @@ describe("browser storage-state persistence", () => {
     });
     assert.deepEqual(await loadStorageState("company", "employee"), state);
 
-    const file = employeeBrowserStateFile("company-slug", "employee-slug");
+    const file = employeeBrowserStateFile("company", "employee");
     const mode = (await fs.stat(file)).mode & 0o777;
     assert.equal(mode, 0o600);
+    assert.equal(file.startsWith(employeeDir("company-slug", "employee-slug")), false);
+    assert.equal((await fs.stat(path.dirname(file))).mode & 0o777, 0o700);
     const siblings = await fs.readdir(path.dirname(file));
-    assert.deepEqual(siblings, [".browser-state.json"]);
+    assert.deepEqual(siblings, ["employee.json"]);
   });
 
   test("returns undefined for missing, malformed, or structurally invalid snapshots", async () => {
     await identity();
     assert.equal(await loadStorageState("company", "employee"), undefined);
-    const file = employeeBrowserStateFile("company-slug", "employee-slug");
+    const file = employeeBrowserStateFile("company", "employee");
     await fs.mkdir(path.dirname(file), { recursive: true });
     await fs.writeFile(file, "{");
     assert.equal(await loadStorageState("company", "employee"), undefined);
@@ -127,6 +133,42 @@ describe("browser storage-state persistence", () => {
     });
     assert.equal(called, false);
     assert.equal(await loadStorageState("company-b", "employee-a"), undefined);
+  });
+
+  test("atomically migrates and removes every workspace-visible legacy artifact", async () => {
+    await identity();
+    const legacy = legacyEmployeeBrowserStateFile("company-slug", "employee-slug");
+    const state = { cookies: [{ name: "session", value: "legacy" }], origins: [] };
+    await fs.mkdir(path.dirname(legacy), { recursive: true });
+    await fs.writeFile(legacy, JSON.stringify(state), { mode: 0o600 });
+    await fs.writeFile(`${legacy}.torn.tmp`, "COOKIE_FRAGMENT", { mode: 0o600 });
+
+    await Promise.all([
+      migrateLegacyBrowserStorage("company", "employee"),
+      migrateLegacyBrowserStorage("company", "employee"),
+    ]);
+
+    assert.deepEqual(await loadStorageState("company", "employee"), state);
+    const remaining = await fs.readdir(path.dirname(legacy));
+    assert.equal(
+      remaining.some((name) => name.startsWith(".browser-state.json")),
+      false,
+    );
+    assert.equal(
+      (await fs.stat(employeeBrowserStateFile("company", "employee"))).mode & 0o777,
+      0o600,
+    );
+  });
+
+  test("fails closed instead of preserving a workspace hardlink to Browser cookies", async () => {
+    await identity();
+    const legacy = legacyEmployeeBrowserStateFile("company-slug", "employee-slug");
+    await fs.mkdir(path.dirname(legacy), { recursive: true });
+    await fs.writeFile(legacy, JSON.stringify({ cookies: [], origins: [] }), { mode: 0o600 });
+    await fs.link(legacy, path.join(path.dirname(legacy), "cookie-alias.txt"));
+
+    await assert.rejects(migrateLegacyBrowserStorage("company", "employee"), /unsafe hard link/);
+    await assert.rejects(fs.stat(employeeBrowserStateFile("company", "employee")), /ENOENT/);
   });
 
   test("swallows a torn-down context failure and leaves no partial file", async () => {

--- a/App/server/services/browserStorage.ts
+++ b/App/server/services/browserStorage.ts
@@ -1,18 +1,20 @@
+import path from "node:path";
 import fs from "node:fs/promises";
 import { AppDataSource } from "../db/datasource.js";
 import { Company } from "../db/entities/Company.js";
 import { AIEmployee } from "../db/entities/AIEmployee.js";
-import { employeeBrowserStateFile, employeeDir, ensureDir } from "./paths.js";
+import { dataRoot, employeeBrowserStateFile, legacyEmployeeBrowserStateFile } from "./paths.js";
 
 /**
  * Per-employee Playwright `storageState()` persistence.
  *
- * We snapshot cookies + localStorage + sessionStorage to a single hidden
- * JSON file under the employee's data dir. Loaded on every browser-context
- * launch and saved on every clean teardown — so logging into X.com once
- * survives container restarts, idle teardown, and fresh conversations
- * with the same employee. IndexedDB and service workers aren't covered;
- * sites that key their auth off those will still need a re-login.
+ * We snapshot cookies + localStorage + sessionStorage to an App-private JSON
+ * file outside the employee's model-visible workspace. Loaded on every
+ * browser-context launch and saved on every clean teardown — so logging into
+ * X.com once survives container restarts, idle teardown, and fresh
+ * conversations with the same employee without making bearer cookies readable
+ * by coding tools. IndexedDB and service workers aren't covered; sites that key
+ * their auth off those will still need a re-login.
  */
 
 type StorageState = {
@@ -20,10 +22,15 @@ type StorageState = {
   origins: Array<{ origin: string; localStorage: Array<{ name: string; value: string }> }>;
 };
 
-async function resolveSlugs(
+type BrowserStorageIdentity = {
+  companySlug: string;
+  employeeSlug: string;
+};
+
+async function resolveIdentity(
   companyId: string,
   employeeId: string,
-): Promise<{ companySlug: string; employeeSlug: string } | null> {
+): Promise<BrowserStorageIdentity | null> {
   const co = await AppDataSource.getRepository(Company).findOneBy({ id: companyId });
   if (!co) return null;
   const emp = await AppDataSource.getRepository(AIEmployee).findOneBy({
@@ -32,6 +39,110 @@ async function resolveSlugs(
   });
   if (!emp) return null;
   return { companySlug: co.slug, employeeSlug: emp.slug };
+}
+
+async function ensurePrivateDirectory(directory: string): Promise<void> {
+  const root = dataRoot();
+  await fs.mkdir(root, { recursive: true });
+  const relative = path.relative(root, directory);
+  if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`)) {
+    throw new Error("Browser storage directory must stay inside the App data directory");
+  }
+  let current = root;
+  for (const component of relative.split(path.sep)) {
+    current = path.join(current, component);
+    try {
+      const stat = await fs.lstat(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("Browser storage directory is not a private directory");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await fs.mkdir(current, { mode: 0o700 }).catch((mkdirError) => {
+        if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+      });
+      const created = await fs.lstat(current);
+      if (!created.isDirectory() || created.isSymbolicLink()) {
+        throw new Error("Browser storage directory is not a private directory");
+      }
+    }
+    await fs.chmod(current, 0o700);
+  }
+}
+
+async function assertPrivateStateFile(file: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+      throw new Error("Browser storage state is not a private regular file");
+    }
+    await fs.chmod(file, 0o600);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/**
+ * Move the legacy workspace-visible snapshot before any coding tool is built.
+ * Temporary/torn legacy snapshots are deleted too, so bubblewrapped bash never
+ * inherits an old cookie file after an upgrade.
+ */
+export async function migrateLegacyBrowserStorage(
+  companyId: string,
+  employeeId: string,
+): Promise<void> {
+  const identity = await resolveIdentity(companyId, employeeId);
+  if (!identity) return;
+  const destination = employeeBrowserStateFile(companyId, employeeId);
+  await ensurePrivateDirectory(path.dirname(destination));
+  let destinationExists = await assertPrivateStateFile(destination);
+  const legacy = legacyEmployeeBrowserStateFile(identity.companySlug, identity.employeeSlug);
+  const legacyDirectory = path.dirname(legacy);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(legacyDirectory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  const artifacts = entries.filter((entry) => entry.startsWith(".browser-state.json"));
+  for (const artifact of artifacts) {
+    const source = path.join(legacyDirectory, artifact);
+    let stat;
+    try {
+      stat = await fs.lstat(source);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    if (stat.isFile() && stat.nlink !== 1) {
+      throw new Error("Legacy Browser storage has an unsafe hard link");
+    }
+    if (artifact === ".browser-state.json" && !destinationExists && stat.isFile()) {
+      try {
+        await fs.rename(source, destination);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      destinationExists = await assertPrivateStateFile(destination);
+      if (destinationExists) continue;
+    }
+    if (!stat.isFile() && !stat.isSymbolicLink()) {
+      throw new Error("Legacy Browser storage artifact is not a regular file");
+    }
+    await fs.unlink(source).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    });
+  }
+}
+
+export async function removeBrowserStorageForEmployee(
+  companyId: string,
+  employeeId: string,
+): Promise<void> {
+  await fs.rm(employeeBrowserStateFile(companyId, employeeId), { force: true });
 }
 
 /**
@@ -43,9 +154,10 @@ export async function loadStorageState(
   companyId: string,
   employeeId: string,
 ): Promise<StorageState | undefined> {
-  const slugs = await resolveSlugs(companyId, employeeId);
-  if (!slugs) return undefined;
-  const file = employeeBrowserStateFile(slugs.companySlug, slugs.employeeSlug);
+  const identity = await resolveIdentity(companyId, employeeId);
+  if (!identity) return undefined;
+  await migrateLegacyBrowserStorage(companyId, employeeId);
+  const file = employeeBrowserStateFile(companyId, employeeId);
   let raw: string;
   try {
     raw = await fs.readFile(file, "utf8");
@@ -79,13 +191,14 @@ export async function saveStorageState(
   context: unknown,
 ): Promise<void> {
   try {
-    const slugs = await resolveSlugs(companyId, employeeId);
-    if (!slugs) return;
+    const identity = await resolveIdentity(companyId, employeeId);
+    if (!identity) return;
+    await migrateLegacyBrowserStorage(companyId, employeeId);
     const cx = context as { storageState: () => Promise<StorageState> } | null;
     if (!cx) return;
     const state = await cx.storageState();
-    ensureDir(employeeDir(slugs.companySlug, slugs.employeeSlug));
-    const file = employeeBrowserStateFile(slugs.companySlug, slugs.employeeSlug);
+    const file = employeeBrowserStateFile(companyId, employeeId);
+    await ensurePrivateDirectory(path.dirname(file));
     const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
     await fs.writeFile(tmp, JSON.stringify(state), { encoding: "utf8", mode: 0o600 });
     await fs.rename(tmp, file);

--- a/App/server/services/chat.ts
+++ b/App/server/services/chat.ts
@@ -462,13 +462,11 @@ export async function streamChatWithEmployee(
       // Materialize granted repos into the employee's cwd so the coding tools
       // find a working tree. Non-fatal — chat still proceeds if a repo fails.
       const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
-      Object.assign(toolEnv, repoSync.extraEnv);
-      const codeRepoSync = await materializeCodeReposForEmployee({
+      await materializeCodeReposForEmployee({
         employeeId: emp.id,
         cwd,
         githubRepoCredentials: repoSync.githubRepoCredentials,
       });
-      Object.assign(toolEnv, codeRepoSync.extraEnv);
     }
 
     mcpToken = issueMcpToken(

--- a/App/server/services/codeRepoSshFiles.test.ts
+++ b/App/server/services/codeRepoSshFiles.test.ts
@@ -2,48 +2,102 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import { after, before, beforeEach, describe, test } from "node:test";
+import { config } from "../../config.js";
 import {
   persistCodeRepoKnownHosts,
-  persistCodeRepoSshKey,
+  purgeLegacyCodeRepoSshFiles,
   readCodeRepoKnownHosts,
 } from "./codeRepoSshFiles.js";
+import { employeeCodeRepoKnownHostsFile } from "./paths.js";
 
-test("SSH key persistence replaces a final symlink without truncating its target", (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-ssh-final-link-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const workspace = path.join(root, "workspace");
-  const sshDirectory = path.join(workspace, "code-repos", ".ssh");
-  const outside = path.join(root, "outside-key");
-  fs.mkdirSync(sshDirectory, { recursive: true });
-  fs.writeFileSync(outside, "outside-must-not-change\n");
-  fs.symlinkSync(outside, path.join(sshDirectory, "repo-id"));
+const originalDataDir = config.dataDir;
+const mutableConfig = config as unknown as { dataDir: string };
+let root = "";
 
-  const keyPath = persistCodeRepoSshKey(workspace, "repo-id", "private-key");
-
-  assert.equal(fs.readFileSync(outside, "utf8"), "outside-must-not-change\n");
-  assert.equal(fs.lstatSync(keyPath).isFile(), true);
-  assert.equal(fs.readFileSync(keyPath, "utf8"), "private-key\n");
+before(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-code-repo-state-"));
+  mutableConfig.dataDir = path.join(root, "data");
 });
 
-test("a symlinked SSH directory cannot redirect reads or writes outside the workspace", (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-ssh-parent-link-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const workspace = path.join(root, "workspace");
-  const codeRepos = path.join(workspace, "code-repos");
-  const outside = path.join(root, "outside");
-  fs.mkdirSync(codeRepos, { recursive: true });
-  fs.mkdirSync(outside);
-  fs.writeFileSync(path.join(outside, "repo-id"), "outside-key\n");
-  fs.writeFileSync(path.join(outside, "known_hosts"), "outside-known-host\n");
-  fs.symlinkSync(outside, path.join(codeRepos, ".ssh"));
-  const outsideEntries = fs.readdirSync(outside).sort();
+beforeEach(() => {
+  fs.rmSync(mutableConfig.dataDir, { recursive: true, force: true });
+});
 
-  assert.throws(() => readCodeRepoKnownHosts(workspace));
-  assert.throws(() => persistCodeRepoSshKey(workspace, "repo-id", "replacement-key"));
-  assert.throws(() => persistCodeRepoKnownHosts(workspace, "replacement-known-host\n"));
+after(() => {
+  mutableConfig.dataDir = originalDataDir;
+  fs.rmSync(root, { recursive: true, force: true });
+});
 
-  assert.equal(fs.readFileSync(path.join(outside, "repo-id"), "utf8"), "outside-key\n");
-  assert.equal(fs.readFileSync(path.join(outside, "known_hosts"), "utf8"), "outside-known-host\n");
-  assert.deepEqual(fs.readdirSync(outside).sort(), outsideEntries);
+describe("private Code Repository SSH state", () => {
+  test("stores only known_hosts outside the model-visible workspace with private modes", () => {
+    const workspace = path.join(root, "workspace");
+    fs.mkdirSync(workspace, { recursive: true });
+
+    persistCodeRepoKnownHosts("company", "employee", "github.com ssh-ed25519 AAAA\n");
+
+    const file = employeeCodeRepoKnownHostsFile("company", "employee");
+    assert.equal(readCodeRepoKnownHosts("company", "employee"), "github.com ssh-ed25519 AAAA\n");
+    assert.equal(file.startsWith(workspace), false);
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(path.dirname(file)).mode & 0o777, 0o700);
+    assert.deepEqual(fs.readdirSync(path.dirname(file)), ["employee.known_hosts"]);
+  });
+
+  test("rejects symlinked or hard-linked private known-host files", () => {
+    const file = employeeCodeRepoKnownHostsFile("company", "employee");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const outside = path.join(root, "outside-known-hosts");
+    fs.writeFileSync(outside, "outside\n");
+    fs.symlinkSync(outside, file);
+    assert.throws(() => persistCodeRepoKnownHosts("company", "employee", "replacement\n"));
+    assert.equal(fs.readFileSync(outside, "utf8"), "outside\n");
+
+    fs.unlinkSync(file);
+    fs.writeFileSync(file, "original\n");
+    fs.linkSync(file, path.join(root, "known-hosts-alias"));
+    assert.throws(() => readCodeRepoKnownHosts("company", "employee"), /private regular file/);
+  });
+});
+
+describe("legacy workspace SSH cleanup", () => {
+  test("removes legacy keys and symlinks without following them", () => {
+    const workspace = path.join(root, "workspace-cleanup");
+    const legacy = path.join(workspace, "code-repos", ".ssh");
+    const outside = path.join(root, "outside-key");
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, "repo-id"), "PRIVATE_KEY\n", { mode: 0o600 });
+    fs.writeFileSync(path.join(legacy, "known_hosts"), "host key\n", { mode: 0o600 });
+    fs.writeFileSync(outside, "outside-must-not-change\n");
+    fs.symlinkSync(outside, path.join(legacy, "outside-link"));
+
+    purgeLegacyCodeRepoSshFiles(workspace);
+
+    assert.equal(fs.existsSync(legacy), false);
+    assert.equal(fs.readFileSync(outside, "utf8"), "outside-must-not-change\n");
+  });
+
+  test("fails closed when a legacy private key has another hardlink", () => {
+    const workspace = path.join(root, "workspace-hardlink");
+    const legacy = path.join(workspace, "code-repos", ".ssh");
+    fs.mkdirSync(legacy, { recursive: true });
+    const key = path.join(legacy, "repo-id");
+    fs.writeFileSync(key, "PRIVATE_KEY\n", { mode: 0o600 });
+    fs.linkSync(key, path.join(workspace, "key-alias.txt"));
+
+    assert.throws(() => purgeLegacyCodeRepoSshFiles(workspace), /unsafe hard link/);
+    assert.equal(fs.readFileSync(path.join(workspace, "key-alias.txt"), "utf8"), "PRIVATE_KEY\n");
+  });
+
+  test("never follows a symlinked code-repos parent", () => {
+    const workspace = path.join(root, "workspace-parent-link");
+    const outside = path.join(root, "outside-code-repos");
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(path.join(outside, ".ssh"), { recursive: true });
+    fs.writeFileSync(path.join(outside, ".ssh", "repo-id"), "OUTSIDE_KEY\n");
+    fs.symlinkSync(outside, path.join(workspace, "code-repos"));
+
+    assert.throws(() => purgeLegacyCodeRepoSshFiles(workspace), /not a private directory/);
+    assert.equal(fs.readFileSync(path.join(outside, ".ssh", "repo-id"), "utf8"), "OUTSIDE_KEY\n");
+  });
 });

--- a/App/server/services/codeRepoSshFiles.ts
+++ b/App/server/services/codeRepoSshFiles.ts
@@ -1,77 +1,155 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
-import {
-  closePinnedDirectory,
-  openPinnedChildDirectory,
-  openPinnedDirectory,
-  readPinnedFile,
-  writePinnedFileAtomic,
-} from "./safeWorkspaceFs.js";
-import type { PinnedDirectory } from "./safeWorkspaceFs.js";
+import { codeRepoPrivateCompanyDir, dataRoot, employeeCodeRepoKnownHostsFile } from "./paths.js";
 
 const MAX_KNOWN_HOSTS_BYTES = 1024 * 1024;
 
-export function persistCodeRepoSshKey(
-  workspaceRoot: string,
-  repositoryId: string,
-  privateKey: string,
-): string {
-  assertRepositoryFilename(repositoryId);
-  withSshDirectory(workspaceRoot, true, (directory) => {
-    const value = privateKey.endsWith("\n") ? privateKey : `${privateKey}\n`;
-    writePinnedFileAtomic(directory, repositoryId, value);
-  });
-  return path.join(workspaceRoot, "code-repos", ".ssh", repositoryId);
+/**
+ * Read the host-key cache used by short-lived, server-owned SSH git commands.
+ * No private key is ever persisted: the encrypted DB value is materialized
+ * only inside workspaceGitRemote's App-private temporary directory.
+ */
+export function readCodeRepoKnownHosts(companyId: string, employeeId: string): string | undefined {
+  const file = employeeCodeRepoKnownHostsFile(companyId, employeeId);
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+      throw new Error("Code Repository known-host state is not a private regular file");
+    }
+    if (stat.size > MAX_KNOWN_HOSTS_BYTES) {
+      throw new Error("SSH known-host data is too large.");
+    }
+    fs.chmodSync(file, 0o600);
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
 }
 
-export function readCodeRepoKnownHosts(workspaceRoot: string): string | undefined {
-  return withSshDirectory(workspaceRoot, false, (directory) =>
-    readPinnedFile(directory, "known_hosts", MAX_KNOWN_HOSTS_BYTES),
-  );
-}
-
-export function persistCodeRepoKnownHosts(workspaceRoot: string, value: string): void {
+export function persistCodeRepoKnownHosts(
+  companyId: string,
+  employeeId: string,
+  value: string,
+): void {
   if (Buffer.byteLength(value) > MAX_KNOWN_HOSTS_BYTES) {
     throw new Error("SSH known-host data is too large.");
   }
-  withSshDirectory(workspaceRoot, true, (directory) => {
-    writePinnedFileAtomic(directory, "known_hosts", value);
-  });
-}
-
-function withSshDirectory<T>(
-  workspaceRoot: string,
-  create: boolean,
-  action: (directory: PinnedDirectory) => T,
-): T | undefined {
-  const root = openPinnedDirectory(workspaceRoot, workspaceRoot, "Employee workspace");
-  let codeRepos: PinnedDirectory | undefined;
-  let sshDirectory: PinnedDirectory | undefined;
+  const directory = codeRepoPrivateCompanyDir(companyId);
+  ensurePrivateDirectory(directory);
+  const file = employeeCodeRepoKnownHostsFile(companyId, employeeId);
+  assertReplaceablePrivateFile(file);
+  const temporary = path.join(directory, `.${employeeId}.${randomUUID()}.tmp`);
   try {
-    try {
-      codeRepos = openPinnedChildDirectory(root, "code-repos", {
-        create,
-        mode: 0o700,
-        label: "Code Repository directory",
-      });
-      sshDirectory = openPinnedChildDirectory(codeRepos, ".ssh", {
-        create,
-        mode: 0o700,
-        label: "Code Repository SSH directory",
-      });
-    } catch (error) {
-      if (!create && (error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-      throw error;
+    fs.writeFileSync(temporary, value, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    fs.renameSync(temporary, file);
+    fs.chmodSync(file, 0o600);
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+      throw new Error("Code Repository known-host state is not a private regular file");
     }
-    return action(sshDirectory);
   } finally {
-    if (sshDirectory) closePinnedDirectory(sshDirectory);
-    if (codeRepos) closePinnedDirectory(codeRepos);
-    closePinnedDirectory(root);
+    fs.rmSync(temporary, { force: true });
   }
 }
 
-function assertRepositoryFilename(repositoryId: string): void {
-  if (!/^[A-Za-z0-9_-]+$/.test(repositoryId)) {
-    throw new Error("Code Repository ID cannot be used as an SSH key filename.");
+/** Remove App-private repository state when an AI Employee is deleted. */
+export function removeCodeRepoPrivateStateForEmployee(companyId: string, employeeId: string): void {
+  fs.rmSync(employeeCodeRepoKnownHostsFile(companyId, employeeId), { force: true });
+}
+
+/**
+ * Delete the pre-1.94 workspace SSH directory before coding tools are built.
+ * Hard-linked files fail closed: renaming or deleting the legacy name would
+ * leave an arbitrary alias with the same private-key bytes.
+ */
+export function purgeLegacyCodeRepoSshFiles(workspaceRoot: string): void {
+  const codeRepos = path.join(path.resolve(workspaceRoot), "code-repos");
+  let codeReposStat: fs.Stats;
+  try {
+    codeReposStat = fs.lstatSync(codeRepos);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (!codeReposStat.isDirectory() || codeReposStat.isSymbolicLink()) {
+    throw new Error("Legacy Code Repository directory is not a private directory");
+  }
+
+  const legacy = path.join(codeRepos, ".ssh");
+  let legacyStat: fs.Stats;
+  try {
+    legacyStat = fs.lstatSync(legacy);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (legacyStat.isSymbolicLink()) {
+    fs.unlinkSync(legacy);
+    return;
+  }
+  if (!legacyStat.isDirectory()) {
+    if (legacyStat.isFile() && legacyStat.nlink !== 1) {
+      throw new Error("Legacy Code Repository SSH state has an unsafe hard link");
+    }
+    fs.rmSync(legacy, { force: true });
+    return;
+  }
+
+  assertNoHardLinkedFiles(legacy);
+  fs.rmSync(legacy, { recursive: true, force: true });
+}
+
+function assertNoHardLinkedFiles(directory: string): void {
+  for (const entry of fs.readdirSync(directory)) {
+    const child = path.join(directory, entry);
+    const stat = fs.lstatSync(child);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) {
+      assertNoHardLinkedFiles(child);
+      continue;
+    }
+    if (stat.isFile() && stat.nlink !== 1) {
+      throw new Error("Legacy Code Repository SSH state has an unsafe hard link");
+    }
+  }
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  const root = dataRoot();
+  fs.mkdirSync(root, { recursive: true });
+  const relative = path.relative(root, directory);
+  if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`)) {
+    throw new Error("Code Repository private state must stay inside the App data directory");
+  }
+  let current = root;
+  for (const component of relative.split(path.sep)) {
+    current = path.join(current, component);
+    try {
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("Code Repository private state is not a private directory");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      fs.mkdirSync(current, { mode: 0o700 });
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("Code Repository private state is not a private directory");
+      }
+    }
+    fs.chmodSync(current, 0o700);
+  }
+}
+
+function assertReplaceablePrivateFile(file: string): void {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+      throw new Error("Code Repository known-host state is not a private regular file");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }

--- a/App/server/services/codeRepos.ts
+++ b/App/server/services/codeRepos.ts
@@ -18,7 +18,6 @@ import {
   assertSafeCredentialToken,
   assertSafeGitRemoteUrl,
   clearEnvCredentialHelper,
-  configureEnvCredentialHelper,
   inlineEnvCredentialHelper,
 } from "./gitCredentialHelper.js";
 import type { GithubRepoCredential } from "./repoSync.js";
@@ -26,7 +25,7 @@ import { runWorkspaceGit } from "./workspaceGit.js";
 import { cloneWorkspaceGitRemote, fetchWorkspaceGitRemote } from "./workspaceGitRemote.js";
 import {
   persistCodeRepoKnownHosts,
-  persistCodeRepoSshKey,
+  purgeLegacyCodeRepoSshFiles,
   readCodeRepoKnownHosts,
 } from "./codeRepoSshFiles.js";
 
@@ -41,18 +40,14 @@ import {
  *
  * Before each chat / routine spawn the runner calls
  * {@link materializeCodeReposForEmployee}, which drops a real `git clone`
- * of every granted repo into `<employeeDir>/code-repos/<slug>/` and wires
- * up credentials so the agent's ordinary `git fetch` / `commit` / `push`
- * Just Work. As in `repoSync`, we only ever `fetch` on an existing
- * checkout (never `reset --hard`) so the agent's WIP between spawns is
+ * of every granted repo into `<employeeDir>/code-repos/<slug>/`. As in
+ * `repoSync`, we only ever `fetch` on an existing
+ * checkout (never `reset --hard`) so the employee's WIP between spawns is
  * never trampled.
  *
- * Credential handling mirrors `repoSync`'s "token never lands on disk"
- * rule for HTTPS: the token is handed to git through a per-repo env var
- * (`GENOSYN_REPO_TOKEN_<id>`) the runner sets for the turn, read back by
- * an inline credential helper in local git config. SSH is the one exception
- * — git needs a private-key *file*, so the key is written under the employee's
- * data dir (gitignored) with mode 0600 and pinned via `core.sshCommand`.
+ * Credentials are handed only to the short-lived, server-owned clone/fetch
+ * workspace. Tokens and SSH private keys never enter the model-visible
+ * checkout, its Git config, or the model tool environment.
  */
 
 // ───────────────────────────── slugs ────────────────────────────────────
@@ -198,21 +193,6 @@ function sshCommandFor(keyPath: string): string {
   return `ssh -i ${q(keyPath)} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=${q(knownHosts)}`;
 }
 
-async function configureCredentialHelper(
-  workspaceRoot: string,
-  repoPath: string,
-  username: string,
-  envKey: string,
-  remoteUrl: string,
-): Promise<void> {
-  await configureEnvCredentialHelper(
-    (args) => runGit(workspaceRoot, repoPath, args),
-    username,
-    envKey,
-    remoteUrl,
-  );
-}
-
 // In-process mutex per (employeeId × repoId) so two concurrent spawns can't
 // race on the same checkout.
 const inflight = new Map<string, Promise<unknown>>();
@@ -243,8 +223,8 @@ export type SyncedCodeRepo = {
 export type CodeRepoSyncError = { scope: string; message: string };
 
 export type CodeRepoSyncResult = {
-  /** Env vars to merge into the spawn so the agent's `git push` finds the
-   *  matching token. Keys: `GENOSYN_REPO_TOKEN_<id>`. */
+  /** Reserved compatibility field. Repository credentials are never exported
+   * to the model tool environment, so this is always empty. */
   extraEnv: Record<string, string>;
   repos: SyncedCodeRepo[];
   errors: CodeRepoSyncError[];
@@ -269,6 +249,7 @@ export async function materializeCodeReposForEmployee(args: {
     id: args.employeeId,
   });
   if (!employee) return result;
+  purgeLegacyCodeRepoSshFiles(args.cwd);
 
   const grants = await AppDataSource.getRepository(EmployeeCodeRepositoryGrant).find({
     where: { employeeId: args.employeeId },
@@ -344,18 +325,6 @@ async function syncOneRepo(
 
   const envKey = linkedGithubCredential?.envKey ?? envKeyFor(repo.id);
   const httpsUsername = linkedGithubCredential ? "x-access-token" : httpsUsernameOf(repo);
-  let sshCommand: string | undefined;
-
-  if (repo.authMode === "ssh" && sshKey) {
-    const keyPath = persistCodeRepoSshKey(cwd, repo.id, sshKey);
-    sshCommand = sshCommandFor(workspaceVisiblePath(cwd, keyPath));
-  }
-  if (repo.authMode === "https" && token) {
-    result.extraEnv[envKey] = token;
-  }
-  if (linkedGithubCredential) {
-    result.extraEnv[envKey] = linkedGithubCredential.token;
-  }
   const credentialEnv = token ? { [envKey]: token } : {};
   const credentialHelper = token
     ? inlineEnvCredentialHelper(httpsUsername, envKey, repo.gitUrl)
@@ -364,7 +333,7 @@ async function syncOneRepo(
     repo.authMode === "ssh" && sshKey
       ? {
           privateKey: sshKey,
-          knownHosts: readCodeRepoKnownHosts(cwd),
+          knownHosts: readCodeRepoKnownHosts(employee.companyId, employee.id),
         }
       : undefined;
   let syncedKnownHosts: string | undefined;
@@ -385,13 +354,6 @@ async function syncOneRepo(
     syncedKnownHosts = cloneResult.sshKnownHosts;
     await runGit(cwd, repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
   } else {
-    // Install/refresh the helper before fetch so a pre-existing private
-    // checkout can authenticate even if it predates Genosyn's helper wiring.
-    if (token) {
-      await configureCredentialHelper(cwd, repoPath, httpsUsername, envKey, repo.gitUrl);
-    } else {
-      await clearCredentialHelper(cwd, repoPath);
-    }
     await runGit(cwd, repoPath, ["remote", "set-url", "origin", repo.gitUrl]);
     // Existing checkout: refresh refs from only the trusted configured URL.
     // Never visit remotes an AI Employee added to the writable local config.
@@ -406,28 +368,19 @@ async function syncOneRepo(
     syncedKnownHosts = fetchResult.sshKnownHosts;
   }
 
-  if (syncedKnownHosts !== undefined) persistCodeRepoKnownHosts(cwd, syncedKnownHosts);
-
-  // Pin per-repo wiring every spawn (idempotent — settings may have changed
-  // between spawns, e.g. a grant downgraded from write to read).
-  if (sshCommand) {
-    await runGit(cwd, repoPath, ["config", "--local", "core.sshCommand", sshCommand]);
-  } else {
-    // Drop any stale sshCommand if the repo flipped away from SSH.
-    await runGit(cwd, repoPath, ["config", "--local", "--unset", "core.sshCommand"]).catch(
-      () => {},
-    );
-  }
-  if (token) {
-    await configureCredentialHelper(cwd, repoPath, httpsUsername, envKey, repo.gitUrl);
-  } else {
-    await clearCredentialHelper(cwd, repoPath);
+  if (syncedKnownHosts !== undefined) {
+    persistCodeRepoKnownHosts(employee.companyId, employee.id, syncedKnownHosts);
   }
 
-  // Read-only grants get their push URL disabled so an accidental `git push`
-  // fails fast with a message naming the missing grant, rather than silently
-  // succeeding on a token that happens to carry write scope.
-  if (accessLevel === "write") {
+  // The checkout is model-writable. Remove reusable helpers and key paths left
+  // by older releases after the credentialed server operation completes.
+  await clearCredentialHelper(cwd, repoPath);
+  await runGit(cwd, repoPath, ["config", "--local", "--unset", "core.sshCommand"]).catch(() => {});
+
+  // Only a genuinely credential-free writable remote may be exposed to the
+  // model shell. Authenticated remotes are refreshed server-side but never get
+  // a reusable credential or credentialed push path.
+  if (accessLevel === "write" && repo.authMode === "none" && !linkedGithubCredential) {
     await runGit(cwd, repoPath, ["remote", "set-url", "--push", "origin", repo.gitUrl]);
   } else {
     await runGit(cwd, repoPath, ["remote", "set-url", "--push", "origin", NO_PUSH_URL]);
@@ -571,9 +524,9 @@ export const CODE_REPO_AUTH_MODES: CodeRepoAuthMode[] = ["none", "https", "ssh"]
 
 /**
  * A ready-made markdown section listing the Code Repositories this employee
- * can work on, where each is checked out, and whether it may push. Injected
+ * can work on and where each is checked out. Injected
  * into the chat / routine prompt so the agent knows the working trees exist
- * and that `git push` is already wired up for it. Returns "" when the
+ * without exposing repository credentials. Returns "" when the
  * employee has no repo grants.
  */
 export async function composeCodeReposContext(employeeId: string): Promise<string> {
@@ -599,12 +552,14 @@ export async function composeCodeReposContext(employeeId: string): Promise<strin
   const lines: string[] = [];
   for (const r of repos) {
     const level = accessById.get(r.id);
-    const canPush = level === "write";
+    const canPushWithoutCredential = level === "write" && r.authMode === "none";
     lines.push(
       `- **${r.name}** — checked out at \`code-repos/${r.slug}/\` (default branch \`${r.defaultBranch}\`). ${
-        canPush
-          ? "You may commit and `git push`."
-          : "Read-only — commit locally if useful, but pushing is disabled for you."
+        canPushWithoutCredential
+          ? "You may commit and push if the remote accepts unauthenticated writes."
+          : level === "write"
+            ? "You may edit and commit locally; direct credentialed pushing is disabled."
+            : "Read-only — commit locally if useful, but pushing is disabled for you."
       }`,
     );
   }
@@ -613,8 +568,8 @@ export async function composeCodeReposContext(employeeId: string): Promise<strin
   return [
     "",
     "## Code Repositories",
-    "You have real git checkouts of these repositories in your working directory. Use ordinary `git` to read, branch, commit, and (where allowed) push — credentials and the committer identity are already configured, so you do not need to set up remotes or tokens.",
-    "When a teammate asks you to deliver a code change, carry the work through: create a focused branch, edit the files with your coding tools, run the relevant checks, commit, and push. If a matching GitHub `*_create_pull_request` tool is available, call it after pushing to open the requested pull request (draft when requested). Never claim a pull request exists unless the tool returned it; if no PR tool is available, say that a GitHub Connection grant is needed and report the pushed branch instead.",
+    "You have real git checkouts of these repositories in your working directory. Use ordinary `git` to read, branch, edit, test, and commit. Repository credentials stay server-side and are never available to your shell or files; do not look for, print, or request tokens or private keys.",
+    "When a teammate asks you to deliver a code change, create a focused branch, edit the files with your coding tools, run the relevant checks, and commit. For an authenticated remote, report the local branch and commit so a governed server-side or Member workflow can publish it; never claim a push or pull request exists unless the corresponding operation actually succeeded.",
     "",
     ...lines,
   ].join("\n");

--- a/App/server/services/companyDelete.ts
+++ b/App/server/services/companyDelete.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import { In } from "typeorm";
 import { AppDataSource } from "../db/datasource.js";
-import { companyDir } from "./paths.js";
+import { browserPrivateCompanyDir, codeRepoPrivateCompanyDir, companyDir } from "./paths.js";
+import { emitMembershipAuthorizationChange } from "./resourceEvents.js";
 
 import { AIEmployee } from "../db/entities/AIEmployee.js";
 import { AIModel } from "../db/entities/AIModel.js";
@@ -141,6 +142,9 @@ import { Resource } from "../db/entities/Resource.js";
 import { Routine } from "../db/entities/Routine.js";
 import { Run } from "../db/entities/Run.js";
 import { Secret } from "../db/entities/Secret.js";
+import { VaultItem } from "../db/entities/VaultItem.js";
+import { VaultItemMemberAccess } from "../db/entities/VaultItemMemberAccess.js";
+import { EmployeeVaultGrant } from "../db/entities/EmployeeVaultGrant.js";
 import { Skill } from "../db/entities/Skill.js";
 import { Tag } from "../db/entities/Tag.js";
 import { TagAssignment } from "../db/entities/TagAssignment.js";
@@ -408,6 +412,9 @@ export async function deleteCompanyCascade(args: {
     await m.delete(AuditEvent, { companyId });
     await m.delete(ApiKey, { companyId });
     await m.delete(Secret, { companyId });
+    await m.delete(VaultItemMemberAccess, { companyId });
+    await m.delete(EmployeeVaultGrant, { companyId });
+    await m.delete(VaultItem, { companyId });
     await m.delete(Resource, { companyId });
     // Newer company-scoped surfaces: sales docs (Estimate / RecurringInvoice +
     // their line items and CustomerContact / CustomerContract), Explore
@@ -477,6 +484,7 @@ export async function deleteCompanyCascade(args: {
     await m.delete(Membership, { companyId });
     await m.delete(Company, { id: companyId });
   });
+  emitMembershipAuthorizationChange(companyId);
 
   // ── 4. Filesystem (best-effort) ──────────────────────────────────────
   try {
@@ -484,6 +492,20 @@ export async function deleteCompanyCascade(args: {
   } catch (err) {
     console.warn(
       `[companyDelete] failed to remove ${companyDir(companySlug)}: ${(err as Error).message}`,
+    );
+  }
+  try {
+    fs.rmSync(browserPrivateCompanyDir(companyId), { recursive: true, force: true });
+  } catch (err) {
+    console.warn(
+      `[companyDelete] failed to remove private Browser state for ${companyId}: ${(err as Error).message}`,
+    );
+  }
+  try {
+    fs.rmSync(codeRepoPrivateCompanyDir(companyId), { recursive: true, force: true });
+  } catch (err) {
+    console.warn(
+      `[companyDelete] failed to remove private Code Repository state for ${companyId}: ${(err as Error).message}`,
     );
   }
 }

--- a/App/server/services/customEndpoint.ts
+++ b/App/server/services/customEndpoint.ts
@@ -9,7 +9,7 @@ import { decryptSecret } from "../lib/secret.js";
  * is no config file on disk any more.
  *
  * configJson shape (encrypted-at-rest fields are AES-256-GCM via `lib/secret`,
- * keyed off `config.sessionSecret`):
+ * keyed from the instance encryption key ring):
  *
  *   {
  *     baseURLEncrypted: string,   // load-bearing — connection signal

--- a/App/server/services/email.ts
+++ b/App/server/services/email.ts
@@ -1,14 +1,7 @@
 import nodemailer, { Transporter } from "nodemailer";
 import { AppDataSource } from "../db/datasource.js";
-import {
-  EmailLog,
-  EmailLogPurpose,
-  EmailLogTransport,
-} from "../db/entities/EmailLog.js";
-import {
-  EmailProvider,
-  EmailProviderKind,
-} from "../db/entities/EmailProvider.js";
+import { EmailLog, EmailLogPurpose, EmailLogTransport } from "../db/entities/EmailLog.js";
+import { EmailProvider, EmailProviderKind } from "../db/entities/EmailProvider.js";
 import { decryptSecret } from "../lib/secret.js";
 import {
   EmailAttachment,
@@ -106,16 +99,12 @@ export type SendEmailResult = {
   logId: string;
 };
 
-export async function sendEmail(
-  opts: SendEmailOptions,
-): Promise<SendEmailResult> {
+export async function sendEmail(opts: SendEmailOptions): Promise<SendEmailResult> {
   const purpose: EmailLogPurpose = opts.purpose ?? "other";
   const triggeredByUserId = opts.triggeredByUserId ?? null;
   const bodyPreview = opts.bodyPreview ?? opts.text;
 
-  const provider = opts.companyId
-    ? await loadDefaultProvider(opts.companyId)
-    : null;
+  const provider = opts.companyId ? await loadDefaultProvider(opts.companyId) : null;
 
   if (provider) {
     const cfg = decryptProviderConfig(provider);
@@ -446,9 +435,7 @@ export async function sendTestEmail(args: {
   }
 }
 
-async function loadDefaultProvider(
-  companyId: string,
-): Promise<EmailProvider | null> {
+async function loadDefaultProvider(companyId: string): Promise<EmailProvider | null> {
   const repo = AppDataSource.getRepository(EmailProvider);
   const row = await repo.findOne({
     where: { companyId, isDefault: true, enabled: true },
@@ -456,25 +443,20 @@ async function loadDefaultProvider(
   return row ?? null;
 }
 
-export function decryptProviderConfig(
-  provider: EmailProvider,
-): EmailProviderConfig {
+export function decryptProviderConfig(provider: EmailProvider): EmailProviderConfig {
   const raw = decryptSecret(provider.encryptedConfig);
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
     throw new Error(
-      "Email provider config is corrupted or was encrypted with a different sessionSecret.",
+      "Email provider config is corrupted or was encrypted with a different encryption key.",
     );
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("Email provider config has an unexpected shape.");
   }
-  return validateProviderConfig(
-    provider.kind,
-    parsed as Record<string, unknown>,
-  );
+  return validateProviderConfig(provider.kind, parsed as Record<string, unknown>);
 }
 
 async function writeLog(args: {

--- a/App/server/services/emailProviders.ts
+++ b/App/server/services/emailProviders.ts
@@ -14,7 +14,7 @@ import { decryptProviderConfig } from "./email.js";
 
 /**
  * Service layer for `EmailProvider` rows. Wraps the repo with:
- *  - encrypt/decrypt of the config blob (same sessionSecret-derived key as
+ *  - encrypt/decrypt of the config blob (same scoped encryption key ring as
  *    Secrets / IntegrationConnections).
  *  - default-row uniqueness — enabling `isDefault` on one row clears it on
  *    the others atomically.

--- a/App/server/services/instanceSecretsDatabase.test.ts
+++ b/App/server/services/instanceSecretsDatabase.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, beforeEach, describe, test } from "node:test";
+import Keygrip from "keygrip";
+
+import { config } from "../../config.js";
+import { AppDataSource } from "../db/datasource.js";
+import { AppSetting } from "../db/entities/AppSetting.js";
+import { User } from "../db/entities/User.js";
+import {
+  ENCRYPTION_SECRET_PLACEHOLDER,
+  INSTANCE_SECRETS_FILENAME,
+  INSTANCE_SECRETS_SENTINEL_FILENAME,
+  SESSION_SECRET_PLACEHOLDER,
+  getEffectiveInstanceSecrets,
+  resetInstanceSecretsCacheForTests,
+} from "../lib/instanceSecrets.js";
+import {
+  deriveUnsubscribeSecret,
+  signUnsubscribeToken,
+  unsubscribeSecrets,
+  verifyUnsubscribeToken,
+} from "./revenue/unsubscribeToken.js";
+import { closeTestDb, initTestDb, resetTestDb } from "../test/dbHarness.js";
+import {
+  INSTANCE_SECRETS_DB_MARKER_KEY,
+  bindInstanceSecretsToDatabase,
+} from "./instanceSecretsDatabase.js";
+
+type MutableConfig = {
+  dataDir: string;
+  db: { driver: "sqlite" | "postgres"; sqlitePath: string };
+  sessionSecret: string;
+  security: {
+    multiTenant: boolean;
+    encryptionSecret: string;
+    previousEncryptionSecrets: string[];
+  };
+};
+
+const mutable = config as unknown as MutableConfig;
+let original: MutableConfig;
+let tempDir = "";
+
+before(initTestDb);
+
+beforeEach(async () => {
+  await resetTestDb();
+  original = structuredClone(mutable);
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-secret-db-marker-"));
+  mutable.dataDir = tempDir;
+  // The shared test DataSource remains in-memory SQLite. The runtime config is
+  // Postgres so filesystem detection deliberately has no legacy DB signal.
+  mutable.db.driver = "postgres";
+  mutable.db.sqlitePath = path.join(tempDir, "unused.sqlite");
+  mutable.sessionSecret = SESSION_SECRET_PLACEHOLDER;
+  mutable.security.multiTenant = false;
+  mutable.security.encryptionSecret = ENCRYPTION_SECRET_PLACEHOLDER;
+  mutable.security.previousEncryptionSecrets = [];
+  resetInstanceSecretsCacheForTests();
+});
+
+afterEach(() => {
+  mutable.dataDir = original.dataDir;
+  mutable.db.driver = original.db.driver;
+  mutable.db.sqlitePath = original.db.sqlitePath;
+  mutable.sessionSecret = original.sessionSecret;
+  mutable.security.multiTenant = original.security.multiTenant;
+  mutable.security.encryptionSecret = original.security.encryptionSecret;
+  mutable.security.previousEncryptionSecrets = original.security.previousEncryptionSecrets;
+  resetInstanceSecretsCacheForTests();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+after(closeTestDb);
+
+describe("managed instance secret database binding", () => {
+  test("detects a legacy Postgres install after DB init and enables decrypt-only fallbacks", async () => {
+    await AppDataSource.getRepository(User).save(
+      AppDataSource.getRepository(User).create({
+        email: "legacy@example.com",
+        passwordHash: "hash",
+        name: "Legacy Member",
+      }),
+    );
+
+    const before = getEffectiveInstanceSecrets();
+    assert.equal(before.placeholderSessionFallbackEnabled, false);
+    assert.equal(before.placeholderEncryptionFallbackEnabled, false);
+
+    await bindInstanceSecretsToDatabase();
+    const after = getEffectiveInstanceSecrets();
+    assert.equal(after.placeholderSessionFallbackEnabled, true);
+    assert.equal(after.placeholderEncryptionFallbackEnabled, true);
+    assert.ok(after.legacySessionDecryptionSecrets.includes(SESSION_SECRET_PLACEHOLDER));
+    assert.ok(after.encryptionDecryptionSecrets.includes(ENCRYPTION_SECRET_PLACEHOLDER));
+
+    const marker = await AppDataSource.getRepository(AppSetting).findOneByOrFail({
+      key: INSTANCE_SECRETS_DB_MARKER_KEY,
+    });
+    assert.equal(JSON.parse(marker.value).keyId, after.managedKeyId);
+
+    const signedCookie = "genosyn.sid=forged-session";
+    const publicCookieSignature = new Keygrip([SESSION_SECRET_PLACEHOLDER]).sign(signedCookie);
+    assert.equal(
+      new Keygrip([after.sessionSecret]).verify(signedCookie, publicCookieSignature),
+      false,
+    );
+
+    const payload = {
+      companyId: "company-legacy",
+      contactId: null,
+      email: "recipient@example.com",
+    };
+    const forgedUnsubscribe = signUnsubscribeToken(
+      payload,
+      deriveUnsubscribeSecret(ENCRYPTION_SECRET_PLACEHOLDER),
+    );
+    assert.equal(
+      unsubscribeSecrets().some(
+        (secret) => verifyUnsubscribeToken(forgedUnsubscribe, secret) !== null,
+      ),
+      false,
+    );
+  });
+
+  test("binds a fresh database without enabling public decrypt fallbacks", async () => {
+    const effective = getEffectiveInstanceSecrets();
+    await bindInstanceSecretsToDatabase();
+
+    assert.equal(effective.placeholderSessionFallbackEnabled, false);
+    assert.equal(effective.placeholderEncryptionFallbackEnabled, false);
+    const marker = await AppDataSource.getRepository(AppSetting).findOneByOrFail({
+      key: INSTANCE_SECRETS_DB_MARKER_KEY,
+    });
+    assert.equal(JSON.parse(marker.value).keyId, effective.managedKeyId);
+  });
+
+  test("fails closed when both managed files are lost and regenerated", async () => {
+    const originalSecrets = getEffectiveInstanceSecrets();
+    await bindInstanceSecretsToDatabase();
+
+    fs.rmSync(path.join(tempDir, INSTANCE_SECRETS_FILENAME));
+    fs.rmSync(path.join(tempDir, INSTANCE_SECRETS_SENTINEL_FILENAME));
+    resetInstanceSecretsCacheForTests();
+    const replacement = getEffectiveInstanceSecrets();
+    assert.notEqual(replacement.managedKeyId, originalSecrets.managedKeyId);
+
+    await assert.rejects(
+      bindInstanceSecretsToDatabase(),
+      /Managed instance secrets do not match this database/,
+    );
+    const marker = await AppDataSource.getRepository(AppSetting).findOneByOrFail({
+      key: INSTANCE_SECRETS_DB_MARKER_KEY,
+    });
+    assert.equal(JSON.parse(marker.value).keyId, originalSecrets.managedKeyId);
+  });
+});

--- a/App/server/services/instanceSecretsDatabase.ts
+++ b/App/server/services/instanceSecretsDatabase.ts
@@ -1,0 +1,105 @@
+import { config } from "../../config.js";
+import { AppDataSource } from "../db/datasource.js";
+import { AppSetting } from "../db/entities/AppSetting.js";
+import { Company } from "../db/entities/Company.js";
+import { User } from "../db/entities/User.js";
+import {
+  ENCRYPTION_SECRET_PLACEHOLDER,
+  SESSION_SECRET_PLACEHOLDER,
+  enableLegacyPlaceholderDecryption,
+  getEffectiveInstanceSecrets,
+} from "../lib/instanceSecrets.js";
+
+export const INSTANCE_SECRETS_DB_MARKER_KEY = "instance.managedSecretsKeyId";
+const MARKER_VERSION = 1;
+
+type DatabaseMarker = {
+  version: typeof MARKER_VERSION;
+  keyId: string;
+};
+
+function parseMarker(value: string): DatabaseMarker {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch (error) {
+    throw new Error("The database contains an invalid managed-secret marker", {
+      cause: error,
+    });
+  }
+  const marker = decoded as Partial<DatabaseMarker>;
+  if (
+    marker.version !== MARKER_VERSION ||
+    typeof marker.keyId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(marker.keyId)
+  ) {
+    throw new Error("The database contains an invalid managed-secret marker");
+  }
+  return { version: MARKER_VERSION, keyId: marker.keyId };
+}
+
+function assertMarkerMatches(marker: DatabaseMarker, managedKeyId: string | null): void {
+  if (!managedKeyId) {
+    throw new Error(
+      "The database requires managed instance secrets, but .instance-secrets.json is missing",
+    );
+  }
+  if (marker.keyId !== managedKeyId) {
+    throw new Error(
+      "Managed instance secrets do not match this database; restore both from the same backup",
+    );
+  }
+}
+
+async function legacyInstallationHasRows(): Promise<boolean> {
+  const [users, companies] = await Promise.all([
+    AppDataSource.getRepository(User).count(),
+    AppDataSource.getRepository(Company).count(),
+  ]);
+  return users > 0 || companies > 0;
+}
+
+/**
+ * Bind a managed secret file to the initialized database before any service
+ * reads encrypted rows or starts background work.
+ *
+ * An existing marker must match. Without a marker, a non-empty legacy database
+ * enables only the placeholder-configured decrypt fallbacks before the marker
+ * is inserted. The insert deliberately does not upsert: concurrent first boots
+ * race on the primary key, then the loser verifies the winner instead of ever
+ * overwriting a different installation identity.
+ */
+export async function bindInstanceSecretsToDatabase(): Promise<void> {
+  if (config.security.multiTenant) return;
+
+  const repo = AppDataSource.getRepository(AppSetting);
+  const existing = await repo.findOneBy({ key: INSTANCE_SECRETS_DB_MARKER_KEY });
+  let effective = getEffectiveInstanceSecrets();
+  if (existing) {
+    assertMarkerMatches(parseMarker(existing.value), effective.managedKeyId);
+    return;
+  }
+  if (!effective.managedKeyId) return;
+
+  if (await legacyInstallationHasRows()) {
+    effective = enableLegacyPlaceholderDecryption({
+      session: String(config.sessionSecret) === SESSION_SECRET_PLACEHOLDER,
+      encryption: String(config.security.encryptionSecret) === ENCRYPTION_SECRET_PLACEHOLDER,
+    });
+  }
+
+  const marker: DatabaseMarker = {
+    version: MARKER_VERSION,
+    keyId: effective.managedKeyId!,
+  };
+  try {
+    await repo.insert({
+      key: INSTANCE_SECRETS_DB_MARKER_KEY,
+      value: JSON.stringify(marker),
+    });
+  } catch (error) {
+    const winner = await repo.findOneBy({ key: INSTANCE_SECRETS_DB_MARKER_KEY });
+    if (!winner) throw error;
+    assertMarkerMatches(parseMarker(winner.value), effective.managedKeyId);
+  }
+}

--- a/App/server/services/integrations.ts
+++ b/App/server/services/integrations.ts
@@ -118,7 +118,7 @@ export function decryptConnectionConfig(c: IntegrationConnection): IntegrationCo
     // fall through
   }
   throw new Error(
-    "Integration config is corrupted or was encrypted with a different sessionSecret.",
+    "Integration config is corrupted or was encrypted with a different encryption key.",
   );
 }
 

--- a/App/server/services/memberToolAuthority.test.ts
+++ b/App/server/services/memberToolAuthority.test.ts
@@ -28,6 +28,9 @@ describe("interactive Member tool policy", () => {
       "send_chat_attachment",
       "run_explore_query",
       "create_chart",
+      "list_vault_items",
+      "create_vault_login",
+      "update_vault_login",
     ]) {
       assert.equal(memberToolPolicy(tool), "admin", tool);
     }

--- a/App/server/services/memberToolAuthority.ts
+++ b/App/server/services/memberToolAuthority.ts
@@ -221,6 +221,13 @@ const ADMIN_TOOLS = [
   "add_memory",
   "update_memory",
   "delete_memory",
+  // Vault tools act with an AI Employee's item Grants. Until the delegated
+  // Member's per-item View/Edit access is intersected in every handler, keep
+  // interactive use owner/admin-only so a Member cannot borrow broader AI
+  // access from chat. Routine Runs still use the EmployeeVaultGrant directly.
+  "list_vault_items",
+  "create_vault_login",
+  "update_vault_login",
   // Code workspaces, raw data-source access, and generated files have no
   // Member-level Grant model. Their human management surfaces are privileged.
   "list_code_repositories",

--- a/App/server/services/paths.ts
+++ b/App/server/services/paths.ts
@@ -9,9 +9,10 @@ import { config } from "../../config.js";
  * (API keys / custom-endpoint URLs) live encrypted in `AIModel.configJson`.
  * There are no per-provider credential dirs any more — the agent talks to model
  * APIs in-process. What remains on disk under
- * `data/companies/<co>/employees/<emp>/` is the employee's working directory:
- * materialized git repos, chat/tool artifacts, and the browser storage-state
- * snapshot.
+ * `data/companies/<co>/employees/<emp>/` is the employee's model-visible
+ * working directory: materialized git repos and chat/tool artifacts. Browser
+ * storage state is App-private under `data/.private/browser-state/` so neither
+ * host file tools nor bubblewrapped bash can read authenticated cookies.
  */
 
 export function dataRoot(): string {
@@ -38,9 +39,24 @@ export function ensureDir(p: string): void {
  * employee — concurrent sessions of the same employee race on save and
  * last-writer-wins, which is fine for "is the user logged in" state.
  */
-export function employeeBrowserStateFile(
-  companySlug: string,
-  employeeSlug: string,
-): string {
+export function employeeBrowserStateFile(companyId: string, employeeId: string): string {
+  return path.join(browserPrivateCompanyDir(companyId), `${employeeId}.json`);
+}
+
+export function browserPrivateCompanyDir(companyId: string): string {
+  return path.join(dataRoot(), ".private", "browser-state", companyId);
+}
+
+/** App-private SSH host-key cache for server-owned repository operations. */
+export function codeRepoPrivateCompanyDir(companyId: string): string {
+  return path.join(dataRoot(), ".private", "code-repository-ssh", companyId);
+}
+
+export function employeeCodeRepoKnownHostsFile(companyId: string, employeeId: string): string {
+  return path.join(codeRepoPrivateCompanyDir(companyId), `${employeeId}.known_hosts`);
+}
+
+/** Pre-1.94 location, used only for one-way secure migration and cleanup. */
+export function legacyEmployeeBrowserStateFile(companySlug: string, employeeSlug: string): string {
   return path.join(employeeDir(companySlug, employeeSlug), ".browser-state.json");
 }

--- a/App/server/services/realtime.ts
+++ b/App/server/services/realtime.ts
@@ -116,8 +116,22 @@ const sockets = new Set<ConnectedSocket>();
 /** userId → count of open sockets, scoped per company, for presence tracking. */
 const presenceCounts = new Map<string, Map<string, number>>();
 
-/** token → { userId, companyId, expiresAt } for short-lived WS upgrade auth. */
-type TokenRecord = { userId: string; companyId: string; expiresAt: number };
+/** Purpose-bound records for short-lived, single-use WS upgrade auth. */
+type WorkspaceTokenRecord = {
+  audience: "workspace";
+  userId: string;
+  companyId: string;
+  expiresAt: number;
+};
+type BrowserViewerTokenRecord = {
+  audience: "browser-viewer";
+  userId: string;
+  companyId: string;
+  employeeId: string;
+  sessionId: string;
+  expiresAt: number;
+};
+type TokenRecord = WorkspaceTokenRecord | BrowserViewerTokenRecord;
 const WS_TOKEN_TTL_MS = 60_000;
 const REALTIME_EVENT_TTL_MS = 5 * 60_000;
 const REALTIME_CHANNEL = "genosyn_realtime";
@@ -130,10 +144,31 @@ export function mintWsToken(userId: string, companyId: string): Promise<string> 
   return createAuthFlowState(
     "websocket",
     {
+      audience: "workspace",
       userId,
       companyId,
       expiresAt: Date.now() + WS_TOKEN_TTL_MS,
-    } satisfies TokenRecord,
+    } satisfies WorkspaceTokenRecord,
+    WS_TOKEN_TTL_MS,
+  );
+}
+
+export function mintBrowserViewerWsToken(
+  userId: string,
+  companyId: string,
+  employeeId: string,
+  sessionId: string,
+): Promise<string> {
+  return createAuthFlowState(
+    "websocket",
+    {
+      audience: "browser-viewer",
+      userId,
+      companyId,
+      employeeId,
+      sessionId,
+      expiresAt: Date.now() + WS_TOKEN_TTL_MS,
+    } satisfies BrowserViewerTokenRecord,
     WS_TOKEN_TTL_MS,
   );
 }
@@ -317,6 +352,14 @@ async function userHasMembership(userId: string, companyId: string): Promise<boo
   return m !== null;
 }
 
+async function userCanViewBrowserSession(userId: string, companyId: string): Promise<boolean> {
+  const membership = await AppDataSource.getRepository(Membership).findOneBy({
+    userId,
+    companyId,
+  });
+  return membership?.role === "owner" || membership?.role === "admin";
+}
+
 /**
  * Attach the WebSocket server to an HTTP server. Called once during boot
  * from server/index.ts so the HTTP and WS surfaces share a port (the Vite
@@ -377,12 +420,17 @@ export function attachRealtime(httpServer: HttpServer): WebSocketServer {
           socket.destroy();
           return;
         }
-        if (rec.companyId !== viewerMatch.cid) {
+        if (
+          rec.audience !== "browser-viewer" ||
+          rec.companyId !== viewerMatch.cid ||
+          rec.employeeId !== viewerMatch.eid ||
+          rec.sessionId !== viewerMatch.sid
+        ) {
           socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
           socket.destroy();
           return;
         }
-        const ok = await userHasMembership(rec.userId, rec.companyId);
+        const ok = await userCanViewBrowserSession(rec.userId, rec.companyId);
         if (!ok) {
           socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
           socket.destroy();
@@ -404,6 +452,8 @@ export function attachRealtime(httpServer: HttpServer): WebSocketServer {
         browserWss.handleUpgrade(req, socket, head, (ws) => {
           attachViewerSocket({
             sessionId: row.id,
+            companyId: row.companyId,
+            employeeId: row.employeeId,
             ws,
             userId: rec.userId,
           });
@@ -426,6 +476,11 @@ export function attachRealtime(httpServer: HttpServer): WebSocketServer {
       const rec = await consumeWsToken(token);
       if (!rec) {
         socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      if (rec.audience !== "workspace") {
+        socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
         socket.destroy();
         return;
       }

--- a/App/server/services/repoSync.ts
+++ b/App/server/services/repoSync.ts
@@ -11,7 +11,7 @@ import {
 import { readGithubRepos, resolveGithubCredentials } from "../integrations/providers/github.js";
 import {
   assertSafeCredentialToken,
-  configureEnvCredentialHelper,
+  clearEnvCredentialHelper,
   inlineEnvCredentialHelper,
 } from "./gitCredentialHelper.js";
 import { runWorkspaceGit } from "./workspaceGit.js";
@@ -23,7 +23,7 @@ import { cloneWorkspaceGitRemote, fetchWorkspaceGitRemote } from "./workspaceGit
  * before each chat / routine spawn.
  *
  * Engineering AI employees are *editor-shaped*, not API-shaped — they need a
- * working tree to read, edit, branch, commit, and push. Calling the github
+ * working tree to read, edit, branch, and commit. Calling the github
  * REST API for every operation is the wrong primitive for that workload, so
  * the runner's pre-spawn step now drops a real `git clone` of each repo into
  * `<employeeDir>/repos/<owner>/<name>/` and leaves it there. The agent uses
@@ -43,11 +43,10 @@ import { cloneWorkspaceGitRemote, fetchWorkspaceGitRemote } from "./workspaceGit
  * pushed but didn't merge). The agent is in charge of its own working tree;
  * we keep `origin/*` refs fresh and stay out of the way.
  *
- * **Credential helper.** Each cloned repo gets an inline, repository-local
- * credential helper that prints the token from a per-connection env var
- * (`GENOSYN_GH_TOKEN_<sanitized-connId>`). The runner sets that env var for
- * the turn so `git push` Just Works, then the env var disappears with the
- * turn and does not leak to other employees.
+ * **Credentials.** Clone/fetch runs in a server-owned temporary Git workspace.
+ * The Connection token never enters the employee checkout or model tool
+ * environment. Authenticated pushes therefore need a future governed server
+ * action instead of exposing a reusable account credential to model code.
  */
 
 export type SyncedRepo = {
@@ -77,8 +76,8 @@ export type RepoSyncError = {
 };
 
 export type RepoSyncResult = {
-  /** Env vars to merge into the spawn so the agent's `git push` finds the
-   * matching token. Keys: `GENOSYN_GH_TOKEN_<sanitized-connId>`. */
+  /** Reserved compatibility field. Repository credentials are never exported
+   * to the model tool environment, so this is always empty. */
   extraEnv: Record<string, string>;
   /** Repos successfully cloned or fetched this round. */
   repos: SyncedRepo[];
@@ -197,8 +196,6 @@ async function syncConnection(
     return;
   }
 
-  result.extraEnv[envKey] = creds.accessToken;
-
   for (const repo of repos) {
     result.githubRepoCredentials.push({
       connectionId: connection.id,
@@ -262,12 +259,7 @@ async function syncOneRepo(args: {
       cwd: args.repoPath,
       args: ["remote", "set-url", "origin", cleanRemote],
     });
-    await configureCredentialHelper(args.workspaceRoot, args.repoPath, args.envKey, cleanRemote);
   } else {
-    // Older/manual checkouts may not have a helper yet. Install it before the
-    // first authenticated fetch, and make its turn token available to this
-    // server-side git process as well as the later employee bash process.
-    await configureCredentialHelper(args.workspaceRoot, args.repoPath, args.envKey, cleanRemote);
     await runWorkspaceGit({
       workspaceRoot: args.workspaceRoot,
       cwd: args.repoPath,
@@ -283,23 +275,26 @@ async function syncOneRepo(args: {
       credentialHelper,
     });
   }
+
+  // A checkout is model-writable. Remove every reusable credential seam after
+  // the short-lived server fetch, including helpers left by an older release.
+  await clearEnvCredentialHelper((gitArgs) =>
+    runWorkspaceGit({
+      workspaceRoot: args.workspaceRoot,
+      cwd: args.repoPath,
+      args: gitArgs,
+    }),
+  );
+  await runWorkspaceGit({
+    workspaceRoot: args.workspaceRoot,
+    cwd: args.repoPath,
+    args: ["config", "--local", "--unset", "core.sshCommand"],
+  }).catch(() => {});
+  await runWorkspaceGit({
+    workspaceRoot: args.workspaceRoot,
+    cwd: args.repoPath,
+    args: ["remote", "set-url", "--push", "origin", NO_PUSH_URL],
+  });
 }
 
-async function configureCredentialHelper(
-  workspaceRoot: string,
-  repoPath: string,
-  envKey: string,
-  remoteUrl: string,
-): Promise<void> {
-  await configureEnvCredentialHelper(
-    (gitArgs) =>
-      runWorkspaceGit({
-        workspaceRoot,
-        cwd: repoPath,
-        args: gitArgs,
-      }),
-    "x-access-token",
-    envKey,
-    remoteUrl,
-  );
-}
+const NO_PUSH_URL = "DISABLED-server-held-credentials.invalid";

--- a/App/server/services/resourceEvents.ts
+++ b/App/server/services/resourceEvents.ts
@@ -23,13 +23,10 @@
  */
 
 /** Delivers one coalesced change to every socket in the company room. */
-export type ResourceChangeSink = (
-  companyId: string,
-  kind: string,
-  scopeIds: string[],
-) => void;
+export type ResourceChangeSink = (companyId: string, kind: string, scopeIds: string[]) => void;
 
 let sink: ResourceChangeSink | null = null;
+let membershipAuthorizationChangeSink: ((companyId: string) => void) | null = null;
 
 /** companyId → kind → set of parent scope ids touched (may be empty). */
 const pending = new Map<string, Map<string, Set<string>>>();
@@ -48,6 +45,15 @@ export function registerResourceChangeSink(fn: ResourceChangeSink): void {
   sink = fn;
 }
 
+/** Browser viewers are privileged; any Membership mutation revokes live viewers immediately. */
+export function registerMembershipAuthorizationChangeSink(fn: (companyId: string) => void): void {
+  membershipAuthorizationChangeSink = fn;
+}
+
+export function emitMembershipAuthorizationChange(companyId: string): void {
+  membershipAuthorizationChangeSink?.(companyId);
+}
+
 /** True once the socket layer has wired its sink; the subscriber checks this. */
 export function resourceEventsActive(): boolean {
   return sink !== null;
@@ -60,11 +66,7 @@ export function resourceEventsActive(): boolean {
  * call from any write path; cheap and synchronous — the actual broadcast is
  * debounced onto {@link FLUSH_MS}.
  */
-export function emitResourceChange(
-  companyId: string,
-  kind: string,
-  scopeId?: string,
-): void {
+export function emitResourceChange(companyId: string, kind: string, scopeId?: string): void {
   if (!sink) return;
   let byKind = pending.get(companyId);
   if (!byKind) {

--- a/App/server/services/revenue/unsubscribeToken.ts
+++ b/App/server/services/revenue/unsubscribeToken.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 
-import { config } from "../../../config.js";
 import { normalizeEmail } from "../../lib/emailAddress.js";
+import { getEffectiveInstanceSecrets, isStrongInstanceSecret } from "../../lib/instanceSecrets.js";
 
 /**
  * Signed unsubscribe links.
@@ -65,10 +65,7 @@ export function deriveUnsubscribeSecret(encryptionSecret: string): string {
  * Throws on an unusable address: a link we cannot resolve back to a mailbox is
  * worse than no link, because the recipient clicks it and nothing happens.
  */
-export function signUnsubscribeToken(
-  payload: UnsubscribePayload,
-  secret: string,
-): string {
+export function signUnsubscribeToken(payload: UnsubscribePayload, secret: string): string {
   const email = normalizeEmail(payload.email);
   if (!email) throw new Error("signUnsubscribeToken: unusable email address");
   if (!payload.companyId) throw new Error("signUnsubscribeToken: companyId required");
@@ -175,5 +172,12 @@ export function unsubscribeUrl(publicUrl: string, token: string): string {
  * would then have to reset.
  */
 export function unsubscribeSecret(): string {
-  return deriveUnsubscribeSecret(config.security.encryptionSecret);
+  return deriveUnsubscribeSecret(getEffectiveInstanceSecrets().encryptionSecret);
+}
+
+/** Current signing key plus every read-only encryption-key fallback. */
+export function unsubscribeSecrets(): readonly string[] {
+  return getEffectiveInstanceSecrets()
+    .encryptionDecryptionSecrets.filter(isStrongInstanceSecret)
+    .map(deriveUnsubscribeSecret);
 }

--- a/App/server/services/runner.ts
+++ b/App/server/services/runner.ts
@@ -340,9 +340,9 @@ export async function startRoutineRun(
       const cwd = employeeDir(co.slug, emp.slug);
       ensureDir(cwd);
 
-      // Env for the bash tool: company vault secrets plus whatever the repo
-      // materializers export. Secrets are validated + reserved-name filtered
-      // by loadCompanySecretsEnv, so this can't clobber anything load-bearing.
+      // Env for the coding runtime: Environment secrets only. Repository
+      // credentials stay inside short-lived server-owned Git operations and
+      // are never exported to model tools.
       const toolEnv: Record<string, string> = {};
       if (!config.security.multiTenant) {
         try {
@@ -356,7 +356,6 @@ export async function startRoutineRun(
         // Materialize granted GitHub Connection repos + provider-agnostic Code
         // Repositories into the employee's cwd. Errors are non-fatal.
         const repoSync = await materializeReposForEmployee({ employeeId: emp.id, cwd });
-        Object.assign(toolEnv, repoSync.extraEnv);
         for (const r of repoSync.repos) {
           log.line(`[repos] synced ${r.owner}/${r.name}@${r.defaultBranch}`);
         }
@@ -367,7 +366,6 @@ export async function startRoutineRun(
           cwd,
           githubRepoCredentials: repoSync.githubRepoCredentials,
         });
-        Object.assign(toolEnv, codeRepoSync.extraEnv);
         for (const r of codeRepoSync.repos) {
           log.line(`[code-repos] synced ${r.slug}@${r.defaultBranch} (${r.accessLevel})`);
         }

--- a/App/server/services/runtimeSecurity.test.ts
+++ b/App/server/services/runtimeSecurity.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test, { afterEach, beforeEach } from "node:test";
 import { config } from "../../config.js";
+import { resetInstanceSecretsCacheForTests } from "../lib/instanceSecrets.js";
 import { secureSessionCookies, validateRuntimeSecurity } from "./runtimeSecurity.js";
 
 type MutableConfig = {
+  dataDir: string;
   agent: {
     browserEnabledInMultiTenant: boolean;
     codingTools: {
@@ -16,6 +21,7 @@ type MutableConfig = {
   db: {
     driver: "sqlite" | "postgres";
     postgresUrl: string;
+    sqlitePath: string;
   };
   security: {
     bootstrapMasterAdminEmail: string;
@@ -31,12 +37,18 @@ type MutableConfig = {
 
 const mutable = config as unknown as MutableConfig;
 let original: MutableConfig;
+let tempDir = "";
 
 beforeEach(() => {
   original = structuredClone(mutable);
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-runtime-security-"));
+  mutable.dataDir = tempDir;
+  mutable.db.sqlitePath = path.join(tempDir, "app.sqlite");
+  resetInstanceSecretsCacheForTests();
 });
 
 afterEach(() => {
+  mutable.dataDir = original.dataDir;
   mutable.agent.browserEnabledInMultiTenant = original.agent.browserEnabledInMultiTenant;
   mutable.agent.codingTools.allowNetwork = original.agent.codingTools.allowNetwork;
   mutable.agent.codingTools.allowUnsafeHostExecution =
@@ -45,6 +57,7 @@ afterEach(() => {
   mutable.agent.maxConcurrentRunsPerCompany = original.agent.maxConcurrentRunsPerCompany;
   mutable.db.driver = original.db.driver;
   mutable.db.postgresUrl = original.db.postgresUrl;
+  mutable.db.sqlitePath = original.db.sqlitePath;
   mutable.security.bootstrapMasterAdminEmail = original.security.bootstrapMasterAdminEmail;
   mutable.security.encryptionSecret = original.security.encryptionSecret;
   mutable.security.multiTenant = original.security.multiTenant;
@@ -53,6 +66,8 @@ afterEach(() => {
   mutable.security.sessionMaxAgeDays = original.security.sessionMaxAgeDays;
   mutable.security.trustedProxyHops = original.security.trustedProxyHops;
   mutable.sessionSecret = original.sessionSecret;
+  resetInstanceSecretsCacheForTests();
+  fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
 test("explicit cookie settings override automatic detection", () => {
@@ -92,6 +107,13 @@ test("self-hosted defaults remain bootable", () => {
   assert.equal(config.agent.codingTools.executionMode, "disabled");
   assert.equal(config.agent.codingTools.allowUnsafeHostExecution, false);
   assert.equal(config.agent.codingTools.allowNetwork, false);
+});
+
+test("self-hosted explicit weak secrets fail instead of bypassing managed defaults", () => {
+  mutable.security.multiTenant = false;
+  mutable.sessionSecret = "explicit-but-short";
+  mutable.security.encryptionSecret = "also-explicit-but-short";
+  assert.throws(validateRuntimeSecurity, /Unsafe self-hosted secret configuration/);
 });
 
 test("unsafe shared hosting reports every actionable boundary at once", () => {

--- a/App/server/services/runtimeSecurity.ts
+++ b/App/server/services/runtimeSecurity.ts
@@ -6,12 +6,7 @@ import { spawnSync } from "node:child_process";
 import { getEffectiveGlobalSmtp } from "./globalEmailTransport.js";
 import { getPublicUrl, isPublicUrlConfigured } from "./publicUrl.js";
 import { buildBubblewrapCommandArgs } from "./agent/bubblewrap.js";
-
-const PLACEHOLDERS = new Set(["change-me-in-production", "change-me-in-production-too"]);
-
-function strongSecret(value: string): boolean {
-  return value.length >= 32 && !PLACEHOLDERS.has(value);
-}
+import { getEffectiveInstanceSecrets, isStrongInstanceSecret } from "../lib/instanceSecrets.js";
 
 let bubblewrapProbeCache: { path: string; error: string | null } | null = null;
 
@@ -61,8 +56,9 @@ export function secureSessionCookies(): boolean {
 
 /**
  * Fail closed when an operator opts into shared multi-tenancy without the
- * boundaries Genosyn relies on. Self-hosted mode remains backwards-compatible,
- * but prints actionable warnings for weak production settings.
+ * boundaries Genosyn relies on. Self-hosted placeholders resolve to managed
+ * per-install secrets; an explicitly configured weak secret fails closed.
+ * Other relaxed self-host settings still produce actionable warnings.
  */
 export function validateRuntimeSecurity(): void {
   if (!Number.isInteger(config.security.trustedProxyHops) || config.security.trustedProxyHops < 0) {
@@ -76,20 +72,29 @@ export function validateRuntimeSecurity(): void {
   }
 
   const problems: string[] = [];
+  const effectiveSecrets = config.security.multiTenant ? null : getEffectiveInstanceSecrets();
+  const sessionSecret = config.security.multiTenant
+    ? String(config.sessionSecret)
+    : effectiveSecrets!.sessionSecret;
+  const encryptionSecret = config.security.multiTenant
+    ? String(config.security.encryptionSecret)
+    : effectiveSecrets!.encryptionSecret;
+  const secretProblems: string[] = [];
   if (config.db.driver !== "postgres") problems.push("config.db.driver must be postgres");
   if (!config.db.postgresUrl.trim()) problems.push("config.db.postgresUrl is required");
   if (!secureSessionCookies()) problems.push("Secure session cookies must be enabled");
-  if (!strongSecret(config.sessionSecret)) {
-    problems.push("config.sessionSecret must be a unique secret of at least 32 characters");
+  if (!isStrongInstanceSecret(sessionSecret)) {
+    secretProblems.push("config.sessionSecret must be a unique secret of at least 32 characters");
   }
-  if (!strongSecret(config.security.encryptionSecret)) {
-    problems.push(
+  if (!isStrongInstanceSecret(encryptionSecret)) {
+    secretProblems.push(
       "config.security.encryptionSecret must be a unique secret of at least 32 characters",
     );
   }
-  if (String(config.security.encryptionSecret) === String(config.sessionSecret)) {
-    problems.push("the session and encryption secrets must be different");
+  if (encryptionSecret === sessionSecret) {
+    secretProblems.push("the session and encryption secrets must be different");
   }
+  problems.push(...secretProblems);
   if (config.agent.codingTools.executionMode !== "bubblewrap") {
     problems.push("config.agent.codingTools.executionMode must be bubblewrap");
   }
@@ -124,6 +129,10 @@ export function validateRuntimeSecurity(): void {
 
   if (config.security.multiTenant && problems.length > 0) {
     throw new Error(`Unsafe multi-tenant configuration:\n- ${problems.join("\n- ")}`);
+  }
+
+  if (!config.security.multiTenant && secretProblems.length > 0) {
+    throw new Error(`Unsafe self-hosted secret configuration:\n- ${secretProblems.join("\n- ")}`);
   }
 
   if (process.env.NODE_ENV === "production" && !config.security.multiTenant) {

--- a/App/server/services/ssoSettings.ts
+++ b/App/server/services/ssoSettings.ts
@@ -143,7 +143,7 @@ function decryptStoredSecret(encrypted: string): string {
     // the admin page reports "not configured" instead of the handshake 500ing.
     // eslint-disable-next-line no-console
     console.warn(
-      "[sso] could not decrypt the stored SSO client secret (was sessionSecret rotated?) — SSO is unavailable until it is re-entered",
+      "[sso] could not decrypt the stored SSO client secret (was the encryption key rotated?) — SSO is unavailable until it is re-entered",
     );
     return "";
   }

--- a/App/server/services/userDelete.ts
+++ b/App/server/services/userDelete.ts
@@ -51,6 +51,9 @@ import { TodoComment } from "../db/entities/TodoComment.js";
 import { User } from "../db/entities/User.js";
 import { Vendor } from "../db/entities/Vendor.js";
 import { WebAuthnCredential } from "../db/entities/WebAuthnCredential.js";
+import { VaultItem } from "../db/entities/VaultItem.js";
+import { VaultItemMemberAccess } from "../db/entities/VaultItemMemberAccess.js";
+import { emitMembershipAuthorizationChange } from "./resourceEvents.js";
 
 /** A company the to-be-deleted user is the registered owner of. */
 export interface OwnedCompany {
@@ -109,12 +112,16 @@ export async function findOwnedCompanies(userId: string): Promise<OwnedCompany[]
  * new entity gains a user-reference column, add a line here (DELETE if it is
  * account-scoped, NULL if it is authorship) so the reference can't dangle.
  */
-export async function deleteUserCascade(args: {
-  userId: string;
-}): Promise<DeleteUserResult> {
+export async function deleteUserCascade(args: { userId: string }): Promise<DeleteUserResult> {
   const { userId } = args;
+  const membershipCompanyIds = (
+    await AppDataSource.getRepository(Membership).find({
+      where: { userId },
+      select: ["companyId"],
+    })
+  ).map((membership) => membership.companyId);
 
-  return AppDataSource.transaction(async (m) => {
+  const result = await AppDataSource.transaction(async (m) => {
     // ── Guard: never orphan a company ──────────────────────────────────
     const owned = await m.find(Company, {
       where: { ownerId: userId },
@@ -136,6 +143,7 @@ export async function deleteUserCascade(args: {
     // still count toward the "last human with write" quorum in
     // `services/projects.ts`, locking the project for everyone left.
     await m.delete(ProjectMember, { userId });
+    await m.delete(VaultItemMemberAccess, { userId });
 
     // ── 2. Authored content — preserve the row, unlink the author ──────
     await m.update(AIEmployee, { reportsToUserId: userId }, { reportsToUserId: null });
@@ -158,6 +166,7 @@ export async function deleteUserCascade(args: {
     await m.update(EmployeeMemory, { authorUserId: userId }, { authorUserId: null });
     await m.update(JournalEntry, { authorUserId: userId }, { authorUserId: null });
     await m.update(TodoComment, { authorUserId: userId }, { authorUserId: null });
+    await m.update(VaultItem, { createdByUserId: userId }, { createdByUserId: null });
 
     await m.update(Todo, { assigneeUserId: userId }, { assigneeUserId: null });
     await m.update(Todo, { reviewerUserId: userId }, { reviewerUserId: null });
@@ -179,16 +188,8 @@ export async function deleteUserCascade(args: {
     await m.update(Activity, { assignedUserId: userId }, { assignedUserId: null });
     await m.update(Partnership, { createdById: userId }, { createdById: null });
     await m.update(Partnership, { ownerId: userId }, { ownerId: null });
-    await m.update(
-      RevenueDocument,
-      { createdByUserId: userId },
-      { createdByUserId: null },
-    );
-    await m.update(
-      RevenueImportBatch,
-      { createdByUserId: userId },
-      { createdByUserId: null },
-    );
+    await m.update(RevenueDocument, { createdByUserId: userId }, { createdByUserId: null });
+    await m.update(RevenueImportBatch, { createdByUserId: userId }, { createdByUserId: null });
     await m.update(Dashboard, { createdById: userId }, { createdById: null });
     await m.update(Estimate, { createdById: userId }, { createdById: null });
     await m.update(Invoice, { createdById: userId }, { createdById: null });
@@ -210,4 +211,8 @@ export async function deleteUserCascade(args: {
 
     return { memberships, apiKeys, notifications, channelMembers, reactions };
   });
+  for (const companyId of membershipCompanyIds) {
+    emitMembershipAuthorizationChange(companyId);
+  }
+  return result;
 }

--- a/App/server/services/vault.ts
+++ b/App/server/services/vault.ts
@@ -1,0 +1,1026 @@
+import crypto from "node:crypto";
+import { In } from "typeorm";
+import { z } from "zod";
+
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import {
+  EMPLOYEE_VAULT_ACCESS_RANK,
+  EmployeeVaultGrant,
+  type EmployeeVaultAccessLevel,
+} from "../db/entities/EmployeeVaultGrant.js";
+import { Membership, type Role } from "../db/entities/Membership.js";
+import { User } from "../db/entities/User.js";
+import {
+  VaultItem,
+  type VaultItemType,
+  type VaultItemVisibility,
+} from "../db/entities/VaultItem.js";
+import {
+  VaultItemMemberAccess,
+  type VaultMemberAccessLevel,
+} from "../db/entities/VaultItemMemberAccess.js";
+import { decryptSecretWithStrongKeys, encryptSecret } from "../lib/secret.js";
+
+const vaultPayloadSchema = z
+  .object({
+    title: z.string(),
+    username: z.string(),
+    secret: z.string(),
+    websiteUrl: z.string(),
+    notes: z.string(),
+  })
+  .strict();
+
+export type VaultPayload = z.infer<typeof vaultPayloadSchema>;
+
+const VAULT_PASSWORD_CHARACTER_CLASSES = [
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  "abcdefghijklmnopqrstuvwxyz",
+  "0123456789",
+  "!@#$%^&*()-_=+[]{}:,.?",
+] as const;
+const VAULT_PASSWORD_ALPHABET = VAULT_PASSWORD_CHARACTER_CLASSES.join("");
+const DEFAULT_VAULT_PASSWORD_LENGTH = 24;
+
+export type VaultHumanActor = {
+  userId: string;
+  role: Role;
+};
+
+export type VaultItemView = {
+  id: string;
+  companyId: string;
+  type: VaultItemType;
+  visibility: VaultItemVisibility;
+  title: string;
+  username: string;
+  websiteUrl: string;
+  notes: string;
+  version: number;
+  createdByUserId: string | null;
+  createdByEmployeeId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  effectiveAccessLevel: VaultMemberAccessLevel;
+  canEdit: boolean;
+  canShare: boolean;
+  canDelete: boolean;
+  canReveal: boolean;
+};
+
+export type VaultMemberAccessView = {
+  id: string;
+  vaultItemId: string;
+  userId: string;
+  accessLevel: VaultMemberAccessLevel;
+  createdAt: Date;
+  updatedAt: Date;
+  member: {
+    id: string;
+    name: string;
+    email: string;
+    role: Role;
+  };
+};
+
+export type VaultMemberAccessCandidate = {
+  id: string;
+  name: string;
+  email: string;
+  role: Role;
+  isCreator: boolean;
+  access: {
+    id: string;
+    accessLevel: VaultMemberAccessLevel;
+  } | null;
+};
+
+export type EmployeeVaultGrantView = {
+  id: string;
+  vaultItemId: string;
+  employeeId: string;
+  accessLevel: EmployeeVaultAccessLevel;
+  createdAt: Date;
+  updatedAt: Date;
+  employee: {
+    id: string;
+    name: string;
+    slug: string;
+    role: string;
+  };
+};
+
+export type EmployeeVaultGrantCandidate = {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  grant: {
+    id: string;
+    accessLevel: EmployeeVaultAccessLevel;
+  } | null;
+};
+
+export class VaultError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "VaultError";
+  }
+}
+
+/**
+ * Generate a cryptographically random password with every standard character
+ * class represented. The length bounds keep generated credentials compatible
+ * with ordinary password fields while still providing ample entropy.
+ */
+export function generateVaultPassword(length = DEFAULT_VAULT_PASSWORD_LENGTH): string {
+  if (!Number.isInteger(length) || length < 16 || length > 128) {
+    throw new VaultError("Password length must be an integer from 16 to 128", 400);
+  }
+
+  const characters = VAULT_PASSWORD_CHARACTER_CLASSES.map(
+    (characterClass) => characterClass[crypto.randomInt(characterClass.length)],
+  );
+  while (characters.length < length) {
+    characters.push(VAULT_PASSWORD_ALPHABET[crypto.randomInt(VAULT_PASSWORD_ALPHABET.length)]);
+  }
+  // Fisher-Yates with crypto.randomInt avoids modulo bias and prevents the
+  // guaranteed character-class positions from being predictable.
+  for (let index = characters.length - 1; index > 0; index -= 1) {
+    const swapIndex = crypto.randomInt(index + 1);
+    [characters[index], characters[swapIndex]] = [characters[swapIndex], characters[index]];
+  }
+  return characters.join("");
+}
+
+function encryptionScope(companyId: string): string {
+  return `company:${companyId}:vault`;
+}
+
+function normalizeVaultWebsiteUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  try {
+    const website = new URL(trimmed);
+    if (website.protocol !== "http:" && website.protocol !== "https:") throw new Error();
+    if (website.username || website.password) throw new Error();
+    return website.toString();
+  } catch {
+    throw new VaultError(
+      "Website URL must be an absolute http(s) URL without embedded credentials",
+      400,
+    );
+  }
+}
+
+function decryptPayload(row: VaultItem): VaultPayload {
+  try {
+    const ciphertextParts = row.encryptedPayload.split(".");
+    const storedScope =
+      ciphertextParts.length === 5 && ciphertextParts[0] === "v2"
+        ? Buffer.from(ciphertextParts[1], "base64url").toString("utf8")
+        : "";
+    if (storedScope !== encryptionScope(row.companyId)) {
+      throw new Error("ciphertext scope does not match item company");
+    }
+    const decoded = JSON.parse(decryptSecretWithStrongKeys(row.encryptedPayload)) as unknown;
+    const parsed = vaultPayloadSchema.safeParse(decoded);
+    if (!parsed.success) throw new Error("invalid payload shape");
+    return parsed.data;
+  } catch {
+    throw new VaultError("This Vault item could not be decrypted", 500);
+  }
+}
+
+function encryptPayload(companyId: string, payload: VaultPayload): string {
+  return encryptSecret(JSON.stringify(payload), encryptionScope(companyId));
+}
+
+function isHumanManager(row: VaultItem, actor: VaultHumanActor): boolean {
+  return actor.role === "owner" || actor.role === "admin" || row.createdByUserId === actor.userId;
+}
+
+function effectiveHumanAccess(
+  row: VaultItem,
+  actor: VaultHumanActor,
+  explicitAccess: VaultMemberAccessLevel | null,
+): VaultMemberAccessLevel | null {
+  if (isHumanManager(row, actor)) return "edit";
+  if (explicitAccess === "edit") return "edit";
+  if (row.visibility === "company" || explicitAccess === "view") return "view";
+  return null;
+}
+
+function toView(
+  row: VaultItem,
+  payload: VaultPayload,
+  actor: VaultHumanActor,
+  explicitAccess: VaultMemberAccessLevel | null,
+): VaultItemView {
+  const effectiveAccessLevel = effectiveHumanAccess(row, actor, explicitAccess);
+  if (!effectiveAccessLevel) throw new VaultError("Vault item not found", 404);
+  const manager = isHumanManager(row, actor);
+  return {
+    id: row.id,
+    companyId: row.companyId,
+    type: row.type,
+    visibility: row.visibility,
+    title: payload.title,
+    username: payload.username,
+    websiteUrl: payload.websiteUrl,
+    notes: payload.notes,
+    version: row.version,
+    createdByUserId: row.createdByUserId,
+    createdByEmployeeId: row.createdByEmployeeId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    effectiveAccessLevel,
+    canEdit: effectiveAccessLevel === "edit",
+    canShare: manager,
+    canDelete: manager,
+    canReveal: true,
+  };
+}
+
+async function loadHumanAccess(
+  companyId: string,
+  itemId: string,
+  userId: string,
+): Promise<VaultItemMemberAccess | null> {
+  return AppDataSource.getRepository(VaultItemMemberAccess).findOneBy({
+    companyId,
+    vaultItemId: itemId,
+    userId,
+  });
+}
+
+async function loadItem(companyId: string, itemId: string): Promise<VaultItem> {
+  const row = await AppDataSource.getRepository(VaultItem).findOneBy({
+    id: itemId,
+    companyId,
+  });
+  if (!row) throw new VaultError("Vault item not found", 404);
+  return row;
+}
+
+async function loadAccessibleItem(
+  companyId: string,
+  itemId: string,
+  actor: VaultHumanActor,
+): Promise<{
+  row: VaultItem;
+  payload: VaultPayload;
+  explicitAccess: VaultMemberAccessLevel | null;
+  view: VaultItemView;
+}> {
+  const row = await loadItem(companyId, itemId);
+  const access = await loadHumanAccess(companyId, itemId, actor.userId);
+  const explicitAccess = access?.accessLevel ?? null;
+  if (!effectiveHumanAccess(row, actor, explicitAccess)) {
+    throw new VaultError("Vault item not found", 404);
+  }
+  const payload = decryptPayload(row);
+  return { row, payload, explicitAccess, view: toView(row, payload, actor, explicitAccess) };
+}
+
+async function loadManagedItem(
+  companyId: string,
+  itemId: string,
+  actor: VaultHumanActor,
+): Promise<{ row: VaultItem; payload: VaultPayload }> {
+  const row = await loadItem(companyId, itemId);
+  if (!isHumanManager(row, actor)) {
+    throw new VaultError("Only the creator or a company admin can manage sharing", 403);
+  }
+  return { row, payload: decryptPayload(row) };
+}
+
+export async function listVaultItems(
+  companyId: string,
+  actor: VaultHumanActor,
+): Promise<VaultItemView[]> {
+  const rows = await AppDataSource.getRepository(VaultItem).find({
+    where: { companyId },
+    order: { updatedAt: "DESC", createdAt: "DESC" },
+  });
+  if (rows.length === 0) return [];
+
+  const accessRows = await AppDataSource.getRepository(VaultItemMemberAccess).find({
+    where: {
+      companyId,
+      userId: actor.userId,
+      vaultItemId: In(rows.map((row) => row.id)),
+    },
+  });
+  const accessByItem = new Map(accessRows.map((row) => [row.vaultItemId, row.accessLevel]));
+  const visible = rows.filter(
+    (row) => effectiveHumanAccess(row, actor, accessByItem.get(row.id) ?? null) !== null,
+  );
+  return visible.map((row) =>
+    toView(row, decryptPayload(row), actor, accessByItem.get(row.id) ?? null),
+  );
+}
+
+export async function getVaultItem(
+  companyId: string,
+  itemId: string,
+  actor: VaultHumanActor,
+): Promise<VaultItemView> {
+  return (await loadAccessibleItem(companyId, itemId, actor)).view;
+}
+
+export async function createVaultItem(args: {
+  companyId: string;
+  actor: VaultHumanActor;
+  type: VaultItemType;
+  visibility: VaultItemVisibility;
+  payload: VaultPayload;
+}): Promise<VaultItemView> {
+  const repo = AppDataSource.getRepository(VaultItem);
+  const payload = {
+    ...args.payload,
+    websiteUrl: normalizeVaultWebsiteUrl(args.payload.websiteUrl),
+  };
+  const row = repo.create({
+    companyId: args.companyId,
+    type: args.type,
+    visibility: args.visibility,
+    encryptedPayload: encryptPayload(args.companyId, payload),
+    createdByUserId: args.actor.userId,
+    createdByEmployeeId: null,
+  });
+  await repo.save(row);
+  return toView(row, payload, args.actor, null);
+}
+
+export async function updateVaultItem(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+  expectedVersion: number;
+  patch: Partial<VaultPayload> & {
+    type?: VaultItemType;
+    visibility?: VaultItemVisibility;
+  };
+}): Promise<{ before: VaultItemView; item: VaultItemView }> {
+  const loaded = await loadAccessibleItem(args.companyId, args.itemId, args.actor);
+  if (!loaded.view.canEdit) throw new VaultError("Edit access is required", 403);
+  if (loaded.row.version !== args.expectedVersion) {
+    throw new VaultError(
+      "This Vault item changed while you were editing it. Reload and retry.",
+      409,
+    );
+  }
+  if (args.patch.visibility !== undefined && !isHumanManager(loaded.row, args.actor)) {
+    throw new VaultError("Only the creator or a company admin can change visibility", 403);
+  }
+
+  const before = loaded.view;
+  const payload: VaultPayload = {
+    title: args.patch.title ?? loaded.payload.title,
+    username: args.patch.username ?? loaded.payload.username,
+    secret: args.patch.secret ?? loaded.payload.secret,
+    websiteUrl:
+      args.patch.websiteUrl === undefined
+        ? loaded.payload.websiteUrl
+        : normalizeVaultWebsiteUrl(args.patch.websiteUrl),
+    notes: args.patch.notes ?? loaded.payload.notes,
+  };
+  const repo = AppDataSource.getRepository(VaultItem);
+  const update = await repo.update(
+    {
+      id: loaded.row.id,
+      companyId: args.companyId,
+      version: args.expectedVersion,
+    },
+    {
+      type: args.patch.type ?? loaded.row.type,
+      visibility: args.patch.visibility ?? loaded.row.visibility,
+      encryptedPayload: encryptPayload(args.companyId, payload),
+      version: args.expectedVersion + 1,
+    },
+  );
+  if (update.affected !== 1) {
+    throw new VaultError(
+      "This Vault item changed while you were editing it. Reload and retry.",
+      409,
+    );
+  }
+  const saved = await loadItem(args.companyId, args.itemId);
+  return {
+    before,
+    item: toView(saved, payload, args.actor, loaded.explicitAccess),
+  };
+}
+
+export async function deleteVaultItem(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<{ id: string; title: string; type: VaultItemType }> {
+  const { row, payload } = await loadManagedItem(args.companyId, args.itemId, args.actor);
+  await AppDataSource.transaction(async (manager) => {
+    await manager.delete(VaultItemMemberAccess, {
+      companyId: args.companyId,
+      vaultItemId: row.id,
+    });
+    await manager.delete(EmployeeVaultGrant, {
+      companyId: args.companyId,
+      vaultItemId: row.id,
+    });
+    await manager.delete(VaultItem, { id: row.id, companyId: args.companyId });
+  });
+  return { id: row.id, title: payload.title, type: row.type };
+}
+
+export async function revealVaultItem(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<{ item: VaultItemView; secret: string }> {
+  const loaded = await loadAccessibleItem(args.companyId, args.itemId, args.actor);
+  return { item: loaded.view, secret: loaded.payload.secret };
+}
+
+export async function listVaultMemberAccess(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<VaultMemberAccessView[]> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const rows = await AppDataSource.getRepository(VaultItemMemberAccess).find({
+    where: { companyId: args.companyId, vaultItemId: args.itemId },
+    order: { createdAt: "ASC" },
+  });
+  if (rows.length === 0) return [];
+  const userIds = rows.map((row) => row.userId);
+  const [users, memberships] = await Promise.all([
+    AppDataSource.getRepository(User).find({ where: { id: In(userIds) } }),
+    AppDataSource.getRepository(Membership).find({
+      where: { companyId: args.companyId, userId: In(userIds) },
+    }),
+  ]);
+  const usersById = new Map(users.map((user) => [user.id, user]));
+  const membershipsByUser = new Map(memberships.map((row) => [row.userId, row]));
+  return rows.flatMap((row) => {
+    const user = usersById.get(row.userId);
+    const membership = membershipsByUser.get(row.userId);
+    if (!user || !membership) return [];
+    return [
+      {
+        id: row.id,
+        vaultItemId: row.vaultItemId,
+        userId: row.userId,
+        accessLevel: row.accessLevel,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        member: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: membership.role,
+        },
+      },
+    ];
+  });
+}
+
+export async function listVaultMemberAccessCandidates(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<VaultMemberAccessCandidate[]> {
+  const { row } = await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const memberships = await AppDataSource.getRepository(Membership).find({
+    where: { companyId: args.companyId },
+  });
+  if (memberships.length === 0) return [];
+  const [users, accessRows] = await Promise.all([
+    AppDataSource.getRepository(User).find({
+      where: { id: In(memberships.map((membership) => membership.userId)) },
+    }),
+    AppDataSource.getRepository(VaultItemMemberAccess).find({
+      where: { companyId: args.companyId, vaultItemId: args.itemId },
+    }),
+  ]);
+  const usersById = new Map(users.map((user) => [user.id, user]));
+  const accessByUser = new Map(accessRows.map((access) => [access.userId, access]));
+  return memberships
+    .flatMap((membership) => {
+      const user = usersById.get(membership.userId);
+      if (!user) return [];
+      const access = accessByUser.get(user.id);
+      return [
+        {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: membership.role,
+          isCreator: row.createdByUserId === user.id,
+          access: access ? { id: access.id, accessLevel: access.accessLevel } : null,
+        },
+      ];
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function assertCompanyMember(companyId: string, userId: string): Promise<void> {
+  const membership = await AppDataSource.getRepository(Membership).findOneBy({
+    companyId,
+    userId,
+  });
+  if (!membership) throw new VaultError("Member not found", 404);
+}
+
+export async function upsertVaultMemberAccess(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+  userId: string;
+  accessLevel: VaultMemberAccessLevel;
+}): Promise<VaultMemberAccessView> {
+  const { row } = await loadManagedItem(args.companyId, args.itemId, args.actor);
+  await assertCompanyMember(args.companyId, args.userId);
+  if (row.createdByUserId === args.userId) {
+    throw new VaultError("The creator already has full access", 400);
+  }
+  const repo = AppDataSource.getRepository(VaultItemMemberAccess);
+  let access = await repo.findOneBy({
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+    userId: args.userId,
+  });
+  if (access) {
+    access.accessLevel = args.accessLevel;
+  } else {
+    access = repo.create({
+      companyId: args.companyId,
+      vaultItemId: args.itemId,
+      userId: args.userId,
+      accessLevel: args.accessLevel,
+    });
+  }
+  await repo.save(access);
+  const rows = await listVaultMemberAccess(args);
+  const hydrated = rows.find((candidate) => candidate.id === access!.id);
+  if (!hydrated) throw new VaultError("Member not found", 404);
+  return hydrated;
+}
+
+export async function updateVaultMemberAccess(args: {
+  companyId: string;
+  itemId: string;
+  accessId: string;
+  actor: VaultHumanActor;
+  accessLevel: VaultMemberAccessLevel;
+}): Promise<VaultMemberAccessView> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const repo = AppDataSource.getRepository(VaultItemMemberAccess);
+  const row = await repo.findOneBy({
+    id: args.accessId,
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+  });
+  if (!row) throw new VaultError("Member access not found", 404);
+  row.accessLevel = args.accessLevel;
+  await repo.save(row);
+  const rows = await listVaultMemberAccess(args);
+  const hydrated = rows.find((candidate) => candidate.id === row.id);
+  if (!hydrated) throw new VaultError("Member not found", 404);
+  return hydrated;
+}
+
+export async function deleteVaultMemberAccess(args: {
+  companyId: string;
+  itemId: string;
+  accessId: string;
+  actor: VaultHumanActor;
+}): Promise<{ id: string; userId: string; accessLevel: VaultMemberAccessLevel }> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const repo = AppDataSource.getRepository(VaultItemMemberAccess);
+  const row = await repo.findOneBy({
+    id: args.accessId,
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+  });
+  if (!row) throw new VaultError("Member access not found", 404);
+  await repo.delete({ id: row.id });
+  return { id: row.id, userId: row.userId, accessLevel: row.accessLevel };
+}
+
+async function hydrateEmployeeGrants(
+  rows: EmployeeVaultGrant[],
+): Promise<EmployeeVaultGrantView[]> {
+  if (rows.length === 0) return [];
+  const employees = await AppDataSource.getRepository(AIEmployee).find({
+    where: { id: In(rows.map((row) => row.employeeId)) },
+  });
+  const byId = new Map(employees.map((employee) => [employee.id, employee]));
+  return rows.flatMap((row) => {
+    const employee = byId.get(row.employeeId);
+    if (!employee || employee.companyId !== row.companyId) return [];
+    return [
+      {
+        id: row.id,
+        vaultItemId: row.vaultItemId,
+        employeeId: row.employeeId,
+        accessLevel: row.accessLevel,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        employee: {
+          id: employee.id,
+          name: employee.name,
+          slug: employee.slug,
+          role: employee.role,
+        },
+      },
+    ];
+  });
+}
+
+export async function listEmployeeVaultGrants(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<EmployeeVaultGrantView[]> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const rows = await AppDataSource.getRepository(EmployeeVaultGrant).find({
+    where: { companyId: args.companyId, vaultItemId: args.itemId },
+    order: { createdAt: "ASC" },
+  });
+  return hydrateEmployeeGrants(rows);
+}
+
+export async function listEmployeeVaultGrantCandidates(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+}): Promise<EmployeeVaultGrantCandidate[]> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const [employees, grants] = await Promise.all([
+    AppDataSource.getRepository(AIEmployee).find({
+      where: { companyId: args.companyId },
+      order: { name: "ASC" },
+    }),
+    AppDataSource.getRepository(EmployeeVaultGrant).find({
+      where: { companyId: args.companyId, vaultItemId: args.itemId },
+    }),
+  ]);
+  const byEmployee = new Map(grants.map((grant) => [grant.employeeId, grant]));
+  return employees.map((employee) => {
+    const grant = byEmployee.get(employee.id);
+    return {
+      id: employee.id,
+      name: employee.name,
+      slug: employee.slug,
+      role: employee.role,
+      grant: grant ? { id: grant.id, accessLevel: grant.accessLevel } : null,
+    };
+  });
+}
+
+async function assertCompanyEmployee(companyId: string, employeeId: string): Promise<void> {
+  const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({
+    id: employeeId,
+    companyId,
+  });
+  if (!employee) throw new VaultError("AI Employee not found", 404);
+}
+
+export async function upsertEmployeeVaultGrant(args: {
+  companyId: string;
+  itemId: string;
+  actor: VaultHumanActor;
+  employeeId: string;
+  accessLevel: EmployeeVaultAccessLevel;
+}): Promise<EmployeeVaultGrantView> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  await assertCompanyEmployee(args.companyId, args.employeeId);
+  const repo = AppDataSource.getRepository(EmployeeVaultGrant);
+  let grant = await repo.findOneBy({
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+    employeeId: args.employeeId,
+  });
+  if (grant) {
+    grant.accessLevel = args.accessLevel;
+  } else {
+    grant = repo.create({
+      companyId: args.companyId,
+      vaultItemId: args.itemId,
+      employeeId: args.employeeId,
+      accessLevel: args.accessLevel,
+    });
+  }
+  await repo.save(grant);
+  const [hydrated] = await hydrateEmployeeGrants([grant]);
+  if (!hydrated) throw new VaultError("AI Employee not found", 404);
+  return hydrated;
+}
+
+export async function updateEmployeeVaultGrant(args: {
+  companyId: string;
+  itemId: string;
+  grantId: string;
+  actor: VaultHumanActor;
+  accessLevel: EmployeeVaultAccessLevel;
+}): Promise<EmployeeVaultGrantView> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const repo = AppDataSource.getRepository(EmployeeVaultGrant);
+  const grant = await repo.findOneBy({
+    id: args.grantId,
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+  });
+  if (!grant) throw new VaultError("Vault Grant not found", 404);
+  grant.accessLevel = args.accessLevel;
+  await repo.save(grant);
+  const [hydrated] = await hydrateEmployeeGrants([grant]);
+  if (!hydrated) throw new VaultError("AI Employee not found", 404);
+  return hydrated;
+}
+
+export async function deleteEmployeeVaultGrant(args: {
+  companyId: string;
+  itemId: string;
+  grantId: string;
+  actor: VaultHumanActor;
+}): Promise<{ id: string; employeeId: string; accessLevel: EmployeeVaultAccessLevel }> {
+  await loadManagedItem(args.companyId, args.itemId, args.actor);
+  const repo = AppDataSource.getRepository(EmployeeVaultGrant);
+  const grant = await repo.findOneBy({
+    id: args.grantId,
+    companyId: args.companyId,
+    vaultItemId: args.itemId,
+  });
+  if (!grant) throw new VaultError("Vault Grant not found", 404);
+  await repo.delete({ id: grant.id });
+  return { id: grant.id, employeeId: grant.employeeId, accessLevel: grant.accessLevel };
+}
+
+/**
+ * AI-facing metadata discovery. It returns only items explicitly granted to
+ * the employee and never includes the encrypted payload's secret field.
+ */
+export async function listVaultItemsForEmployee(
+  companyId: string,
+  employeeId: string,
+): Promise<
+  Array<{
+    id: string;
+    type: VaultItemType;
+    title: string;
+    username: string;
+    websiteUrl: string;
+    accessLevel: EmployeeVaultAccessLevel;
+  }>
+> {
+  await assertCompanyEmployee(companyId, employeeId);
+  const grants = await AppDataSource.getRepository(EmployeeVaultGrant).find({
+    where: { companyId, employeeId },
+  });
+  if (grants.length === 0) return [];
+  const rows = await AppDataSource.getRepository(VaultItem).find({
+    where: { companyId, id: In(grants.map((grant) => grant.vaultItemId)) },
+  });
+  const grantByItem = new Map(grants.map((grant) => [grant.vaultItemId, grant]));
+  return rows.flatMap((row) => {
+    const grant = grantByItem.get(row.id);
+    const rank = grant ? EMPLOYEE_VAULT_ACCESS_RANK[grant.accessLevel] : undefined;
+    if (!grant || typeof rank !== "number") return [];
+    const payload = decryptPayload(row);
+    return [
+      {
+        id: row.id,
+        type: row.type,
+        title: payload.title,
+        username: payload.username,
+        websiteUrl: payload.websiteUrl,
+        accessLevel: grant.accessLevel,
+      },
+    ];
+  });
+}
+
+/**
+ * Sensitive resolution seam for a governed server-side AI action (for
+ * example, filling the App-owned browser). Callers must never serialize the
+ * returned payload into a model tool result, transcript, audit row or log.
+ */
+export async function getVaultItemPayloadForEmployee(args: {
+  companyId: string;
+  employeeId: string;
+  itemId: string;
+  required?: EmployeeVaultAccessLevel;
+}): Promise<{
+  item: VaultItem;
+  payload: VaultPayload;
+  accessLevel: EmployeeVaultAccessLevel;
+}> {
+  await assertCompanyEmployee(args.companyId, args.employeeId);
+  const required = args.required ?? "use";
+  const [item, grant] = await Promise.all([
+    AppDataSource.getRepository(VaultItem).findOneBy({
+      id: args.itemId,
+      companyId: args.companyId,
+    }),
+    AppDataSource.getRepository(EmployeeVaultGrant).findOneBy({
+      companyId: args.companyId,
+      vaultItemId: args.itemId,
+      employeeId: args.employeeId,
+    }),
+  ]);
+  if (!item || !grant) throw new VaultError("No Grant for that Vault item", 403);
+  const have = EMPLOYEE_VAULT_ACCESS_RANK[grant.accessLevel];
+  const need = EMPLOYEE_VAULT_ACCESS_RANK[required];
+  if (typeof have !== "number" || have < need) {
+    throw new VaultError(`The "${required}" Vault Grant level is required`, 403);
+  }
+  return { item, payload: decryptPayload(item), accessLevel: grant.accessLevel };
+}
+
+/**
+ * Resolve one credential field for an App-owned, server-side action. The
+ * plaintext return is intentionally narrow and ephemeral: callers must pass it
+ * directly to the governed sink (such as Playwright `fill`) and must never put
+ * it in a model result, response body, transcript, audit row, or log.
+ */
+export async function getVaultFieldForEmployee(args: {
+  companyId: string;
+  employeeId: string;
+  itemId: string;
+  field: "username" | "secret";
+}): Promise<string> {
+  const resolved = await getVaultItemPayloadForEmployee({
+    companyId: args.companyId,
+    employeeId: args.employeeId,
+    itemId: args.itemId,
+    required: "use",
+  });
+  return resolved.payload[args.field];
+}
+
+/**
+ * Store a login captured or generated during an AI Employee's browser flow.
+ * The creator receives a `manage` Grant atomically. A missing secret is
+ * generated server-side and is deliberately not included in the return value.
+ */
+export async function createVaultLoginForEmployee(args: {
+  companyId: string;
+  employeeId: string;
+  title: string;
+  username?: string;
+  secret?: string;
+  passwordLength?: number;
+  websiteUrl?: string;
+  notes?: string;
+  visibility?: VaultItemVisibility;
+}): Promise<{
+  id: string;
+  companyId: string;
+  type: "login";
+  visibility: VaultItemVisibility;
+  title: string;
+  username: string;
+  websiteUrl: string;
+  createdByEmployeeId: string;
+  grantAccessLevel: "manage";
+  createdAt: Date;
+  updatedAt: Date;
+}> {
+  await assertCompanyEmployee(args.companyId, args.employeeId);
+  const secret = args.secret ?? generateVaultPassword(args.passwordLength);
+  if (!secret) throw new VaultError("A captured secret cannot be empty", 400);
+  const payload: VaultPayload = {
+    title: args.title.trim(),
+    username: args.username ?? "",
+    secret,
+    websiteUrl: normalizeVaultWebsiteUrl(args.websiteUrl ?? ""),
+    notes: args.notes ?? "",
+  };
+  if (!payload.title) throw new VaultError("A title is required", 400);
+
+  const saved = await AppDataSource.transaction(async (manager) => {
+    const itemRepo = manager.getRepository(VaultItem);
+    const item = itemRepo.create({
+      companyId: args.companyId,
+      type: "login",
+      visibility: args.visibility ?? "company",
+      encryptedPayload: encryptPayload(args.companyId, payload),
+      createdByUserId: null,
+      createdByEmployeeId: args.employeeId,
+    });
+    await itemRepo.save(item);
+    const grantRepo = manager.getRepository(EmployeeVaultGrant);
+    await grantRepo.save(
+      grantRepo.create({
+        companyId: args.companyId,
+        vaultItemId: item.id,
+        employeeId: args.employeeId,
+        accessLevel: "manage",
+      }),
+    );
+    return item;
+  });
+
+  return {
+    id: saved.id,
+    companyId: saved.companyId,
+    type: "login",
+    visibility: saved.visibility,
+    title: payload.title,
+    username: payload.username,
+    websiteUrl: payload.websiteUrl,
+    createdByEmployeeId: args.employeeId,
+    grantAccessLevel: "manage",
+    createdAt: saved.createdAt,
+    updatedAt: saved.updatedAt,
+  };
+}
+
+/**
+ * Let an AI Employee with a `manage` Grant maintain login metadata without
+ * gaining a plaintext read or rotation primitive. The existing secret is
+ * decrypted only inside this service and immediately re-encrypted unchanged.
+ */
+export async function updateVaultLoginMetadataForEmployee(args: {
+  companyId: string;
+  employeeId: string;
+  itemId: string;
+  patch: {
+    title?: string;
+    username?: string;
+    notes?: string;
+  };
+}): Promise<{
+  id: string;
+  companyId: string;
+  type: "login";
+  visibility: VaultItemVisibility;
+  title: string;
+  username: string;
+  websiteUrl: string;
+  createdByEmployeeId: string | null;
+  accessLevel: "manage";
+  createdAt: Date;
+  updatedAt: Date;
+}> {
+  if (Object.keys(args.patch).length === 0) {
+    throw new VaultError("Provide at least one metadata field to update", 400);
+  }
+  if (Object.keys(args.patch).some((field) => !["title", "username", "notes"].includes(field))) {
+    throw new VaultError("AI Employees cannot change a Vault login's saved website", 403);
+  }
+  const resolved = await getVaultItemPayloadForEmployee({
+    companyId: args.companyId,
+    employeeId: args.employeeId,
+    itemId: args.itemId,
+    required: "manage",
+  });
+  if (resolved.item.type !== "login") {
+    throw new VaultError("Only Vault login metadata can be updated this way", 400);
+  }
+
+  const payload: VaultPayload = {
+    title: args.patch.title?.trim() ?? resolved.payload.title,
+    username: args.patch.username ?? resolved.payload.username,
+    secret: resolved.payload.secret,
+    websiteUrl: resolved.payload.websiteUrl,
+    notes: args.patch.notes ?? resolved.payload.notes,
+  };
+  if (!payload.title) throw new VaultError("A title is required", 400);
+
+  const repo = AppDataSource.getRepository(VaultItem);
+  const update = await repo.update(
+    {
+      id: resolved.item.id,
+      companyId: args.companyId,
+      version: resolved.item.version,
+    },
+    {
+      encryptedPayload: encryptPayload(args.companyId, payload),
+      version: resolved.item.version + 1,
+    },
+  );
+  if (update.affected !== 1) {
+    throw new VaultError("This Vault login changed while it was being updated. Retry safely.", 409);
+  }
+  const saved = await loadItem(args.companyId, args.itemId);
+  return {
+    id: saved.id,
+    companyId: saved.companyId,
+    type: "login",
+    visibility: saved.visibility,
+    title: payload.title,
+    username: payload.username,
+    websiteUrl: payload.websiteUrl,
+    createdByEmployeeId: saved.createdByEmployeeId,
+    accessLevel: "manage",
+    createdAt: saved.createdAt,
+    updatedAt: saved.updatedAt,
+  };
+}

--- a/App/server/services/workspaceGit.test.ts
+++ b/App/server/services/workspaceGit.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { buildWorkspaceGitInvocation } from "./workspaceGit.js";
+import {
+  assertWorkspaceGitMetadataContained,
+  buildWorkspaceGitInvocation,
+} from "./workspaceGit.js";
 
 test("bubblewrapped Git receives private namespaces and an explicit environment", () => {
   const invocation = buildWorkspaceGitInvocation(
@@ -133,4 +139,30 @@ test("workspace Git host execution requires the separate unsafe-host acknowledge
   const acknowledged = buildWorkspaceGitInvocation(options, "host", "/usr/bin/bwrap", true);
   assert.equal(acknowledged.executable, "git");
   assert.equal(acknowledged.isolated, false);
+});
+
+test("workspace Git rejects gitdir and commondir pointers outside the employee workspace", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-git-metadata-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const workspace = path.join(root, "workspace");
+  const checkout = path.join(workspace, "repo");
+  const outsideGit = path.join(root, "outside.git");
+  fs.mkdirSync(path.join(checkout, ".git"), { recursive: true });
+  fs.mkdirSync(outsideGit);
+
+  fs.writeFileSync(
+    path.join(checkout, ".git", "commondir"),
+    path.relative(path.join(checkout, ".git"), outsideGit),
+  );
+  assert.throws(
+    () => assertWorkspaceGitMetadataContained(workspace, checkout),
+    /common directory escapes/,
+  );
+
+  fs.rmSync(path.join(checkout, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(checkout, ".git"), `gitdir: ${outsideGit}\n`);
+  assert.throws(
+    () => assertWorkspaceGitMetadataContained(workspace, checkout),
+    /Git directory escapes/,
+  );
 });

--- a/App/server/services/workspaceGit.ts
+++ b/App/server/services/workspaceGit.ts
@@ -1,4 +1,6 @@
 import { execFile, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { config } from "../../config.js";
 import { buildBubblewrapCommandArgs } from "./agent/bubblewrap.js";
@@ -112,6 +114,7 @@ export function buildWorkspaceGitInvocation(
 }
 
 export async function runWorkspaceGit(options: WorkspaceGitOptions): Promise<{ stdout: string }> {
+  assertWorkspaceGitMetadataContained(options.workspaceRoot, options.cwd);
   const invocation = buildWorkspaceGitInvocation(options);
   try {
     const { stdout } =
@@ -135,6 +138,53 @@ export async function runWorkspaceGit(options: WorkspaceGitOptions): Promise<{ s
     const detail = error as { stderr?: string; stdout?: string; message?: string };
     const tail = (detail.stderr || detail.stdout || detail.message || "").toString().trim();
     throw new Error(`git ${command} failed: ${tail.split("\n").slice(-3).join(" | ")}`);
+  }
+}
+
+/**
+ * Git follows `.git` and `commondir` pointers before applying local config.
+ * Validate those pointers before every command so an AI-writable checkout
+ * cannot make the App process mutate another repository's configuration.
+ */
+export function assertWorkspaceGitMetadataContained(workspaceRoot: string, cwd: string): void {
+  const resolvedWorkspace = fs.realpathSync(workspaceRoot);
+  const resolvedCwd = fs.realpathSync(cwd);
+  assertContained(resolvedWorkspace, resolvedCwd, "Git checkout");
+  const gitEntry = path.join(resolvedCwd, ".git");
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(gitEntry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  let unresolvedGitDir: string;
+  if (stat.isDirectory()) {
+    unresolvedGitDir = gitEntry;
+  } else if (stat.isFile()) {
+    const pointer = fs.readFileSync(gitEntry, "utf8");
+    const match = pointer.match(/^gitdir: ([^\0\r\n]+)\r?\n?$/);
+    if (!match?.[1]) throw new Error("Git checkout has an invalid gitdir pointer.");
+    unresolvedGitDir = path.resolve(resolvedCwd, match[1]);
+  } else {
+    throw new Error("Git checkout has an unsupported .git entry.");
+  }
+  const gitDir = fs.realpathSync(unresolvedGitDir);
+  assertContained(resolvedWorkspace, gitDir, "Git directory");
+  const commonDirFile = path.join(gitDir, "commondir");
+  if (!fs.existsSync(commonDirFile)) return;
+  const pointer = fs.readFileSync(commonDirFile, "utf8");
+  if (/\0|\r|\n.*\S/s.test(pointer)) {
+    throw new Error("Git checkout has an invalid common directory pointer.");
+  }
+  const commonDir = fs.realpathSync(path.resolve(gitDir, pointer.trim()));
+  assertContained(resolvedWorkspace, commonDir, "Git common directory");
+}
+
+function assertContained(root: string, candidate: string, label: string): void {
+  const relative = path.relative(root, candidate);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes the employee workspace.`);
   }
 }
 

--- a/CLI/genosyn
+++ b/CLI/genosyn
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-CLI_VERSION="0.4.3"
+CLI_VERSION="0.4.4"
 
 PORT="${GENOSYN_PORT:-8471}"
 NAME="${GENOSYN_NAME:-genosyn}"
@@ -397,12 +397,13 @@ backup_volume_to() {
     -v "${VOLUME}:/data:ro" \
     -v "${out_dir}:/backup" \
     alpine:3.20 \
-    sh -c 'cd /data && tar -czf "/backup/$1" . && { chown "$2:$3" "/backup/$1" 2>/dev/null || true; }' \
+    sh -c 'umask 077; rm -f "/backup/$1"; cd /data && tar -czf "/backup/$1" . && chmod 0600 "/backup/$1" && { chown "$2:$3" "/backup/$1" 2>/dev/null || true; }' \
     sh "${out_base}" "${owner_uid}" "${owner_gid}" >/dev/null; then
     return 1
   fi
 
   [ -s "${out}" ] || return 1
+  chmod 0600 "${out}" || return 1
   docker run --rm \
     -v "${out_dir}:/backup:ro" \
     alpine:3.20 \

--- a/Home/client/docs/DocsApp.tsx
+++ b/Home/client/docs/DocsApp.tsx
@@ -26,6 +26,7 @@ import { Sequences } from "@/docs/pages/Sequences";
 import { Signals } from "@/docs/pages/Signals";
 import { Deliverability } from "@/docs/pages/Deliverability";
 import { WorkspaceChat } from "@/docs/pages/WorkspaceChat";
+import { Vault } from "@/docs/pages/Vault";
 import { Email } from "@/docs/pages/Email";
 import { Tasks } from "@/docs/pages/Tasks";
 import { Pipelines } from "@/docs/pages/Pipelines";
@@ -67,6 +68,7 @@ const PAGES: Record<string, () => JSX.Element> = {
   "/docs/signals": Signals,
   "/docs/deliverability": Deliverability,
   "/docs/workspace-chat": WorkspaceChat,
+  "/docs/vault": Vault,
   "/docs/email": Email,
   "/docs/tasks": Tasks,
   "/docs/pipelines": Pipelines,

--- a/Home/client/docs/DocsShell.tsx
+++ b/Home/client/docs/DocsShell.tsx
@@ -24,6 +24,7 @@ const PATH_TO_SOURCE: Record<string, string> = {
   "/docs/explore": "Explore.tsx",
   "/docs/marketing": "Marketing.tsx",
   "/docs/workspace-chat": "WorkspaceChat.tsx",
+  "/docs/vault": "Vault.tsx",
   "/docs/self-hosting": "SelfHosting.tsx",
   "/docs/saas-hosting": "SaasHosting.tsx",
   "/docs/cli": "Cli.tsx",

--- a/Home/client/docs/nav.ts
+++ b/Home/client/docs/nav.ts
@@ -103,7 +103,7 @@ export const DOCS_NAV: DocsSection[] = [
       {
         path: "/docs/code",
         title: "Code Repositories",
-        blurb: "Add any git repo; let granted AI employees commit and push.",
+        blurb: "Add any git repo; let granted AI employees edit, test, and commit safely.",
       },
     ],
   },
@@ -175,6 +175,12 @@ export const DOCS_NAV: DocsSection[] = [
         path: "/docs/workspace-chat",
         title: "Workspace chat",
         blurb: "Channels and DMs with AI replies, context resets, and company resource tags.",
+      },
+      {
+        path: "/docs/vault",
+        title: "Vault",
+        blurb:
+          "Encrypted logins, API keys, and secure notes for Members and item-granted AI Employees.",
       },
       {
         path: "/docs/email",

--- a/Home/client/docs/pages/Browser.tsx
+++ b/Home/client/docs/pages/Browser.tsx
@@ -21,6 +21,12 @@ export function Browser() {
         hosted profile disables it. It remains available for single-tenant self-hosting. A hosted
         browser needs a separately isolated worker before operators should enable it.
       </Callout>
+      <Callout kind="info" title="Genosyn Member sessions are isolated from AI Browser authority">
+        If App-owned Chromium holds a Member&apos;s Genosyn session, every Genosyn App API request
+        from that browser is refused. The session cannot mint API keys, change company roles, or
+        become a shortcut around Vault access. Use the AI Employee&apos;s Grants and governed tools
+        instead.
+      </Callout>
 
       <H2 id="enabling">Enabling it</H2>
       <P>
@@ -54,6 +60,10 @@ export function Browser() {
           },
           { term: "browser_fill", def: "Type into an input or textarea, replacing its contents." },
           {
+            term: "browser_fill_vault",
+            def: "Fill a username or Login password from an explicitly granted Vault item. Passwords go only into password inputs, and the App never returns plaintext to the model.",
+          },
+          {
             term: "browser_select",
             def: "Choose an option in a native dropdown by value or visible label.",
           },
@@ -75,8 +85,12 @@ export function Browser() {
             def: "Wait for a selector to appear (up to 15s) or pause a fixed time, instead of polling with snapshots.",
           },
           {
+            term: "browser_save_vault_login",
+            def: "Request owner/admin approval to capture a same-origin password input into a new restricted Vault login without reading it back through the model.",
+          },
+          {
             term: "browser_screenshot",
-            def: "A JPEG of the viewport, for when layout or imagery matters.",
+            def: "A JPEG of the viewport when layout matters. It is unavailable after the session has observed or filled a password; use the redacted snapshot then.",
           },
           {
             term: "browser_submit",
@@ -84,7 +98,7 @@ export function Browser() {
           },
           {
             term: "browser_resume",
-            def: "Re-fire an approved submit — in the same turn or any later one.",
+            def: "Run an approved submit or restricted Vault capture in its original Browser session and page.",
           },
           {
             term: "browser_close",
@@ -108,6 +122,12 @@ export function Browser() {
         popup tab that was adopted, a selector that matched more than one element — are surfaced as{" "}
         <Code>NOTE:</Code> lines at the top of the next snapshot.
       </P>
+      <P>
+        Password-input values are removed from snapshots before they reach the model, including
+        password fields inside frames. Once a password has been observed or filled in the session,
+        <Code>browser_screenshot</Code> refuses to create a model-visible image; the structural
+        snapshot remains available with the password redacted.
+      </P>
 
       <H2 id="allow-list">The allow list</H2>
       <P>
@@ -129,8 +149,37 @@ export function Browser() {
         </LI>
       </UL>
       <P>
-        The list is enforced server-side on every <Code>browser_open</Code>, so edits apply
-        immediately — no restart needed.
+        The list is enforced server-side on <Code>browser_open</Code> and intersected with Vault
+        autofill and capture checks on the live top page and target frame. Edits apply immediately —
+        no restart needed — and a Vault Grant never widens this Browser policy.
+      </P>
+
+      <H2 id="vault">Vault autofill and capture</H2>
+      <P>
+        A granted <DocLink to="/docs/vault">Vault</DocLink> login removes the need to paste a
+        password into Chat or type it during take-over. The employee first calls{" "}
+        <Code>list_vault_items</Code> for safe metadata, opens the saved website, then calls{" "}
+        <Code>browser_fill_vault</Code> for the username or password field. The App resolves the
+        current item-level Grant and types the value directly into Chromium. The tool result only
+        confirms that the field was filled.
+      </P>
+      <P>
+        Autofill is bound to the login&apos;s exact saved origin: scheme, host, and port must match
+        on both the top page and target frame. The stored password is accepted only from a Login
+        item and only into an input with <Code>type=password</Code>; API keys and secure-note bodies
+        are not Browser-fill sinks. A missing or revoked Grant fails closed. Browser access and the
+        host allow list still apply independently, so a Vault Grant cannot turn the Browser on or
+        widen where it may navigate.
+      </P>
+      <P>
+        For signup and password-generation flows, <Code>browser_save_vault_login</Code> captures the
+        current value of a same-origin password input only after a company owner or admin approves
+        the request. This approval is mandatory even when ordinary form-submit approval is off. The
+        result is a restricted Vault item bound to the current origin, with a Manage Grant for the
+        employee; other Members do not see it until an owner or admin changes its access. The
+        password is neither read back nor included in model output. An employee can instead use{" "}
+        <Code>create_vault_login</Code> to have Genosyn generate and encrypt a company-visible
+        password before filling it into the page.
       </P>
 
       <H2 id="approvals">Approval-gated submits</H2>
@@ -156,9 +205,10 @@ export function Browser() {
       <P>
         While the employee browses, the chat panel shows the page live. Click{" "}
         <Strong>Take over</Strong> to drive it yourself — your mouse and keyboard go straight to the
-        same Chromium. That is the intended flow for credentials, captchas, and 2FA: the employee
-        navigates to the login page, you type the secret, the employee carries on. The browser is
-        never torn down while someone is watching.
+        same Chromium. Use Vault autofill for a granted stored credential; take-over remains the
+        fallback for a credential not in the Vault and the intended flow for captchas and 2FA. The
+        employee navigates to the right page, you complete the human-only step, and the employee
+        carries on. The browser is never torn down while someone is watching.
       </P>
 
       <H2 id="persistence">What persists</H2>

--- a/Home/client/docs/pages/Code.tsx
+++ b/Home/client/docs/pages/Code.tsx
@@ -23,7 +23,7 @@ export function CodeRepositories() {
           <>
             Add any git repository to your company and grant the AI employees you choose access to
             work on it. Each granted employee gets a real checkout in its workspace — read, branch,
-            commit, and <Strong>push</Strong>, all with ordinary <Code>git</Code>.
+            edit, test, and commit with ordinary <Code>git</Code>.
           </>
         }
       />
@@ -35,12 +35,13 @@ export function CodeRepositories() {
         or a self-hosted server over HTTPS or SSH. Unlike a read-only API integration, this gives
         employees an editable working tree: the runner clones each granted repo into{" "}
         <Code>code-repos/&lt;slug&gt;/</Code> inside the employee&apos;s workspace before every chat
-        and routine run, with credentials and the committer identity already wired up.
+        and Routine Run, with the committer identity already configured. Credentials stay in the
+        server-owned refresh operation and never enter that working tree.
       </P>
 
       <Callout kind="info" title="Access is opt-in, per employee.">
         Adding a repository does not expose it to anyone. You decide which employees can touch it,
-        and whether each may only read or also push.
+        and whether each is reference-only or authorized to prepare a local change.
       </Callout>
 
       <H2 id="add">Adding a repository</H2>
@@ -63,7 +64,7 @@ export function CodeRepositories() {
         </LI>
         <LI>
           Use the repository side menu to open <Strong>AI access</Strong>, add an employee, and
-          choose <Strong>Read &amp; push</Strong> when it should deliver branches or pull requests.
+          choose <Strong>Work locally</Strong> when it should prepare branches and commits.
         </LI>
       </OL>
 
@@ -95,30 +96,37 @@ export function CodeRepositories() {
           HTTPS GitHub URL, Genosyn automatically reuses a GitHub Connection granted to the same
           employee. An exact owner/repository allowlist match wins; when the employee has only one
           GitHub Connection, the Code Repository grant itself is the repository boundary. The token
-          powers both fetch and push without being copied onto the Code Repository row. Without a
-          matching Connection, pushing is rejected by the remote.
+          is used only by Genosyn&apos;s server-owned clone/refresh operation and is never exposed
+          to the AI employee.
         </LI>
         <LI>
-          <Strong>HTTPS token / password.</Strong> A username plus a personal access token (with
-          repo read/write scope). The token is handed to git at run time through an environment
-          variable and <Strong>never lands on disk</Strong>. Username tips:{" "}
-          <Code>x-access-token</Code> for GitHub, <Code>oauth2</Code> for GitLab, your account name
-          for Bitbucket.
+          <Strong>HTTPS token / password.</Strong> A username plus a personal access token (with the
+          narrowest repository scope you can grant). The token is decrypted only for a short-lived
+          server-owned git operation; it never lands in the checkout or the AI employee&apos;s shell
+          environment. Username tips: <Code>x-access-token</Code> for GitHub, <Code>oauth2</Code>{" "}
+          for GitLab, your account name for Bitbucket.
         </LI>
         <LI>
           <Strong>SSH private key.</Strong> Paste a private key whose public half is registered as a
-          deploy key on your host. The key is written into the employee&apos;s gitignored workspace
-          only while a checkout exists, and pinned via <Code>core.sshCommand</Code> with host keys
-          accepted on first contact.
+          deploy key on your host. The key is materialized only in an App-private temporary
+          directory for clone/refresh, then removed. Only the non-secret host-key cache persists,
+          outside the employee workspace.
         </LI>
       </UL>
       <P>
         Authenticated clone and refresh operations contact only the configured repository from a
         private server-owned git workspace, then transfer the fetched objects into the employee
         checkout. Employee-written remote rewrites, proxy settings, and TLS settings are not read by
-        that networked process. HTTPS credential helpers are additionally scoped to the exact host,
-        port, and repository path.
+        that networked process. The checkout is left without a credential helper, SSH key path, or
+        credentialed push URL.
       </P>
+
+      <Callout kind="warn" title="Publishing authenticated branches is a human or governed step">
+        AI employees can branch, edit, test, and commit locally. Genosyn does not place reusable
+        repository credentials in model-controlled tools, so a credentialed remote cannot be pushed
+        directly from the AI coding shell. Ask a Member to publish the reported branch and commit,
+        or use a separately governed server-side delivery flow.
+      </Callout>
 
       <H2 id="access">Granting access</H2>
       <P>
@@ -128,39 +136,38 @@ export function CodeRepositories() {
       </P>
       <UL>
         <LI>
-          <Strong>Read &amp; push.</Strong> Full access — the employee may commit and{" "}
-          <Code>git push</Code>. This is the default, since the point of adding a repo is usually to
-          let an employee work on it.
+          <Strong>Work locally.</Strong> The employee may prepare a branch and local commits. This
+          is the default when the point of adding a repository is to let an employee work on it.
         </LI>
         <LI>
-          <Strong>Read only.</Strong> The repo is cloned and kept fetched; the employee can read,
-          branch, and commit locally, but the push URL is disabled so an accidental push fails fast.
+          <Strong>Reference only.</Strong> The repo is cloned and kept refreshed for research. Any
+          local changes remain unpublished, and the push URL is disabled.
         </LI>
       </UL>
 
       <H2 id="how-employees-use-it">How employees use it</H2>
       <P>
         Granted employees are told, in their prompt, which repositories are checked out, where, and
-        whether they may push. They work with ordinary git — no special tooling. The built-in{" "}
-        <Code>genosyn</Code> MCP server also exposes a <Code>list_code_repositories</Code> tool so
-        an employee can enumerate its repos and their local paths at any time.
+        how to hand off local changes. They work with ordinary git — no special tooling. The
+        built-in <Code>genosyn</Code> MCP server also exposes a <Code>list_code_repositories</Code>{" "}
+        tool so an employee can enumerate its repos and their local paths at any time.
       </P>
       <Pre lang="bash">{`cd code-repos/acme-web
 git checkout -b fix/typo
 # …edit files…
 git commit -am "Fix typo in README"
-git push -u origin fix/typo`}</Pre>
+git status --short --branch`}</Pre>
       <P>
         Existing checkouts are only <Code>git fetch</Code>ed between runs, never hard-reset — so a
-        branch an employee pushed in one run is still there the next time it starts.
+        local branch an employee prepared in one Run is still there the next time it starts.
       </P>
 
-      <H2 id="pull-requests">Writing code and opening a pull request</H2>
+      <H2 id="pull-requests">Writing code and handing off a pull request</H2>
       <P>
         Code editing needs no extra plugin or MCP server. Every AI employee has built-in tools for
         shell commands, file reads and writes, exact edits, directory listing, globbing, and search.
-        A <Strong>Read &amp; push</Strong> repository grant adds the working tree and git
-        credentials.
+        A <Strong>Work locally</Strong> repository grant adds the working tree, while repository
+        credentials remain server-owned.
       </P>
       <P>
         Opening a GitHub pull request uses the GitHub Connection&apos;s{" "}
@@ -181,17 +188,16 @@ git push -u origin fix/typo`}</Pre>
         </LI>
       </OL>
       <P>
-        When the Code Repository uses <Strong>None / GitHub Connection</Strong>, those same grants
-        also wire the Connection&apos;s token into ordinary <Code>git fetch</Code> and{" "}
-        <Code>git push</Code> commands. You do not need to paste the PAT into the repository a
-        second time.
+        When the Code Repository uses <Strong>None / GitHub Connection</Strong>, the same grants let
+        the Genosyn server refresh the checkout without copying the PAT into the repository or AI
+        shell. A Member or governed delivery action must publish the local branch before the PR tool
+        can open a pull request for it.
       </P>
       <P>
         You can then ask: “Create a branch, implement this change, run the tests, and send me a
-        draft PR.” Genosyn tells the employee to carry the request through editing, tests, commit,
-        push, and the PR tool. It must not claim a pull request exists unless the GitHub call
-        succeeds; when the Connection grant is missing, it reports the pushed branch and the missing
-        setup instead.
+        draft PR.” Genosyn carries the request through editing, tests, and a local commit, then
+        reports the exact branch and commit that need publishing. It must not claim a push or pull
+        request exists unless the corresponding operation actually succeeds.
       </P>
 
       <H3 id="vs-github">Code Repositories vs. the GitHub integration</H3>
@@ -199,14 +205,14 @@ git push -u origin fix/typo`}</Pre>
         The <DocLink to="/docs/integrations">GitHub integration</DocLink> is the right tool when you
         want an employee calling the GitHub API (issues, pull requests, reviews) against repos on a
         connected GitHub account. Code Repositories are for the editor-shaped workflow — a working
-        tree to commit and push to — and work against any git host, not just GitHub. Use both for
-        the full code-to-pull-request workflow.
+        tree to edit and commit in — and work against any git host, not just GitHub. Use both with a
+        governed publish step for the full code-to-pull-request workflow.
       </P>
 
       <Callout kind="warn" title="Least privilege.">
         Scope tokens and deploy keys to exactly the repositories an employee needs, and prefer{" "}
-        <Strong>read only</Strong> when an employee just needs to reference code. Deleting a
-        repository in Genosyn revokes every grant; the remote git repository is never touched.
+        <Strong>Reference only</Strong> when an employee just needs to inspect code. Deleting a
+        repository in Genosyn never deletes or changes the remote git repository.
       </Callout>
     </>
   );

--- a/Home/client/docs/pages/Employees.tsx
+++ b/Home/client/docs/pages/Employees.tsx
@@ -162,24 +162,25 @@ export function Employees() {
 └── ...   # files the employee's coding tools read and write`}
       </pre>
       <P>
-        The runner starts the selected agent runtime with this directory as <Code>cwd</Code> for the
-        built-in coding tools (<Code>bash</Code>, <Code>read_file</Code>, <Code>write_file</Code>,{" "}
-        <Code>edit_file</Code>, <Code>list_dir</Code>, <Code>glob</Code>, <Code>grep</Code>), and
-        captures the agent transcript into a Run log. API-key and custom models use Genosyn&apos;s
-        in-process loop; OpenAI subscription models use the official Codex app-server. A Routine
-        does not make its AI employee unavailable: Members can keep chatting with that employee and
-        start independent Routines in parallel, up to the company workload limit. Concurrent work
-        shares this directory, so give overlapping Runs distinct output files and avoid simultaneous
-        edits to the same git working tree. Model credentials stay encrypted in the database. They
-        never enter the employee working directory. For an OpenAI subscription login or Run, Genosyn
-        gives the official app-server a locked temporary <Code>CODEX_HOME</Code>. Managed ChatGPT
-        sessions are materialized there; access tokens enter only the child process environment.
-        Genosyn removes the directory afterward. Subscription auth is unavailable while coding tools
-        use host mode, because a concurrent AI Employee&apos;s same-user shell could inspect that
-        sibling process. Use working Linux bubblewrap mode. In that mode every AI Model turn uses
-        sandboxed <Code>bash</Code> for file work, and repository synchronization stays inside the
-        same namespace; Genosyn omits its host-process file helpers install-wide so concurrent turns
-        cannot race them across the boundary.
+        The runner gives the selected agent runtime path-confined file and search tools rooted in
+        this directory (<Code>read_file</Code>, <Code>write_file</Code>, <Code>edit_file</Code>,{" "}
+        <Code>list_dir</Code>, <Code>glob</Code>, and <Code>grep</Code>) and captures the agent
+        transcript into a Run log. Host mode never exposes <Code>bash</Code>, because a working
+        directory is not a security boundary for an unrestricted same-user shell. API-key and custom
+        models use Genosyn&apos;s in-process loop; OpenAI subscription models use the official Codex
+        app-server. A Routine does not make its AI employee unavailable: Members can keep chatting
+        with that employee and start independent Routines in parallel, up to the company workload
+        limit. Concurrent work shares this directory, so give overlapping Runs distinct output files
+        and avoid simultaneous edits to the same git working tree. Model credentials stay encrypted
+        in the database. They never enter the employee working directory. For an OpenAI subscription
+        login or Run, Genosyn gives the official app-server a locked temporary{" "}
+        <Code>CODEX_HOME</Code>. Managed ChatGPT sessions are materialized there; access tokens
+        enter only the child process environment. Genosyn removes the directory afterward.
+        Subscription auth is unavailable while coding tools use host mode. Use working Linux
+        bubblewrap mode. In that mode every AI Model turn uses sandboxed <Code>bash</Code> for file
+        work, and repository synchronization stays inside the same namespace; Genosyn omits its
+        host-process file helpers install-wide so concurrent turns cannot race them across the
+        boundary.
       </P>
 
       <H3 id="org-chart">Org chart</H3>

--- a/Home/client/docs/pages/Integrations.tsx
+++ b/Home/client/docs/pages/Integrations.tsx
@@ -256,18 +256,18 @@ export function Integrations() {
       <H3 id="hacker-news">Hacker News monitoring and review</H3>
       <P>
         Open <Strong>Settings → Integrations</Strong>, choose <Strong>Hacker News</Strong>, and
-        optionally enter a public HN username. Hacker News does not require an API key: the
-        username only becomes the default profile for activity tools. Grant the Connection to an
-        AI employee, then use a Skill or Routine to monitor the top, new, best, Ask HN, Show HN,
-        or jobs feeds; read individual items; review bounded comment trees; watch public profile
-        activity; or poll the official updates feed.
+        optionally enter a public HN username. Hacker News does not require an API key: the username
+        only becomes the default profile for activity tools. Grant the Connection to an AI employee,
+        then use a Skill or Routine to monitor the top, new, best, Ask HN, Show HN, or jobs feeds;
+        read individual items; review bounded comment trees; watch public profile activity; or poll
+        the official updates feed.
       </P>
       <Callout kind="warn" title="Publication stays human.">
         Hacker News exposes a supported read-only API, not a write API, and its guidelines prohibit
         generated or AI-edited comments. Genosyn therefore does not automate HN posts or comments.
-        An AI employee can package a link title, original-source URL, internal review notes, and
-        the submission checklist, but a human must review and publish it in Hacker News. Employees
-        must not draft or post HN comments.
+        An AI employee can package a link title, original-source URL, internal review notes, and the
+        submission checklist, but a human must review and publish it in Hacker News. Employees must
+        not draft or post HN comments.
       </Callout>
 
       <H2 id="grants-and-revocation">Grants & revocation</H2>
@@ -333,13 +333,12 @@ export function Integrations() {
         GitHub is special: a Connection holds a list of repos the employee is allowed to touch, and
         the runner materializes a git checkout of each allowed repo into{" "}
         <Code>data/companies/&lt;co&gt;/employees/&lt;emp&gt;/repos/...</Code> before each run. The
-        git token never lands on disk — it&apos;s read from the env var the runner injects, via a
-        repository-local inline credential helper. Because the helper does not contain an absolute
-        workspace path, it works the same way in the self-hosted runtime and the isolated SaaS
-        sandbox. A matching HTTPS Code Repository can reuse the same turn-scoped credential when the
-        Connection is granted to that employee. Genosyn prefers an exact owner/repository allowlist
-        match and can use the employee&apos;s sole GitHub Connection when no disambiguation is
-        needed, so ordinary git pushes do not need a second copy of the PAT.
+        git token exists only inside a short-lived server-owned clone or refresh operation. It is
+        never copied into the checkout, an environment variable visible to the AI employee, or a
+        reusable credential helper. A matching HTTPS Code Repository can reuse the same server-held
+        credential when the Connection is granted to that employee. Genosyn prefers an exact
+        owner/repository allowlist match and can use the employee&apos;s sole GitHub Connection when
+        no disambiguation is needed.
       </P>
 
       <H3 id="lightning-payments">Lightning payments</H3>

--- a/Home/client/docs/pages/Models.tsx
+++ b/Home/client/docs/pages/Models.tsx
@@ -162,8 +162,8 @@ export function Models() {
         the trust boundary of a self-hosted deployment.
       </Callout>
       <Callout kind="info" title="Subscription auth needs coding-tool isolation">
-        Genosyn requires working Linux bubblewrap for subscription auth. A same-user host shell from
-        any concurrent AI Employee could inspect the temporary Codex credential. Set{" "}
+        Genosyn requires working Linux bubblewrap for subscription auth. Host mode deliberately
+        omits bash because a same-user shell could inspect temporary credentials and Vault data. Set{" "}
         <Code>config.agent.codingTools.executionMode</Code> to <Code>bubblewrap</Code>; host and
         disabled modes are rejected. API-key models are unchanged.
       </Callout>
@@ -247,14 +247,14 @@ export function Models() {
       </P>
       <UL>
         <LI>
-          <Strong>Coding tools.</Strong> In host mode, <Code>bash</Code>, <Code>read_file</Code>,{" "}
+          <Strong>Coding tools.</Strong> In host mode, <Code>read_file</Code>,{" "}
           <Code>write_file</Code>, <Code>edit_file</Code>, <Code>list_dir</Code>, <Code>glob</Code>,
-          and <Code>grep</Code> are rooted at the employee directory; host shell processes are not
-          OS-sandboxed. In bubblewrap mode, every model receives only sandboxed <Code>bash</Code>{" "}
-          and performs file work through it. OpenAI subscription access requires working bubblewrap
-          mode. The dedicated file helpers cap full reads, writes, and edits at 400 KiB;{" "}
-          <Code>read_file</Code> can still stream a bounded line slice from a larger text file, and{" "}
-          <Code>bash</Code> handles larger generated artifacts.
+          and <Code>grep</Code> are confined to the employee directory; unrestricted host bash is
+          never exposed to an AI Employee. In bubblewrap mode, every model receives only sandboxed{" "}
+          <Code>bash</Code> and performs file work through it. OpenAI subscription access requires
+          working bubblewrap mode. The dedicated file helpers cap full reads, writes, and edits at
+          400 KiB; <Code>read_file</Code> can still stream a bounded line slice from a larger text
+          file, and <Code>bash</Code> handles larger generated artifacts.
         </LI>
         <LI>
           <Code>genosyn</Code> — the tools the employee calls to run Routines and Todos, write
@@ -307,10 +307,10 @@ export function Models() {
       <P>
         An employee can hold several models side by side — say an <Code>Anthropic</Code> key for
         everyday work and an <Code>OpenAI</Code> subscription model for a second opinion. Exactly
-        one is <Strong>active</Strong> at a time; the active model is the default brain for
-        employee Chat and the model inherited by Routines and other AI surfaces. The most recently
-        added model becomes active automatically — hit <Strong>Make active</Strong> on any other
-        to switch, instantly and as often as you like.
+        one is <Strong>active</Strong> at a time; the active model is the default brain for employee
+        Chat and the model inherited by Routines and other AI surfaces. The most recently added
+        model becomes active automatically — hit <Strong>Make active</Strong> on any other to
+        switch, instantly and as often as you like.
       </P>
       <P>
         Open an employee, then <Strong>Settings → Model</Strong> to see the roster: each card shows
@@ -337,8 +337,8 @@ export function Models() {
         so those turns do not use Genosyn&apos;s five-attempt loop or its retry transcript lines.
       </P>
       <P>
-        The error names the model used for that turn, shows the safe host-only endpoint, preserves the
-        provider&apos;s detail and request ID when available, and lists checks for that failure
+        The error names the model used for that turn, shows the safe host-only endpoint, preserves
+        the provider&apos;s detail and request ID when available, and lists checks for that failure
         type. In chat, use <Strong>Review AI Model settings</Strong> on the error to jump straight
         to the active employee&apos;s model roster. A separate{" "}
         <Strong>chat connection interrupted</Strong> message means the browser lost its stream to

--- a/Home/client/docs/pages/SelfHosting.tsx
+++ b/Home/client/docs/pages/SelfHosting.tsx
@@ -50,11 +50,13 @@ export function SelfHosting() {
   // HTTP port.
   port: 8471,
 
-  // 32+ random bytes. Rotate to log everyone out.
+  // Default self-host installs replace this placeholder with a durable,
+  // generated value under dataDir. An explicit 32+ character value wins.
   sessionSecret: "change-me-in-production",
 
   security: {
     multiTenant: false,
+    // Managed separately from the cookie secret on default self-host installs.
     encryptionSecret: "change-me-in-production-too",
     previousEncryptionSecrets: [],
     secureCookies: "auto",
@@ -103,21 +105,22 @@ export function SelfHosting() {
         other independent Routines for the same employee. Increase it only when your AI Model quotas
         and host capacity can support the extra parallel requests.
       </P>
-      <Callout kind="info" title="Coding tools require an isolated Linux deployment.">
-        Coding execution is disabled by default because a host shell shares the App process user and
-        can read outside an AI Employee&apos;s working directory. To enable coding tools or use
-        ChatGPT subscription auth, run Genosyn from source on Linux, set the mode to{" "}
-        <Code>bubblewrap</Code>, and confirm the model card reports that the isolation check passed.
-        The standard Docker installer does not currently relax Docker&apos;s namespace policy, so
-        subscription auth remains unavailable in that container; API-key and custom-endpoint models
-        continue to work normally. Do not make the App container privileged or disable its security
-        profile just to bypass the check.
+      <Callout kind="info" title="Subscription auth needs an isolated Linux deployment.">
+        Coding execution is disabled by default. Host mode can expose only the path-confined file and
+        search tools; it never gives an AI Employee an unrestricted shell that could read App data,
+        Vault keys, or sibling process tokens. To use sandboxed bash or ChatGPT subscription auth,
+        run Genosyn from source on Linux, set the mode to <Code>bubblewrap</Code>, and confirm the
+        model card reports that the isolation check passed. The standard Docker installer does not
+        currently relax Docker&apos;s namespace policy, so subscription auth remains unavailable in
+        that container; API-key and custom-endpoint models continue to work normally. Do not make
+        the App container privileged or disable its security profile just to bypass the check.
       </Callout>
       <Callout kind="warn" title="Host execution is an explicit unsafe compatibility mode.">
         A trusted, single-company operator can select <Code>host</Code> and separately set{" "}
-        <Code>allowUnsafeHostExecution: true</Code>. This gives every coding-enabled AI Employee the
-        App container&apos;s filesystem and network authority; never use it for multiple companies
-        or with untrusted Members, prompts, Skills, repositories, or content.
+        <Code>allowUnsafeHostExecution: true</Code> to let Genosyn&apos;s repository Git operations run
+        outside bubblewrap. AI Employees still receive no host shell, but those server-owned Git
+        children share the App process user&apos;s filesystem and network authority. Never use it for
+        multiple companies or with untrusted Members, prompts, Skills, repositories, or content.
       </Callout>
 
       <H2 id="public-url">Public URL</H2>
@@ -167,9 +170,13 @@ export function SelfHosting() {
       </P>
       <pre className="mt-4 overflow-x-auto rounded-xl border border-slate-200 bg-slate-50 px-5 py-4 font-mono text-[12.5px] leading-[1.7] text-slate-700">
         {`data/
+├── .instance-secrets.json
+├── .instance-secrets.required
+├── .private/
+│   ├── browser-state/<company-id>/<employee-id>.json
+│   └── code-repository-ssh/<company-id>/<employee-id>.known_hosts
 ├── app.sqlite
 └── companies/<co-slug>/employees/<emp-slug>/
-    ├── .browser-state.json
     ├── repos/
     ├── code-repos/
     └── ...`}
@@ -179,6 +186,16 @@ export function SelfHosting() {
         volume <Code>genosyn-data</Code> there — back that volume up and you&apos;ve backed up
         everything.
       </P>
+      <Callout kind="warn" title="Back up the managed instance secrets with the database">
+        When the stock placeholders remain, a default self-host install atomically creates strong,
+        distinct values in <Code>data/.instance-secrets.json</Code> with file mode <Code>0600</Code>
+        . Its non-secret <Code>.instance-secrets.required</Code> marker prevents a missing key from
+        being replaced silently, and the database stores a matching non-secret key ID so replacing
+        or losing both files stops startup. Keep the whole data directory together: losing the
+        secret file makes data encrypted with its managed key unreadable. Never expose its values in
+        logs, support bundles, employee working trees, or source control. Explicit strong values in{" "}
+        <Code>config.ts</Code> remain supported and take precedence.
+      </Callout>
 
       <H2 id="email">Email</H2>
       <P>
@@ -217,16 +234,20 @@ export function SelfHosting() {
         redacted from the stored preview.
       </P>
 
-      <H2 id="secrets">Secrets</H2>
-      <P>Three places store secrets, each for a different lifecycle:</P>
+      <H2 id="secrets">Secrets and the Password Vault</H2>
+      <P>
+        Genosyn stores several kinds of sensitive value, each with a different lifecycle. In
+        particular, environment Secrets and Password Vault items are separate products:
+      </P>
       <KeyList
         rows={[
           {
             term: "sessionSecret",
             def: (
               <>
-                In <Code>config.ts</Code>. Used to sign cookies. Rotating it invalidates every
-                session.
+                Used to sign cookies. Default self-host placeholders resolve to the managed
+                per-install value; an explicit strong <Code>config.ts</Code> value takes precedence.
+                Rotation invalidates every session.
               </>
             ),
           },
@@ -235,8 +256,8 @@ export function SelfHosting() {
             def: (
               <>
                 Master for scoped AES-256-GCM data-encryption keys. Rotate by moving the old value
-                into <Code>previousEncryptionSecrets</Code>
-                while new writes use the new value.
+                into <Code>previousEncryptionSecrets</Code> while new writes use the new value.
+                Default self-host placeholders resolve to the distinct managed encryption key.
               </>
             ),
           },
@@ -250,17 +271,30 @@ export function SelfHosting() {
             ),
           },
           {
-            term: "Secret entity",
+            term: "Environment Secret",
             def: (
               <>
-                Free-form encrypted key/value pairs scoped to a company, editable from{" "}
-                <Code>Settings → Secrets</Code>. Surfaced to Pipelines.
+                A <Code>Secret</Code> row is an encrypted key/value pair scoped to a company,
+                editable from <Code>Settings → Secrets</Code>. It is surfaced to coding-tool
+                environments and Pipelines by name. It has no human reveal flow or item-level AI
+                Employee Grant.
+              </>
+            ),
+          },
+          {
+            term: "Password Vault item",
+            def: (
+              <>
+                A separate encrypted <Code>VaultItem</Code> for a login, API key, or secure note,
+                managed from <Strong>Vault</Strong>. Member access and AI Employee Grants are set
+                per item; AI browser autofill uses the value server-side instead of injecting it
+                into an environment or returning it to the model. See{" "}
+                <DocLink to="/docs/vault">Vault</DocLink>.
               </>
             ),
           },
         ]}
       />
-
       <H2 id="admin">Admin &amp; instance health</H2>
       <P>
         Install-wide operations live under the <Code>Admin</Code> section (your avatar menu →{" "}
@@ -445,7 +479,8 @@ export function SelfHosting() {
       <H2 id="backups">Backups</H2>
       <P>
         A backup zips the <em>entire</em> data directory — every company&apos;s rows, uploads, and
-        credentials — so it is install-wide, not per company. Run one from the CLI:
+        credentials, including the hidden managed <Code>.instance-secrets.json</Code> file — so it
+        is install-wide, not per company. Run one from the CLI:
       </P>
       <Pre lang="bash">{`genosyn backup --out ~/backups/genosyn-$(date +%F).tar.gz
 genosyn restore ~/backups/genosyn-2026-04-22.tar.gz`}</Pre>
@@ -465,6 +500,13 @@ genosyn restore ~/backups/genosyn-2026-04-22.tar.gz`}</Pre>
         swept on the next start. Restoring also opens the archive before it touches anything, so a
         damaged file is refused up front rather than part-way through replacing your data.
       </P>
+      <Callout kind="warn" title="Treat every backup like the live Vault">
+        Every archive contains both encrypted credentials and the installation key that can decrypt
+        them, so it is a plaintext-equivalent secret bundle. Genosyn creates local in-app, mounted
+        path, and CLI archives with file mode <Code>0600</Code>, but you must still restrict who can
+        read, copy, or restore them. TLS or SSH protects a backup while it is moving; it does not
+        encrypt the archive after it reaches its destination.
+      </Callout>
 
       <H3 id="off-box-destinations">Off-box destinations (NAS / remote volumes)</H3>
       <P>

--- a/Home/client/docs/pages/ToolDiscovery.tsx
+++ b/Home/client/docs/pages/ToolDiscovery.tsx
@@ -36,9 +36,9 @@ export function ToolDiscovery() {
       </P>
       <UL>
         <LI>
-          <Strong>Coding tools</Strong> — <Code>bash</Code>, <Code>read_file</Code>,{" "}
-          <Code>write_file</Code> and the rest. Their arguments are large free-form strings, which
-          survive better sent directly.
+          <Strong>Coding tools</Strong> — the path-confined file/search tools in host mode, or
+          isolated <Code>bash</Code> in bubblewrap mode. Their arguments are large free-form
+          strings, which survive better sent directly.
         </LI>
         <LI>
           <Strong>Everything that writes</Strong> — creating a Routine, a Project, a Todo, a journal
@@ -59,8 +59,8 @@ export function ToolDiscovery() {
         workspace channels, handoffs, and every{" "}
         <DocLink to="/docs/integrations">Integration</DocLink> tool — lives in the catalogue. The
         employee calls <Code>find_tools</Code> with what it is trying to do (&quot;record a
-        payment&quot;, &quot;reply to that email&quot;, &quot;read a spreadsheet&quot;) and gets back
-        the matching tools with their exact arguments, then runs one.
+        payment&quot;, &quot;reply to that email&quot;, &quot;read a spreadsheet&quot;) and gets
+        back the matching tools with their exact arguments, then runs one.
       </P>
       <P>
         Every search result also carries the complete list of catalogue tool names. So even when a
@@ -71,8 +71,8 @@ export function ToolDiscovery() {
       <Callout kind="info" title="Grants are unchanged.">
         Discovery decides what an employee is <Strong>shown</Strong>, never what it is{" "}
         <Strong>allowed</Strong>. A tool the employee holds no Grant for is still refused when
-        called, and <Code>find_tools</Code> labels it as such before the employee wastes a step
-        on it.
+        called, and <Code>find_tools</Code> labels it as such before the employee wastes a step on
+        it.
       </Callout>
 
       <H2 id="skill-toolsets">Skipping the search</H2>

--- a/Home/client/docs/pages/Vault.tsx
+++ b/Home/client/docs/pages/Vault.tsx
@@ -1,0 +1,221 @@
+import {
+  Callout,
+  Code,
+  DocLink,
+  H2,
+  KeyList,
+  LI,
+  OL,
+  P,
+  PageHeader,
+  Strong,
+  UL,
+} from "@/docs/Prose";
+
+export function Vault() {
+  return (
+    <>
+      <PageHeader
+        eyebrow="Operations"
+        title="Vault"
+        lead={
+          <>
+            Keep company logins, API keys, and secure notes in one encrypted password manager for
+            Members and AI Employees. People can reveal a value when they need it; AI Employees use
+            credentials through governed server-side actions that keep plaintext out of model output
+            and Run transcripts.
+          </>
+        }
+      />
+
+      <Callout kind="info" title="The Vault is not Settings → Secrets">
+        Vault items are credentials people and AI Employees use deliberately, with access set on
+        each item. <Strong>Settings → Secrets</Strong> holds environment variables for coding tools
+        and Pipelines. Those values are injected by name and do not appear in the Vault. See{" "}
+        <DocLink to="/docs/self-hosting#secrets">Configuration</DocLink> for the full distinction.
+      </Callout>
+
+      <H2 id="add">Add a Vault item</H2>
+      <OL>
+        <LI>
+          Open <Strong>Vault</Strong> from the company navigation and choose{" "}
+          <Strong>Add item</Strong>.
+        </LI>
+        <LI>
+          Choose <Strong>Login</Strong>, <Strong>API key</Strong>, or <Strong>Secure note</Strong>.
+          Add a clear title and the fields that belong to that type. Login and API-key items can
+          also carry a website and private context.
+        </LI>
+        <LI>
+          For a login, paste an existing password or choose{" "}
+          <Strong>Generate strong password</Strong>. Copy a generated password before saving when
+          you also need to enter it somewhere outside Genosyn.
+        </LI>
+        <LI>
+          Choose whether every Member in the company may view the item or only selected Members may.
+          Save it, then open <Strong>Access</Strong> to add people or AI Employees.
+        </LI>
+      </OL>
+      <P>
+        The list and detail screens show the title, username, website, type, and private context
+        only to Members who can access the item. The stored password, API key, or secure-note body
+        stays masked until someone explicitly chooses <Strong>Reveal</Strong> or{" "}
+        <Strong>Copy</Strong>. Editing an item never loads the current stored value into the form;
+        leave the value blank to keep it, or enter a replacement to rotate it.
+      </P>
+
+      <H2 id="members">Member access</H2>
+      <P>
+        A Vault item has either <Strong>Everyone in the company</Strong> visibility or{" "}
+        <Strong>Only selected Members</Strong> visibility. Restricted items are absent from other
+        Members&apos; lists instead of advertising that a hidden credential exists. The creator and
+        company owners or admins can always manage sharing and deletion.
+      </P>
+      <KeyList
+        rows={[
+          {
+            term: "View",
+            def: "Open the item, read its encrypted metadata and private context, and deliberately reveal or copy the stored value.",
+          },
+          {
+            term: "Edit",
+            def: "Everything in View, plus change fields and replace the stored value. It does not confer sharing or deletion control.",
+          },
+        ]}
+      />
+      <P>
+        Company-wide visibility affects Members only. It never gives an AI Employee access. Every AI
+        Employee starts with no Vault access and needs a separate item-level Grant.
+      </P>
+
+      <H2 id="ai-access">AI Employee Grants</H2>
+      <P>
+        Open a Vault item&apos;s <Strong>Access</Strong> panel and add only the AI Employees that
+        need it. Grants are independent per item, so access to one GitHub login does not expose
+        another login or anything else in the company Vault.
+      </P>
+      <KeyList
+        rows={[
+          {
+            term: "Use",
+            def: (
+              <>
+                Discover safe item metadata. For a Login, use server-side Browser autofill for its
+                username or password without returning plaintext to the model. A stored password can
+                go only into a password input; API-key values and secure-note bodies have no AI
+                plaintext-read or Browser-fill path.
+              </>
+            ),
+          },
+          {
+            term: "Manage",
+            def: (
+              <>
+                Everything in Use, plus update a login&apos;s title, username, and private context.
+                The saved website origin cannot be rebound by an AI Employee. Manage also cannot
+                reveal, rotate, or delete the stored password. A login an employee creates receives
+                this level automatically.
+              </>
+            ),
+          },
+        ]}
+      />
+      <Callout kind="tip" title="Start with Use">
+        Use is enough for an employee that signs in to an existing account. Reserve Manage for an
+        employee expected to maintain the login&apos;s safe metadata, and remove the Grant when that
+        work is finished. Grant checks happen again at the moment of use, so revocation fails
+        closed.
+      </Callout>
+      <Callout kind="info" title="Host mode never exposes an unrestricted shell">
+        A working directory alone cannot contain a same-user shell: it could read the Vault
+        database, installation encryption key, or another Browser session. Genosyn therefore gives
+        host-mode AI Employees only path-confined file and search tools. Sandboxed <Code>bash</Code>{" "}
+        is available only in a working Linux bubblewrap deployment. This boundary applies even to an
+        employee with no Vault Grants.
+      </Callout>
+      <P>
+        With Manage, <Code>update_vault_login</Code> can change the title, username, or private
+        context while preserving both the encrypted password and saved website origin. Website
+        rebinding, password rotation, and deletion remain deliberate Member actions in the Vault.
+      </P>
+
+      <H2 id="browser">Sign in without showing the model a password</H2>
+      <P>
+        With the <DocLink to="/docs/browser">built-in Browser</DocLink> enabled, an AI Employee can
+        complete a login without asking a Member to paste a password into Chat:
+      </P>
+      <OL>
+        <LI>
+          <Code>list_vault_items</Code> returns only granted item ids and safe metadata. It never
+          returns the password, API key, or secure-note body.
+        </LI>
+        <LI>The employee opens the website saved on the login item.</LI>
+        <LI>
+          <Code>browser_fill_vault</Code> asks the App to resolve a granted username or password and
+          fill the selected field directly in App-owned Chromium. The top page and target frame must
+          both match the item&apos;s exact saved origin — scheme, host, and port. A password is
+          accepted only from a Login item and only into an input with <Code>type=password</Code>.
+        </LI>
+      </OL>
+      <P>
+        Browser access and the employee&apos;s host allow list remain independent gates: a Vault
+        Grant cannot enable the Browser or widen its browsing policy. The plaintext exists only at
+        the server-side credential-to-browser boundary. It is not serialized into the tool response,
+        model context, Run transcript, audit detail, or log. Captchas and 2FA can still use the
+        Browser&apos;s human take-over flow.
+      </P>
+      <P>
+        Browser snapshots redact password-input values, including values inside frames, before the
+        model sees them. After the session has observed or filled a password, model-requested
+        screenshots are refused; use the redacted structural snapshot instead.
+      </P>
+      <Callout kind="info" title="A Member session cannot become AI authority">
+        A Member session used inside App-owned Chromium is marked as an AI Browser request. The App
+        rejects every Genosyn API request from that browser, even when the stored cookies belong to
+        an owner or admin. This also prevents settings, API keys, invitations, and role changes from
+        becoming a route back to Vault authority. AI Employees must use their own item-level Grants
+        and <Code>browser_fill_vault</Code>.
+      </Callout>
+
+      <H2 id="create">Let an AI Employee create a login safely</H2>
+      <P>
+        AI Employees can store new credentials without first learning the password in model context.{" "}
+        <Code>create_vault_login</Code> generates a strong password inside Genosyn, encrypts it
+        immediately, creates a company-visible login, and gives the creating employee a Manage
+        Grant. Members can therefore recover the credential, while other AI Employees still receive
+        no access. The employee can then use <Code>browser_fill_vault</Code> to enter that generated
+        value into a signup or password-change form.
+      </P>
+      <P>
+        When a website or browser flow already put a password into an input,{" "}
+        <Code>browser_save_vault_login</Code> can request capture from a same-origin password input.
+        Capture always needs approval from a company owner or admin, even when ordinary Browser form
+        submissions do not require approval. Once approved, the App saves a restricted Vault item
+        bound to the exact current origin and gives the employee a Manage Grant. The password is not
+        read back or included in model output. Other Members do not see the restricted item until an
+        owner or admin changes its visibility or Member access.
+      </P>
+
+      <H2 id="audit">Reveal, copy, and audit</H2>
+      <P>
+        Revealing and copying are separate, explicit Member actions. Each one writes a company audit
+        event identifying the Member, Vault item, action, and time, without recording the secret
+        itself. Creating, updating, deleting, sharing, granting, and AI use are audited too. Review
+        the history under <Strong>Settings → Audit log</Strong> when investigating access or
+        rotating a credential.
+      </P>
+      <UL>
+        <LI>Do not paste a Vault value into Chat; Grant the item and use a governed action.</LI>
+        <LI>
+          Save the intended website origin on login items. Browser autofill requires the top page
+          and target frame to match its scheme, host, and port exactly.
+        </LI>
+        <LI>
+          Back up the whole data directory so the database and any managed instance-secret file stay
+          together. Rotating <Code>security.encryptionSecret</Code> follows the same key-ring
+          procedure as other encrypted company data.
+        </LI>
+      </UL>
+    </>
+  );
+}

--- a/Home/client/products/data.ts
+++ b/Home/client/products/data.ts
@@ -1446,15 +1446,15 @@ export const PRODUCTS: ProductDef[] = [
     tagline: "Give your AI a real checkout.",
     taglineAccent: "Any git repo, per-employee grants, ordinary git.",
     summary:
-      "Point at any git URL — GitHub, GitLab, Bitbucket, self-hosted — and grant chosen AI employees a live checkout with read or read-and-push rights.",
+      "Point at any git URL — GitHub, GitLab, Bitbucket, self-hosted — and grant chosen AI employees a live checkout for reference or local engineering work.",
     seoTitle: "Code Repositories — Git access for AI · Genosyn",
     description:
-      "Give AI employees real git checkouts of any repo — GitHub, GitLab, Bitbucket, or self-hosted — with per-employee read/push grants and encrypted credentials.",
+      "Give AI employees real git checkouts of any repo — GitHub, GitLab, Bitbucket, or self-hosted — with per-employee access and server-held encrypted credentials.",
     intro:
-      "Code Repositories make any git repo a first-class resource your AI employees can actually work on — not read through an API. Every granted employee gets a live checkout with credentials and committer identity pre-wired, so AI ships code the way human engineers do: branches, commits, and pushes your existing review pipeline already understands.",
+      "Code Repositories make any git repo a first-class resource your AI employees can actually work on — not read through an API. Every granted employee gets a live checkout and committer identity, while reusable repository credentials stay outside model-controlled tools. AI prepares branches and commits for a governed publish step.",
     checks: [
       "Any HTTPS or SSH clone URL",
-      "Read-only or read-and-push, per employee",
+      "Reference-only or local work, per employee",
       "Credentials AES-256-GCM encrypted",
       "Work survives between Runs",
     ],
@@ -1467,22 +1467,22 @@ export const PRODUCTS: ProductDef[] = [
       {
         icon: "keyRound",
         title: "Grants with teeth",
-        body: "Access is opt-in per employee at two levels. Read-and-push is the default; read-only disables the push URL on the checkout so a stray git push fails immediately, naming the missing grant.",
+        body: "Access is opt-in per employee at two levels. Work locally lets an employee prepare branches and commits; reference-only keeps publishing disabled. Neither level exposes a reusable credential to model tools.",
       },
       {
         icon: "shieldCheck",
         title: "Credentials handled right",
-        body: "Tokens and SSH keys encrypt at rest with AES-256-GCM. HTTPS tokens ride an env var and a credential helper — never on disk; SSH keys are written 0600 and pinned, without touching the operator's ~/.ssh.",
+        body: "Tokens and SSH keys encrypt at rest with AES-256-GCM, then exist only inside short-lived server-owned clone and refresh operations. They never enter the employee checkout, shell environment, or Git config.",
       },
       {
         icon: "folderGit2",
         title: "Checkouts that persist",
-        body: "Repos materialize into the employee's workspace before every chat and Routine Run, then only fetch between runs — never hard-reset. The branch an employee pushed yesterday is still there today.",
+        body: "Repos materialize into the employee's workspace before every chat and Routine Run, then only fetch between runs — never hard-reset. The branch an employee prepared yesterday is still there today.",
       },
       {
         icon: "terminal",
         title: "Ordinary git",
-        body: "No special git API. Employees use their built-in coding tools: checkout a branch, edit files, commit, push. Committer identity stamps AI commits, falling back to the employee's name.",
+        body: "No special editing API. Employees use built-in coding tools to checkout a branch, edit files, test, and commit. Committer identity stamps AI commits; a Member or governed action publishes them.",
       },
       {
         icon: "activity",
@@ -1492,11 +1492,11 @@ export const PRODUCTS: ProductDef[] = [
     ],
     employees: {
       heading: "AI engineers on your pipeline",
-      body: "Granted employees see a prompt-injected list of their repos, checkout paths, default branches, and push rights, plus a tool to enumerate them anytime. From there it's just engineering.",
+      body: "Granted employees see a prompt-injected list of their repos, checkout paths, default branches, and handoff policy, plus a tool to enumerate them anytime. From there it's just engineering.",
       bullets: [
         {
-          title: "Branch, commit, push",
-          body: "Work lands as branches and commits your review pipeline already understands — PRs, CI, and code review apply to AI work exactly as they do to human work.",
+          title: "Branch, test, commit",
+          body: "Work lands as local branches and commits your review pipeline already understands, ready for a Member or governed delivery flow to publish.",
         },
         {
           title: "No racing checkouts",
@@ -1515,15 +1515,15 @@ export const PRODUCTS: ProductDef[] = [
       },
       {
         q: "Can I control which AI employees can touch a repo?",
-        a: "Yes — access is opt-in per employee. Adding a repository exposes it to no one until you add employees and pick a level: read-and-push (the default) or read-only, where the push URL on the checkout is disabled so an accidental push fails fast.",
+        a: "Yes — access is opt-in per employee. Adding a repository exposes it to no AI employee until you grant access. Work locally authorizes a local deliverable; reference-only keeps publication disabled, and neither exposes repository credentials to model tools.",
       },
       {
         q: "How are my tokens and SSH keys stored?",
-        a: "Encrypted at rest with AES-256-GCM — the same protection as model API keys — and never shown back in plaintext. HTTPS tokens are handed to git at run time via an environment variable and a credential helper, so they never land on disk.",
+        a: "Encrypted at rest with AES-256-GCM — the same protection as model API keys — and never shown back in plaintext. They are decrypted only inside short-lived server-owned clone and refresh operations, never into model tools or employee workspaces.",
       },
       {
         q: "Will an employee's in-progress work get wiped between runs?",
-        a: "No. Existing checkouts are only fetched between runs, never hard-reset, and a per-employee, per-repo mutex stops concurrent runs racing on the same checkout. A branch pushed in one Run is still there the next time the employee starts.",
+        a: "No. Existing checkouts are only fetched between runs, never hard-reset, and a per-employee, per-repo mutex stops concurrent runs racing on the same checkout. A local branch prepared in one Run is still there the next time the employee starts.",
       },
       {
         q: "What happens if I delete a repository in Genosyn?",
@@ -1534,7 +1534,7 @@ export const PRODUCTS: ProductDef[] = [
     keywords: [
       "AI coding agent git access",
       "give AI agent access to git repo",
-      "AI employee commit and push code",
+      "AI employee edit and commit code",
       "self-hosted AI software engineer",
       "per-agent repository permissions",
       "read-only git access for AI agents",

--- a/Home/client/products/previews.tsx
+++ b/Home/client/products/previews.tsx
@@ -554,8 +554,8 @@ function NotesPreview() {
         <div className="p-5 md:col-span-2">
           <div className="text-lg font-semibold text-slate-950">🚨 Incident runbook</div>
           <div className="mt-1 text-[11px] text-slate-400">
-            Last edited by <span className="font-medium text-slate-600">Sam (AI)</span> · 2 hours ago
-            · audit-logged
+            Last edited by <span className="font-medium text-slate-600">Sam (AI)</span> · 2 hours
+            ago · audit-logged
           </div>
           <div className="mt-4 space-y-2.5 text-[12.5px] leading-relaxed text-slate-700">
             <div className="font-semibold text-slate-900">## First five minutes</div>
@@ -1316,17 +1316,17 @@ function CodePreview() {
             {[
               {
                 name: "api-server",
-                grant: "read & push",
+                grant: "work locally",
                 tone: "bg-emerald-50 text-emerald-700 ring-emerald-200",
               },
               {
                 name: "marketing-site",
-                grant: "read & push",
+                grant: "work locally",
                 tone: "bg-emerald-50 text-emerald-700 ring-emerald-200",
               },
               {
                 name: "infra",
-                grant: "read only",
+                grant: "reference only",
                 tone: "bg-slate-100 text-slate-600 ring-slate-200",
               },
             ].map((r) => (
@@ -1360,8 +1360,8 @@ function CodePreview() {
             <div className="text-slate-500">
               [fix/rate-limit-headers 3f2a91c] 2 files changed, 18 insertions(+)
             </div>
-            <div className="text-slate-400">$ git push -u origin fix/rate-limit-headers</div>
-            <div className="text-emerald-400">✓ pushed — PR ready for human review</div>
+            <div className="text-slate-400">$ git status --short --branch</div>
+            <div className="text-emerald-400">✓ local commit ready for governed publishing</div>
           </div>
           <div className="mt-3 flex items-center gap-2 text-[11px] text-slate-500">
             <GitCommitHorizontal className="h-3.5 w-3.5" />

--- a/Home/client/public/genosyn
+++ b/Home/client/public/genosyn
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-CLI_VERSION="0.4.3"
+CLI_VERSION="0.4.4"
 
 PORT="${GENOSYN_PORT:-8471}"
 NAME="${GENOSYN_NAME:-genosyn}"
@@ -397,12 +397,13 @@ backup_volume_to() {
     -v "${VOLUME}:/data:ro" \
     -v "${out_dir}:/backup" \
     alpine:3.20 \
-    sh -c 'cd /data && tar -czf "/backup/$1" . && { chown "$2:$3" "/backup/$1" 2>/dev/null || true; }' \
+    sh -c 'umask 077; rm -f "/backup/$1"; cd /data && tar -czf "/backup/$1" . && chmod 0600 "/backup/$1" && { chown "$2:$3" "/backup/$1" 2>/dev/null || true; }' \
     sh "${out_base}" "${owner_uid}" "${owner_gid}" >/dev/null; then
     return 1
   fi
 
   [ -s "${out}" ] || return 1
+  chmod 0600 "${out}" || return 1
   docker run --rm \
     -v "${out_dir}:/backup:ro" \
     alpine:3.20 \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -176,7 +176,9 @@ genosyn/
   `MailLabel`, `MailRule`, `MailHandover`, `MailChatMessage`,
   `EmployeeMailAccountGrant`
 - **Backups:** `Backup`, `BackupSchedule`, `BackupDestination`
-- **Secrets:** `Secret`
+- **Environment secrets:** `Secret`
+- **Password Vault (M37):** `VaultItem`, `VaultItemMemberAccess`,
+  `EmployeeVaultGrant`
 - **Organization:** `Tag`, `TagAssignment` (company-scoped labels attached to
   taggable resources)
 - **Revenue (M32):** `Contact`, `DealStage`, `Deal`, `DealContact`, `Activity`,
@@ -806,9 +808,9 @@ sends system mail); this is the company's real inbox. Internal namespace is
 - [x] `services/repoSync.ts` materializes git checkouts under
       `<employeeDir>/repos/<owner>/<name>/` before each spawn; per-employee+
       connection mutex; fetch-only on existing checkouts (won't trample WIP)
-- [x] Per-connection git credential helper (`.git/genosyn-cred.sh`) reads
-      from `GENOSYN_GH_TOKEN_<connId>` env var the runner sets at spawn time
-      — token never lands on disk
+- [x] GitHub tokens stay inside short-lived server-owned clone/fetch
+      operations. Checkouts contain no reusable helper, token, or credentialed
+      push path, so model tools cannot export the Connection credential
 - [x] `create_pull_request` MCP tool on the github provider
 - [x] Settings → Integrations UI for GitHub repo allowlist editing
 - [x] Workspace tree shows materialized `repos/` subtree
@@ -822,7 +824,7 @@ Provider-agnostic cousin of M12. Where M12's repos ride on a GitHub
 **Connection** + allowlist, a **Code Repository** is a first-class
 company row pointed at _any_ git URL (GitHub, GitLab, Bitbucket,
 self-hosted) over HTTPS or SSH, with access handed out per-employee.
-"Add any repo; let the employees you choose commit and push."
+"Add any repo; let the employees you choose work in a real checkout."
 
 - [x] `CodeRepository` entity — companyId, name, slug, gitUrl,
       defaultBranch, authMode (`none` | `https` | `ssh`), httpsUsername,
@@ -830,33 +832,32 @@ self-hosted) over HTTPS or SSH, with access handed out per-employee.
       committer identity, last-sync health. Credentials never returned to
       the client in plaintext.
 - [x] `EmployeeCodeRepositoryGrant` — employee → repo with `read` < `write`
-      (write = commit + push). Default `write`; sharing is fully opt-in
-      (no auto-grant-to-all).
+      (write records delivery authority; both levels keep credentials out of
+      the model shell). Default `write`; sharing is fully opt-in.
 - [x] `services/codeRepos.ts` — `materializeCodeReposForEmployee` clones
       each granted repo into `<employeeDir>/code-repos/<slug>/` before every
       chat / routine spawn; per-(employee × repo) mutex; fetch-only on
-      existing checkouts. HTTPS token rides a per-repo env var +
-      credential-helper (never on disk); SSH key written 0600 + pinned via
-      `core.sshCommand`. Read-only grants get the push URL disabled.
+      existing checkouts. HTTPS tokens and SSH keys exist only in a
+      short-lived server-owned Git workspace; no reusable credential, private
+      key, or credentialed push path enters the employee checkout.
       HTTPS GitHub repos without a separately stored token reuse the same
       employee's granted GitHub Connection: exact owner/repo allowlist match
       first, or the employee's sole GitHub Connection when unambiguous. The
-      turn-scoped PAT is available to both materializer fetches and the
-      employee's ordinary git push commands.
+      PAT is available only to the server materializer.
       `testCodeRepoConnection` probes creds via `git ls-remote --symref`.
 - [x] HTTP routes under `/api/companies/:cid/code-repositories`: CRUD,
       `/test`, grant CRUD + candidates. zod-validated.
-- [x] Prompt context — granted repos + their checkout paths + push rights
-      injected into the chat / routine prompt; `list_code_repositories` MCP
+- [x] Prompt context — granted repos + their checkout paths and local delivery
+      policy injected into the chat / routine prompt; `list_code_repositories` MCP
       tool on the built-in `genosyn` server.
 - [x] React UI under `/c/<co>/code`: index (list + add modal), detail
       split into sidebar-addressable Overview, AI access, and Settings pages
       (connection health, per-employee PR readiness, credentials, delete).
       New "Code" section under an Engineering group in the app shell.
 - [x] Code-delivery guidance — repository context tells employees to branch,
-      edit, test, commit, push, then call the granted GitHub
-      `create_pull_request` tool; the UI shows which write-granted employees
-      have that tool through a connected GitHub Connection.
+      edit, test, and commit locally, then report the branch and commit for a
+      governed server-side or Member publish step. Connection credentials are
+      never made available to model-controlled Git.
 - [ ] Worktree-per-routine isolation (shared with M12; deferred)
 - [ ] Browse the checkout in a web file tree (deferred — agents use it on
       disk today)
@@ -1690,6 +1691,67 @@ Employee workflow in one company-scoped system.
       multi-signer field ownership obvious with recipient-specific colors and
       names, support direct pointer, touch and keyboard field resizing, and send
       clear company-branded invitation, reminder and completion emails.
+
+### M37 — AI-native Vault ✅
+
+Treat credentials as governed company resources, not prompt text. The Password
+Vault is deliberately separate from the existing `Secret` environment-variable
+store: Members use Vault items explicitly, while AI Employees receive
+item-level Grants and pass plaintext only across narrow server-side action
+boundaries.
+
+- [x] **Dedicated Vault data model.** `VaultItem` stores a company-scoped
+      login, API key, or secure note with `company | restricted` visibility and
+      human/AI creator attribution. Title, username, secret, website URL, and
+      private notes live together in one scoped AES-256-GCM payload rather than
+      plaintext metadata columns. `Secret` remains the separate environment
+      Secrets entity used by coding tools and Pipelines.
+- [x] **Member password manager.** A first-class responsive `/vault` surface
+      supports search and type filters, strong-password generation, create,
+      inspect, edit/rotate and delete flows, plus explicit reveal and copy.
+      Editing never loads the existing secret into the form.
+- [x] **Human item access.** `VaultItemMemberAccess` adds `view < edit` to
+      restricted items. Company-visible items are viewable by all Members;
+      restricted items are undiscoverable without access. The creator and
+      company owners/admins manage visibility, sharing and deletion.
+- [x] **Default-deny AI Grants.** `EmployeeVaultGrant` adds item-level
+      `use < manage`. Company visibility never implies AI access, safe
+      discovery returns only granted metadata, and every sensitive use
+      re-checks the live Grant so revocation fails closed. Manage permits safe
+      login-metadata maintenance while preserving the saved website origin;
+      it never permits website rebinding, plaintext read, password rotation or
+      deletion.
+- [x] **Server-side browser use.** `list_vault_items` returns no password,
+      API-key value, or secure-note body. `browser_fill_vault` resolves one
+      granted username or Login password inside the App and fills App-owned
+      Chromium only when both the top page and target frame match the saved
+      website origin exactly (scheme, host and port). A stored password can go
+      only into an input with `type=password`; API-key and secure-note values
+      have no Browser-fill sink. Browser enablement and the host allow list are
+      intersected with the Vault checks, so a Grant cannot widen Browser policy.
+      Password-input values are redacted from model snapshots, and screenshots
+      are refused after the session observes or fills a password;
+      plaintext never enters model output, Run transcripts, audit detail, or
+      logs. Host-mode AI Employees receive only path-confined file/search tools;
+      unrestricted `bash` is available only behind the bubblewrap boundary, so
+      a zero-Grant employee cannot bypass Vault policy through the App filesystem
+      or sibling process tokens.
+- [x] **AI-native login creation and capture.** `create_vault_login` generates
+      and encrypts a strong password server-side in a company-visible item.
+      `browser_save_vault_login` requests mandatory company-owner/admin approval
+      before capturing a same-origin password input into a restricted item bound
+      to the exact current origin. Both paths return no secret and atomically
+      give the creating AI Employee a `manage` Grant; every other AI Employee
+      remains denied, and a captured restricted item stays hidden from ordinary
+      Members until its human access is changed.
+- [x] **Audit, docs and tests.** Human reveal and copy are separate audit
+      events with no secret content; item, sharing, Grant and AI-use mutations
+      retain actor evidence. Dedicated `/docs/vault` guidance distinguishes
+      Password Vault items from environment Secrets and documents Browser
+      autofill/capture. Automated service, route, tool-policy and browser
+      coverage exercises tenancy, access levels, revocation, encryption,
+      exact-origin/frame binding, password-only sinks, approval, redaction and
+      plaintext non-disclosure.
 
 ### M33 — AI-native accounting
 


### PR DESCRIPTION
Milestone: M37 — AI-native Vault

## Summary
- Add an encrypted Vault for Logins, API keys, and secure notes.
- Give Members explicit View/Edit access and AI Employees item-level Use/Manage Grants.
- Add server-side Browser autofill and approved login capture without placing passwords in model context.
- Add SQLite and Postgres migrations, operator-safe managed encryption keys, docs, and release hardening.

## Security
- Default deny for every AI Employee and every Vault item.
- Exact-origin, password-input-only autofill with live Grant and Browser policy checks.
- One-use human-approved capture, model-visible redaction, viewer authorization, and API-key/browser privilege boundaries.
- Independent post-rebase audit found no unresolved Vault or credential P0/P1 blockers; 201 focused security regressions passed.

## Validation
- App lint and typecheck passed; production build passed.
- App full suite: 2,229 of 2,229 tests passed across 358 suites.
- Home lint, typecheck, build, and 56-page prerender passed.
- CLI syntax and 80 of 80 tests passed.
- Fresh production SQLite boot applied all 127 migrations once; Vault is migration head and all three Vault tables exist.
- Real-browser production smoke passed: signup, company creation, AI Employee hire, Login generation, reveal/hide, explicit AI Use Grant, and persistence after reload.