### PR TITLE
Close the shared-SaaS boundaries before a hosted launch

### DIFF
--- a/App/server/db/datasource.ts
+++ b/App/server/db/datasource.ts
@@ -471,7 +471,83 @@ export async function initDb(): Promise<void> {
     // run just below never fan out.
     AppDataSource.subscribers.push(new ResourceChangeSubscriber());
   }
-  // Run any pending migrations on boot. Idempotent -- already-run migrations
-  // are tracked in the `migrations` table that TypeORM manages.
-  await AppDataSource.runMigrations();
+  await runMigrationsExclusively();
+}
+
+/**
+ * Advisory-lock keys for the boot migration. `classid` spells "GENO"
+ * (0x47454E4F) so a `pg_locks` row is recognisably ours; `objid` 1 is the
+ * migration lock specifically, leaving the rest of the space for later needs.
+ */
+export const MIGRATION_LOCK_CLASS_ID = 0x47454e4f;
+export const MIGRATION_LOCK_OBJECT_ID = 1;
+
+/**
+ * How long a replica waits for a peer's migration before giving up.
+ *
+ * Generous, because a real migration on a large table legitimately takes
+ * minutes and killing it halfway is far worse than waiting. Bounded, because a
+ * lock held by a pod that died without releasing its session must eventually
+ * fail the boot loudly — Kubernetes then restarts and retries — rather than
+ * hang forever behind a liveness probe that never fires.
+ */
+export const MIGRATION_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Run pending migrations under a Postgres advisory lock.
+ *
+ * `runMigrations()` reads the `migrations` table, decides what is missing, and
+ * applies it — with no lock between the read and the write. One pod is fine.
+ * Several pods starting together (a RollingUpdate, a scaled Deployment, a
+ * cluster restart) each read "nothing applied" and race the same DDL: the
+ * losers crash on `relation already exists`, and with `failureThreshold: 6` on
+ * the liveness probe that turns into a slow, partial rollout rather than an
+ * obvious failure.
+ *
+ * The lock is session-scoped and taken on a dedicated QueryRunner, so it is
+ * held for exactly the span of the migration and released even if the pool
+ * hands `runMigrations` a different connection. A crashed holder releases it
+ * when Postgres reaps the backend, which is the property a row-in-a-table
+ * lock would not have given us.
+ *
+ * SQLite is single-process by construction and has no advisory locks, so it
+ * keeps the direct call.
+ */
+export async function runMigrationsExclusively(): Promise<void> {
+  if (AppDataSource.options.type !== "postgres") {
+    // Idempotent -- already-run migrations are tracked in the `migrations`
+    // table that TypeORM manages.
+    await AppDataSource.runMigrations();
+    return;
+  }
+
+  const runner = AppDataSource.createQueryRunner();
+  let held = false;
+  try {
+    await runner.connect();
+    // Applies to advisory-lock waits too, so the acquire below fails rather
+    // than blocking boot indefinitely behind a wedged peer.
+    await runner.query(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT_MS}`);
+    await runner.query("SELECT pg_advisory_lock($1, $2)", [
+      MIGRATION_LOCK_CLASS_ID,
+      MIGRATION_LOCK_OBJECT_ID,
+    ]);
+    held = true;
+    await AppDataSource.runMigrations();
+  } finally {
+    if (held) {
+      try {
+        await runner.query("SELECT pg_advisory_unlock($1, $2)", [
+          MIGRATION_LOCK_CLASS_ID,
+          MIGRATION_LOCK_OBJECT_ID,
+        ]);
+      } catch (error) {
+        // Releasing the session below drops the lock anyway; failing here
+        // must not mask whatever the migration itself threw.
+        // eslint-disable-next-line no-console
+        console.error("[db] failed to release the migration advisory lock:", error);
+      }
+    }
+    await runner.release();
+  }
 }

--- a/App/server/db/migrationLock.test.ts
+++ b/App/server/db/migrationLock.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, beforeEach, describe, test } from "node:test";
+
+import { closeTestDb, initTestDb, resetTestDb } from "../test/dbHarness.js";
+import {
+  AppDataSource,
+  MIGRATION_LOCK_CLASS_ID,
+  MIGRATION_LOCK_OBJECT_ID,
+  MIGRATION_LOCK_TIMEOUT_MS,
+  runMigrationsExclusively,
+} from "./datasource.js";
+
+/**
+ * Boot migrations are mutually exclusive across replicas.
+ *
+ * `runMigrations()` reads the `migrations` table, decides what is missing, and
+ * applies it, with no lock between the read and the write. One pod is fine.
+ * Several starting together — a RollingUpdate, a scaled Deployment, a cluster
+ * restart — each read "nothing applied" and race the same DDL; the losers
+ * crash on `relation already exists`, and `failureThreshold: 6` on the
+ * liveness probe turns that into a slow partial rollout rather than an obvious
+ * failure.
+ *
+ * There is no Postgres in this suite, so the driver is stubbed and the
+ * assertions are about the *sequence*: what is issued, in what order, and that
+ * the lock is released on both the happy and the failing path. Those are the
+ * properties a real server would not check any better.
+ */
+
+type Issued = { sql: string; params?: unknown[] };
+
+let issued: Issued[];
+let released: number;
+let migrationsRun: number;
+let originalType: string;
+const originalCreateQueryRunner = AppDataSource.createQueryRunner.bind(AppDataSource);
+const originalRunMigrations = AppDataSource.runMigrations.bind(AppDataSource);
+
+before(initTestDb);
+after(closeTestDb);
+
+beforeEach(async () => {
+  await resetTestDb();
+  issued = [];
+  released = 0;
+  migrationsRun = 0;
+  originalType = AppDataSource.options.type;
+});
+
+afterEach(() => {
+  (AppDataSource.options as { type: string }).type = originalType;
+  AppDataSource.createQueryRunner = originalCreateQueryRunner;
+  AppDataSource.runMigrations = originalRunMigrations;
+});
+
+/** Pretend to be Postgres, recording every statement the lock path issues. */
+function stubPostgres(options: { failMigration?: boolean; failUnlock?: boolean } = {}) {
+  (AppDataSource.options as { type: string }).type = "postgres";
+  AppDataSource.createQueryRunner = (() => ({
+    connect: async () => undefined,
+    query: async (sql: string, params?: unknown[]) => {
+      issued.push({ sql, params });
+      if (options.failUnlock && sql.includes("pg_advisory_unlock")) {
+        throw new Error("unlock exploded");
+      }
+      return [];
+    },
+    release: async () => {
+      released += 1;
+    },
+  })) as never;
+  AppDataSource.runMigrations = (async () => {
+    migrationsRun += 1;
+    if (options.failMigration) throw new Error("migration exploded");
+    return [];
+  }) as never;
+}
+
+describe("lock identity", () => {
+  test('classid spells "GENO" so a pg_locks row is recognisable', () => {
+    assert.equal(MIGRATION_LOCK_CLASS_ID, 0x47454e4f);
+    assert.equal(
+      Buffer.from(MIGRATION_LOCK_CLASS_ID.toString(16), "hex").toString("ascii"),
+      "GENO",
+    );
+  });
+
+  test("the keys are stable constants", () => {
+    // A rolling upgrade runs two builds at once. If a release changed either
+    // key, the old and new pods would take *different* locks and neither would
+    // exclude the other — which is the exact failure this lock exists to
+    // prevent, reintroduced silently. Changing these is a breaking change.
+    assert.equal(MIGRATION_LOCK_CLASS_ID, 1195724367);
+    assert.equal(MIGRATION_LOCK_OBJECT_ID, 1);
+  });
+
+  test("both keys fit in the int4 pair pg_advisory_lock takes", () => {
+    for (const key of [MIGRATION_LOCK_CLASS_ID, MIGRATION_LOCK_OBJECT_ID]) {
+      assert.ok(Number.isInteger(key));
+      assert.ok(key >= -(2 ** 31) && key <= 2 ** 31 - 1, `${key} out of int4 range`);
+    }
+  });
+
+  test("the wait is generous but bounded", () => {
+    // Long enough that a real migration on a large table is not killed
+    // halfway; short enough that a lock orphaned by a dead backend eventually
+    // fails the boot loudly instead of hanging behind a probe that never fires.
+    assert.ok(MIGRATION_LOCK_TIMEOUT_MS >= 60_000);
+    assert.ok(MIGRATION_LOCK_TIMEOUT_MS <= 30 * 60_000);
+  });
+});
+
+describe("postgres path", () => {
+  test("takes the lock, migrates, then releases", async () => {
+    stubPostgres();
+    await runMigrationsExclusively();
+    const sql = issued.map((i) => i.sql);
+    assert.match(sql[0], /SET lock_timeout/);
+    assert.match(sql[1], /pg_advisory_lock/);
+    assert.match(sql[2], /pg_advisory_unlock/);
+    assert.equal(migrationsRun, 1);
+    assert.equal(released, 1);
+  });
+
+  test("the lock is taken before migrations run, not after", async () => {
+    const order: string[] = [];
+    (AppDataSource.options as { type: string }).type = "postgres";
+    AppDataSource.createQueryRunner = (() => ({
+      connect: async () => undefined,
+      query: async (sql: string) => {
+        if (sql.includes("pg_advisory_lock")) order.push("lock");
+        if (sql.includes("pg_advisory_unlock")) order.push("unlock");
+        return [];
+      },
+      release: async () => order.push("release"),
+    })) as never;
+    AppDataSource.runMigrations = (async () => {
+      order.push("migrate");
+      return [];
+    }) as never;
+
+    await runMigrationsExclusively();
+    assert.deepEqual(order, ["lock", "migrate", "unlock", "release"]);
+  });
+
+  test("passes both key halves as parameters, never interpolated", async () => {
+    stubPostgres();
+    await runMigrationsExclusively();
+    const lock = issued.find((i) => i.sql.includes("pg_advisory_lock"));
+    assert.deepEqual(lock?.params, [MIGRATION_LOCK_CLASS_ID, MIGRATION_LOCK_OBJECT_ID]);
+    assert.match(String(lock?.sql), /\$1, \$2/);
+  });
+
+  test("unlocks with the same keys it locked with", async () => {
+    stubPostgres();
+    await runMigrationsExclusively();
+    const lock = issued.find((i) => i.sql.includes("pg_advisory_lock"));
+    const unlock = issued.find((i) => i.sql.includes("pg_advisory_unlock"));
+    assert.deepEqual(unlock?.params, lock?.params);
+  });
+
+  test("sets the wait bound before attempting to acquire", async () => {
+    stubPostgres();
+    await runMigrationsExclusively();
+    const timeoutIndex = issued.findIndex((i) => i.sql.includes("lock_timeout"));
+    const lockIndex = issued.findIndex((i) => i.sql.includes("pg_advisory_lock"));
+    assert.ok(timeoutIndex >= 0 && timeoutIndex < lockIndex);
+    assert.match(issued[timeoutIndex].sql, new RegExp(String(MIGRATION_LOCK_TIMEOUT_MS)));
+  });
+
+  test("a failing migration still releases the lock and the connection", async () => {
+    stubPostgres({ failMigration: true });
+    await assert.rejects(() => runMigrationsExclusively(), /migration exploded/);
+    assert.ok(
+      issued.some((i) => i.sql.includes("pg_advisory_unlock")),
+      "the lock must not be leaked when a migration throws",
+    );
+    assert.equal(released, 1);
+  });
+
+  test("a failing unlock does not mask the migration error", async () => {
+    stubPostgres({ failMigration: true, failUnlock: true });
+    await assert.rejects(() => runMigrationsExclusively(), /migration exploded/);
+    assert.equal(released, 1, "the connection is released even when unlock throws");
+  });
+
+  test("a failing unlock on the happy path does not fail the boot", async () => {
+    stubPostgres({ failUnlock: true });
+    // Releasing the session drops the lock anyway, so this must not be fatal.
+    await assert.doesNotReject(() => runMigrationsExclusively());
+    assert.equal(released, 1);
+  });
+});
+
+describe("sqlite path", () => {
+  test("migrates directly, with no advisory lock", async () => {
+    let ran = 0;
+    AppDataSource.runMigrations = (async () => {
+      ran += 1;
+      return [];
+    }) as never;
+    AppDataSource.createQueryRunner = (() => {
+      throw new Error("sqlite must not open a query runner for locking");
+    }) as never;
+
+    await runMigrationsExclusively();
+    assert.equal(ran, 1);
+  });
+
+  test("the real in-memory database runs it without incident", async () => {
+    // No stubs at all: the harness's own DataSource, which is what every
+    // other test file boots against.
+    await assert.doesNotReject(() => runMigrationsExclusively());
+  });
+});

--- a/App/server/index.ts
+++ b/App/server/index.ts
@@ -25,7 +25,7 @@ import { finalizeInterruptedAssistantTurns } from "./services/mail/assistant.js"
 import { finalizeInterruptedAssistantTurns as finalizeInterruptedRoutineAssistantTurns } from "./services/routineAssistant.js";
 import { finalizeInterruptedTldrQuestionTurns } from "./services/tldrQuestions.js";
 import { attachRealtime, bootRealtimeBridge } from "./services/realtime.js";
-import { errorHandler } from "./middleware/error.js";
+import { errorHandler, installProcessErrorHandlers } from "./middleware/error.js";
 import { authRouter } from "./routes/auth.js";
 import { ssoRouter } from "./routes/sso.js";
 import { companySsoAuthRouter } from "./routes/companySsoAuth.js";
@@ -120,6 +120,7 @@ import { backfillLegacyResourceTags, backfillTagColors } from "./services/tags.j
 import { billingRouter } from "./routes/billing.js";
 import { billingWebhookRouter } from "./routes/billingWebhook.js";
 import { requireTrustedOrigin, securityHeaders } from "./middleware/httpSecurity.js";
+import { loopbackOnly } from "./middleware/loopbackOnly.js";
 import { appVersion } from "./lib/version.js";
 import {
   resolveCodingExecutionMode,
@@ -141,6 +142,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function main() {
+  // First, so nothing that follows can print a raw error object. Node's
+  // default handler would dump the whole thing — bound SQL parameters and all
+  // — and log retention makes that unfixable after the fact.
+  installProcessErrorHandlers();
   // Resolve or create durable self-host secrets before migrations, timers or
   // any other subsystem can observe placeholder credentials.
   getEffectiveInstanceSecrets();
@@ -325,12 +330,12 @@ async function main() {
   // every AI employee. Auth is a short-lived Bearer token we issued moments
   // earlier — session-less on purpose, but mounted before the session router
   // anyway so no cookie state leaks into these requests.
-  app.use("/api/internal/mcp", mcpInternalRouter);
+  app.use("/api/internal/mcp", loopbackOnly, mcpInternalRouter);
 
   // Built-in browser-tool RPC. The (now stripped down) `browser` MCP child
   // posts every tool call here; the App owns Chromium so it persists
   // across MCP child spawns / chat turns.
-  app.use("/api/internal/browser/sessions/:id", browserRpcRouter);
+  app.use("/api/internal/browser/sessions/:id", loopbackOnly, browserRpcRouter);
 
   // Public OpenAPI document + Swagger UI. Mounted before the session router
   // so the docs page works for unauthenticated visitors — the spec describes

--- a/App/server/lib/outboundUrl.test.ts
+++ b/App/server/lib/outboundUrl.test.ts
@@ -237,3 +237,49 @@ test("safe fetch can refuse every redirect before replaying a POST", async () =>
     assert.equal(calls, 1, String(status));
   }
 });
+
+/**
+ * IPv6 literals in a URL.
+ *
+ * `new URL("http://[::1]").hostname` is `"[::1]"` — brackets included — and
+ * `net.isIP` does not recognise that form. Before the brackets were stripped,
+ * every IPv6 literal missed the literal branch entirely and fell through to
+ * `dns.lookup("[::1]")`. That failed closed, so nothing unsafe was ever
+ * reachable, but it failed with `ENOTFOUND` instead of the real reason, and it
+ * refused public IPv6 literals with equal enthusiasm.
+ */
+test("a bracketed IPv6 loopback is refused as non-public, not as a DNS failure", async () => {
+  await assert.rejects(
+    () => assertSafeOutboundUrl("http://[::1]/"),
+    /non-public address \(::1\)/,
+  );
+});
+
+test("bracketed IPv6 private ranges are refused for the right reason", async () => {
+  for (const address of ["fc00::1", "fe80::1", "::", "2001:db8::1", "::ffff:127.0.0.1"]) {
+    await assert.rejects(
+      () => assertSafeOutboundUrl(`http://[${address}]/`),
+      /resolves to a non-public address/,
+      `${address} should be refused as non-public`,
+    );
+  }
+});
+
+test("a bracketed public IPv6 literal is allowed without DNS", async () => {
+  const url = await assertSafeOutboundUrl("http://[2606:4700:4700::1111]/");
+  assert.equal(url.hostname, "[2606:4700:4700::1111]");
+});
+
+test("a bracketed IPv6 literal with a port is still classified as a literal", async () => {
+  const url = await assertSafeOutboundUrl("http://[2606:4700:4700::1111]:587/");
+  assert.equal(url.port, "587");
+});
+
+test("IPv4 literals are unaffected by the bracket handling", async () => {
+  await assert.rejects(
+    () => assertSafeOutboundUrl("http://127.0.0.1/"),
+    /non-public address \(127\.0\.0\.1\)/,
+  );
+  const ok = await assertSafeOutboundUrl("http://8.8.8.8/");
+  assert.equal(ok.hostname, "8.8.8.8");
+});

--- a/App/server/lib/outboundUrl.ts
+++ b/App/server/lib/outboundUrl.ts
@@ -117,9 +117,19 @@ export async function assertSafeOutboundUrl(input: string | URL): Promise<URL> {
   }
   if (privateHostAllowed(url.hostname)) return url;
 
-  const literalKind = net.isIP(url.hostname);
+  // WHATWG `hostname` keeps the brackets on an IPv6 literal ("[::1]"), which
+  // `net.isIP` does not recognise. Without stripping them every IPv6 literal
+  // fell through to a DNS lookup of a bracketed string: it failed closed, so
+  // nothing unsafe was ever reachable, but it failed with `ENOTFOUND` rather
+  // than the real reason — and it refused *public* IPv6 literals just as
+  // indiscriminately.
+  const literalHost =
+    url.hostname.startsWith("[") && url.hostname.endsWith("]")
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
+  const literalKind = net.isIP(literalHost);
   const addresses = literalKind
-    ? [{ address: url.hostname, family: literalKind }]
+    ? [{ address: literalHost, family: literalKind }]
     : await dns.lookup(url.hostname, { all: true, verbatim: true });
   if (addresses.length === 0) throw new Error("Outbound hostname did not resolve");
   const blocked = addresses.find((entry) => !isPublicIp(entry.address));
@@ -127,6 +137,26 @@ export async function assertSafeOutboundUrl(input: string | URL): Promise<URL> {
     throw new Error(`Outbound URL resolves to a non-public address (${blocked.address})`);
   }
   return url;
+}
+
+/**
+ * Resolve a bare hostname and refuse every non-public answer.
+ *
+ * For destinations that are not URLs at all — an SMTP or IMAP endpoint, which
+ * is a host and a port reached over a raw TCP socket. Those never pass through
+ * the patched HTTP agents, so this is the only thing standing between a
+ * tenant-supplied hostname and the operator's private network.
+ *
+ * Accepts `host`, `host:port` and `[::1]:993`; the port is discarded, since
+ * callers police their own port policy.
+ */
+export async function assertPublicOutboundHost(host: string): Promise<void> {
+  const trimmed = host.trim();
+  if (!trimmed) throw new Error("A hostname is required");
+  const bare = trimmed.startsWith("[")
+    ? trimmed.slice(0, trimmed.indexOf("]") + 1)
+    : trimmed.replace(/:\d+$/, "");
+  await assertSafeOutboundUrl(`http://${bare}`);
 }
 
 /** Validate URL/host-shaped values in an Integration connection form. */

--- a/App/server/middleware/error.ts
+++ b/App/server/middleware/error.ts
@@ -1,8 +1,127 @@
 import { Request, Response, NextFunction } from "express";
 
-export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+/**
+ * What may be written to the operator log when a request fails.
+ *
+ * `console.error("[error]", err)` printed the whole object, and TypeORM's
+ * `QueryFailedError` carries `query` and `parameters` as own enumerable
+ * properties — so every failed INSERT or UPDATE exported its bound values.
+ * Those values are the row being written: chat text, a mail body, a Soul, a
+ * customer's name. On a hosted install stdout goes to an aggregator with its
+ * own retention, outside any tenant's deletion request, which makes this the
+ * one leak on the list that cannot be fixed after the fact — you cannot
+ * un-export logs you already shipped.
+ *
+ * The projection keeps what an on-call engineer actually uses: the error's
+ * name, its message, the status, the stack, and — for a query failure — the
+ * parameterized SQL, which names the table and the columns without carrying a
+ * single value. `parameters` never appears.
+ */
+export type RedactedError = {
+  name: string;
+  message: string;
+  stack?: string;
+  status?: number;
+  code?: string;
+  /** Parameterized SQL only. The bound values are deliberately dropped. */
+  query?: string;
+  /** Present when the original carried a `cause`, redacted the same way. */
+  cause?: RedactedError;
+};
+
+const MAX_MESSAGE = 2_000;
+const MAX_STACK = 8_000;
+const MAX_QUERY = 2_000;
+
+function clamp(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}… (truncated)` : value;
+}
+
+function readString(source: Record<string, unknown>, key: string): string | undefined {
+  const value = source[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+/**
+ * Project any thrown value onto {@link RedactedError}.
+ *
+ * Deliberately allowlist-shaped: it reads the fields it names and nothing
+ * else, so a driver error that grows a new value-bearing property in a future
+ * release does not silently start being logged.
+ */
+export function redactErrorForLog(err: unknown, depth = 0): RedactedError {
+  if (typeof err === "string") {
+    return { name: "Error", message: clamp(err, MAX_MESSAGE) };
+  }
+  if (!err || typeof err !== "object") {
+    return { name: "Error", message: clamp(String(err), MAX_MESSAGE) };
+  }
+
+  const source = err as Record<string, unknown>;
+  const redacted: RedactedError = {
+    name: readString(source, "name") ?? "Error",
+    message: clamp(readString(source, "message") ?? "", MAX_MESSAGE),
+  };
+
+  const stack = readString(source, "stack");
+  if (stack) redacted.stack = clamp(stack, MAX_STACK);
+
+  const status = source["status"];
+  if (typeof status === "number" && Number.isInteger(status)) redacted.status = status;
+
+  const code = source["code"];
+  if (typeof code === "string" && code) redacted.code = code;
+  else if (typeof code === "number") redacted.code = String(code);
+
+  // TypeORM's QueryFailedError. The SQL is parameterized, so it identifies the
+  // statement without carrying the row; `parameters` is the row and is never
+  // read here.
+  const query = readString(source, "query");
+  if (query) redacted.query = clamp(query, MAX_QUERY);
+
+  // One level only. A cause chain is almost always driver-wrapping-driver, and
+  // walking it without a bound is how a cyclic `cause` takes the process down
+  // inside the handler that exists to keep it alive.
+  if (depth === 0 && source["cause"]) {
+    redacted.cause = redactErrorForLog(source["cause"], depth + 1);
+  }
+
+  return redacted;
+}
+
+/** The single place an error reaches the operator log. */
+export function logRedactedError(label: string, err: unknown): void {
   // eslint-disable-next-line no-console
-  console.error("[error]", err);
+  console.error(label, redactErrorForLog(err));
+}
+
+/**
+ * Catch what escapes every request. Without these Node prints the raw error —
+ * the exact object {@link redactErrorForLog} exists to keep out of the log —
+ * and then, for an uncaught exception, exits.
+ *
+ * Registered once from `index.ts`. Idempotent so a test importing the module
+ * twice does not stack listeners.
+ */
+let processHandlersInstalled = false;
+export function installProcessErrorHandlers(): void {
+  if (processHandlersInstalled) return;
+  processHandlersInstalled = true;
+  process.on("unhandledRejection", (reason) => {
+    logRedactedError("[unhandledRejection]", reason);
+  });
+  process.on("uncaughtException", (err) => {
+    logRedactedError("[uncaughtException]", err);
+    // Node's default for an uncaught exception is to exit, and staying up on a
+    // corrupted process is worse than restarting: the pod restarts, in-flight
+    // work is recovered by the lease sweeps, and the operator sees the crash.
+    // The only change here is that the log line on the way out is redacted.
+    process.exit(1);
+  });
+}
+
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+  logRedactedError("[error]", err);
   const candidateStatus =
     err && typeof err === "object" && "status" in err && typeof err.status === "number"
       ? err.status

--- a/App/server/middleware/errorRedaction.test.ts
+++ b/App/server/middleware/errorRedaction.test.ts
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import { AppDataSource } from "../db/datasource.js";
+import { User } from "../db/entities/User.js";
+import { closeTestDb, initTestDb, insert, resetTestDb, testId } from "../test/dbHarness.js";
+import { errorHandler, logRedactedError, redactErrorForLog } from "./error.js";
+
+/**
+ * Tenant content must never reach the operator log.
+ *
+ * The handler used to be `console.error("[error]", err)` on the whole object.
+ * TypeORM's `QueryFailedError` carries `query` and `parameters` as own
+ * enumerable properties, and Node prints them — so every failed INSERT or
+ * UPDATE exported its bound values: the chat message, the mail body, the Soul,
+ * the customer's name. On a hosted install stdout goes to an aggregator with
+ * its own retention, outside any tenant's deletion request. That makes it the
+ * one item on the hardening list that cannot be fixed after the fact, which is
+ * why the projection is an allowlist rather than a denylist: a driver error
+ * that grows a new value-bearing property in some future release does not
+ * silently start being logged.
+ */
+
+const SECRET = "sk-live-do-not-log-this-value";
+
+before(initTestDb);
+beforeEach(resetTestDb);
+after(closeTestDb);
+
+/** Capture what the module actually writes, not what we hope it writes. */
+function captureConsoleError<T>(fn: () => T): { result: T; written: string } {
+  const original = console.error;
+  const chunks: string[] = [];
+  // eslint-disable-next-line no-console
+  console.error = (...args: unknown[]) => {
+    chunks.push(args.map((a) => JSON.stringify(a) ?? String(a)).join(" "));
+  };
+  try {
+    const result = fn();
+    return { result, written: chunks.join("\n") };
+  } finally {
+    // eslint-disable-next-line no-console
+    console.error = original;
+  }
+}
+
+describe("redactErrorForLog — the projection", () => {
+  test("keeps the fields an on-call engineer actually uses", () => {
+    const err = Object.assign(new Error("boom"), { status: 503, code: "ECONNRESET" });
+    const out = redactErrorForLog(err);
+    assert.equal(out.name, "Error");
+    assert.equal(out.message, "boom");
+    assert.equal(out.status, 503);
+    assert.equal(out.code, "ECONNRESET");
+    assert.ok(out.stack?.includes("boom"));
+  });
+
+  test("drops bound query parameters", () => {
+    const err = Object.assign(new Error("insert failed"), {
+      name: "QueryFailedError",
+      query: 'INSERT INTO "users"("email") VALUES ($1)',
+      parameters: [SECRET],
+    });
+    const out = redactErrorForLog(err);
+    assert.equal(out.query, 'INSERT INTO "users"("email") VALUES ($1)');
+    assert.equal(JSON.stringify(out).includes(SECRET), false);
+    assert.equal("parameters" in out, false);
+  });
+
+  test("keeps the SQL, because the statement is not the row", () => {
+    const err = Object.assign(new Error("x"), {
+      query: 'UPDATE "channel_messages" SET "content" = $1 WHERE "id" = $2',
+      parameters: ["a private message", "id_1"],
+    });
+    const out = redactErrorForLog(err);
+    assert.match(String(out.query), /channel_messages/);
+    assert.equal(String(JSON.stringify(out)).includes("a private message"), false);
+  });
+
+  test("ignores every property it was not told about", () => {
+    const err = Object.assign(new Error("x"), {
+      // The shape a future driver release might add.
+      values: [SECRET],
+      row: { email: SECRET },
+      detail: `Key (email)=(${SECRET}) already exists`,
+      parameters: [SECRET],
+      driverError: { parameters: [SECRET] },
+    });
+    const out = redactErrorForLog(err);
+    assert.equal(JSON.stringify(out).includes(SECRET), false);
+  });
+
+  test("redacts a cause the same way", () => {
+    const inner = Object.assign(new Error("inner"), { parameters: [SECRET] });
+    const outer = Object.assign(new Error("outer"), { cause: inner });
+    const out = redactErrorForLog(outer);
+    assert.equal(out.cause?.message, "inner");
+    assert.equal(JSON.stringify(out).includes(SECRET), false);
+  });
+
+  test("does not walk a cause chain forever", () => {
+    const a: Record<string, unknown> = { name: "A", message: "a" };
+    const b: Record<string, unknown> = { name: "B", message: "b", cause: a };
+    a.cause = b;
+    const out = redactErrorForLog(b);
+    assert.equal(out.cause?.name, "A");
+    assert.equal(out.cause?.cause, undefined);
+  });
+
+  test("survives a self-referential error object", () => {
+    const err: Record<string, unknown> = { name: "Cyclic", message: "loop" };
+    err.self = err;
+    err.cause = err;
+    const out = redactErrorForLog(err);
+    assert.equal(out.name, "Cyclic");
+    assert.doesNotThrow(() => JSON.stringify(out));
+  });
+
+  test("truncates a huge message rather than shipping it whole", () => {
+    const err = new Error("x".repeat(50_000));
+    const out = redactErrorForLog(err);
+    assert.ok(out.message.length < 3_000);
+    assert.match(out.message, /truncated/);
+  });
+
+  test("truncates a huge query", () => {
+    const err = Object.assign(new Error("x"), { query: "SELECT ".repeat(10_000) });
+    const out = redactErrorForLog(err);
+    assert.ok(String(out.query).length < 3_000);
+  });
+
+  test("handles a thrown string", () => {
+    const out = redactErrorForLog("just a string");
+    assert.equal(out.message, "just a string");
+    assert.equal(out.name, "Error");
+  });
+
+  test("handles thrown null and undefined", () => {
+    assert.equal(redactErrorForLog(null).message, "null");
+    assert.equal(redactErrorForLog(undefined).message, "undefined");
+  });
+
+  test("handles a thrown number", () => {
+    assert.equal(redactErrorForLog(42).message, "42");
+  });
+
+  test("a numeric code is normalised to a string", () => {
+    const out = redactErrorForLog(Object.assign(new Error("x"), { code: 1062 }));
+    assert.equal(out.code, "1062");
+  });
+
+  test("a non-integer status is dropped rather than logged as-is", () => {
+    const out = redactErrorForLog(Object.assign(new Error("x"), { status: 4.5 }));
+    assert.equal(out.status, undefined);
+  });
+});
+
+describe("redactErrorForLog — against a real TypeORM error", () => {
+  /**
+   * The whole fix rests on one claim about a third-party object: that
+   * `QueryFailedError` exposes `parameters` as an own enumerable property and
+   * that Node therefore prints it. This provokes a genuine one rather than
+   * asserting against a hand-built lookalike, so an upgrade that changes the
+   * shape fails here instead of silently in production.
+   */
+  test("a genuine QueryFailedError carries the row, and the projection drops it", async () => {
+    const users = AppDataSource.getRepository(User);
+    const email = `${SECRET}@example.com`;
+    await insert(User, {
+      id: testId("usr"),
+      email,
+      name: "First",
+      passwordHash: "x",
+    } as never);
+
+    let caught: unknown = null;
+    try {
+      // Same email a second time: `users.email` is unique.
+      await users.insert({
+        id: testId("usr"),
+        email,
+        name: "Second",
+        passwordHash: "x",
+      } as never);
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught, "expected the duplicate insert to fail");
+
+    // The premise: the raw object really would have leaked the address.
+    const rawDump = JSON.stringify(caught, Object.getOwnPropertyNames(caught));
+    assert.ok(
+      rawDump.includes(SECRET),
+      "premise failed — the raw error no longer carries the row, so re-read this fix",
+    );
+
+    // The fix: the projection does not.
+    const out = redactErrorForLog(caught);
+    assert.equal(JSON.stringify(out).includes(SECRET), false);
+  });
+
+  test("what is actually written to the console carries no row values", async () => {
+    const users = AppDataSource.getRepository(User);
+    const email = `${SECRET}@example.com`;
+    await insert(User, {
+      id: testId("usr"),
+      email,
+      name: "First",
+      passwordHash: "x",
+    } as never);
+    let caught: unknown = null;
+    try {
+      await users.insert({
+        id: testId("usr"),
+        email,
+        name: "Second",
+        passwordHash: "x",
+      } as never);
+    } catch (err) {
+      caught = err;
+    }
+
+    const { written } = captureConsoleError(() => logRedactedError("[error]", caught));
+    assert.ok(written.length > 0, "expected something to be logged");
+    assert.equal(written.includes(SECRET), false);
+  });
+});
+
+describe("errorHandler", () => {
+  function invoke(err: unknown) {
+    let status: number | null = null;
+    let body: unknown = null;
+    const res = {
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        body = payload;
+        return this;
+      },
+    } as never;
+    const { written } = captureConsoleError(() =>
+      errorHandler(err, {} as never, res, (() => {}) as never),
+    );
+    return { status, body, written };
+  }
+
+  test("still logs, and still answers the request", () => {
+    const out = invoke(new Error("boom"));
+    assert.equal(out.status, 500);
+    assert.deepEqual(out.body, { error: "Internal server error" });
+    assert.ok(out.written.includes("[error]"));
+  });
+
+  test("a 4xx keeps its message, as before", () => {
+    const out = invoke(Object.assign(new Error("Bad input"), { status: 400 }));
+    assert.equal(out.status, 400);
+    assert.deepEqual(out.body, { error: "Bad input" });
+  });
+
+  test("a query failure answers generically and logs no parameters", () => {
+    const out = invoke(
+      Object.assign(new Error("insert failed"), {
+        name: "QueryFailedError",
+        query: "INSERT INTO x VALUES ($1)",
+        parameters: [SECRET],
+      }),
+    );
+    assert.equal(out.status, 500);
+    assert.deepEqual(out.body, { error: "Internal server error" });
+    assert.equal(out.written.includes(SECRET), false);
+    assert.ok(out.written.includes("INSERT INTO x"));
+  });
+
+  test("an out-of-range status falls back to 500", () => {
+    assert.equal(invoke(Object.assign(new Error("x"), { status: 999 })).status, 500);
+    assert.equal(invoke(Object.assign(new Error("x"), { status: 99 })).status, 500);
+  });
+});

--- a/App/server/middleware/loopbackOnly.test.ts
+++ b/App/server/middleware/loopbackOnly.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { after, before, describe, test } from "node:test";
+
+import express from "express";
+
+import { isLoopbackAddress, loopbackOnly } from "./loopbackOnly.js";
+
+/**
+ * `/api/internal/*` may only be reached from this machine.
+ *
+ * Both internal routers mount above `requireTrustedOrigin` and above the
+ * session middleware — correctly, because their callers are machines holding a
+ * bearer token rather than browsers holding a cookie. What was missing is the
+ * other half: nothing checked that the machine was one we spawned. The Helm
+ * ingress publishes `/` with `pathType: Prefix`, so on a hosted install the
+ * full AI-Employee tool surface (send mail, create and delete Routines, write
+ * Bases) was reachable from the public internet behind a seven-hour in-memory
+ * token with no throttling.
+ *
+ * Two independent conditions have to hold, and the second is the one that is
+ * easy to miss: the socket must be loopback, AND the request must not carry
+ * proxy headers. A reverse proxy sharing the host satisfies the first while
+ * relaying something from anywhere, which is exactly the topology that would
+ * otherwise smuggle a public request in as a local one.
+ */
+
+describe("isLoopbackAddress", () => {
+  const loopback = [
+    "127.0.0.1",
+    "127.0.0.53",
+    "127.255.255.254",
+    "::1",
+    "::ffff:127.0.0.1",
+    "::FFFF:127.0.0.1",
+    "::ffff:127.1.2.3",
+    "::1%lo0",
+  ];
+  for (const address of loopback) {
+    test(`accepts ${address}`, () => {
+      assert.equal(isLoopbackAddress(address), true);
+    });
+  }
+
+  const remote = [
+    "10.0.0.1",
+    "192.168.1.10",
+    "172.16.5.4",
+    "8.8.8.8",
+    "169.254.169.254",
+    "0.0.0.0",
+    "::",
+    "fe80::1",
+    "2001:db8::1",
+    "::ffff:10.0.0.1",
+    "::ffff:169.254.169.254",
+    "128.0.0.1",
+    "27.0.0.1",
+  ];
+  for (const address of remote) {
+    test(`rejects ${address}`, () => {
+      assert.equal(isLoopbackAddress(address), false);
+    });
+  }
+
+  const malformed = ["", "localhost", "not-an-ip", "127.0.0.1.1", "999.0.0.1", "127.0.0"];
+  for (const address of malformed) {
+    test(`rejects the unparseable ${JSON.stringify(address)}`, () => {
+      assert.equal(isLoopbackAddress(address), false);
+    });
+  }
+
+  test("rejects undefined rather than failing open", () => {
+    assert.equal(isLoopbackAddress(undefined), false);
+  });
+
+  test("does not accept a hostname that merely starts with 127", () => {
+    // "127.0.0.1.example.com" is a real DNS-rebinding trick; it is not an IP,
+    // so `net.isIP` refuses it and the prefix check is never reached.
+    assert.equal(isLoopbackAddress("127.0.0.1.example.com"), false);
+  });
+});
+
+describe("loopbackOnly over a real socket", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  before(async () => {
+    const app = express();
+    app.use("/api/internal/mcp", loopbackOnly, (_req, res) => {
+      res.json({ reached: true });
+    });
+    // A control route with no guard, so a failing assertion below cannot be
+    // explained by the test server simply being broken.
+    app.use("/api/open", (_req, res) => res.json({ reached: true }));
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", resolve);
+    });
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  test("a genuine loopback call passes through", async () => {
+    const res = await fetch(`${baseUrl}/api/internal/mcp`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { reached: true });
+  });
+
+  test("the control route is reachable, proving the harness works", async () => {
+    const res = await fetch(`${baseUrl}/api/open`);
+    assert.equal(res.status, 200);
+  });
+
+  const forwardedHeaders = [
+    ["x-forwarded-for", "203.0.113.9"],
+    ["x-forwarded-host", "genosyn.example.com"],
+    ["x-forwarded-proto", "https"],
+    ["x-real-ip", "203.0.113.9"],
+    ["forwarded", "for=203.0.113.9;proto=https"],
+  ] as const;
+
+  for (const [header, value] of forwardedHeaders) {
+    test(`a loopback socket carrying ${header} is refused`, async () => {
+      const res = await fetch(`${baseUrl}/api/internal/mcp`, {
+        headers: { [header]: value },
+      });
+      assert.equal(res.status, 404);
+    });
+  }
+
+  test("a forwarded header is refused even when it claims to come from loopback", async () => {
+    // The header's *value* is never trusted — its presence is what decides.
+    // Otherwise spoofing `X-Forwarded-For: 127.0.0.1` would be the bypass.
+    const res = await fetch(`${baseUrl}/api/internal/mcp`, {
+      headers: { "x-forwarded-for": "127.0.0.1" },
+    });
+    assert.equal(res.status, 404);
+  });
+
+  test("the refusal does not confirm the surface exists", async () => {
+    const res = await fetch(`${baseUrl}/api/internal/mcp`, {
+      headers: { "x-forwarded-for": "203.0.113.9" },
+    });
+    assert.equal(res.status, 404);
+    assert.deepEqual(await res.json(), { error: "Not found" });
+  });
+
+  test("refusal applies to every method, not just GET", async () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const res = await fetch(`${baseUrl}/api/internal/mcp`, {
+        method,
+        headers: { "x-forwarded-for": "203.0.113.9" },
+      });
+      assert.equal(res.status, 404, `${method} should be refused`);
+    }
+  });
+});
+
+describe("loopbackOnly unit contract", () => {
+  function call(remoteAddress: string | undefined, headers: Record<string, string> = {}) {
+    let nexted = false;
+    let status: number | null = null;
+    let body: unknown = null;
+    const req = { socket: { remoteAddress }, headers } as never;
+    const res = {
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        body = payload;
+        return this;
+      },
+    } as never;
+    loopbackOnly(req, res, () => {
+      nexted = true;
+    });
+    return { nexted, status, body };
+  }
+
+  test("a remote socket is refused even with no headers at all", () => {
+    const result = call("203.0.113.9");
+    assert.equal(result.nexted, false);
+    assert.equal(result.status, 404);
+  });
+
+  test("a missing socket address fails closed", () => {
+    const result = call(undefined);
+    assert.equal(result.nexted, false);
+    assert.equal(result.status, 404);
+  });
+
+  test("a loopback socket with clean headers is allowed", () => {
+    const result = call("127.0.0.1");
+    assert.equal(result.nexted, true);
+    assert.equal(result.status, null);
+  });
+
+  test("header matching is case-insensitive, as Node lowercases them", () => {
+    // Express/Node normalise incoming header names to lowercase, so the guard
+    // reads lowercase keys. This pins that assumption.
+    const result = call("127.0.0.1", { "x-forwarded-for": "1.2.3.4" });
+    assert.equal(result.nexted, false);
+  });
+
+  test("an empty forwarded header still counts as relayed", () => {
+    // A proxy that sets the header to an empty string has still relayed.
+    const result = call("127.0.0.1", { "x-forwarded-for": "" });
+    assert.equal(result.nexted, false);
+  });
+
+  test("an unrelated header does not trip the guard", () => {
+    const result = call("127.0.0.1", { authorization: "Bearer x", "user-agent": "genosyn" });
+    assert.equal(result.nexted, true);
+  });
+});

--- a/App/server/middleware/loopbackOnly.ts
+++ b/App/server/middleware/loopbackOnly.ts
@@ -1,0 +1,63 @@
+import { NextFunction, Request, Response } from "express";
+import net from "node:net";
+
+/**
+ * Refuse anything that did not arrive on the loopback interface.
+ *
+ * `/api/internal/*` is the AI Employee tool surface — send mail, create and
+ * delete Routines, write Bases — and its only credential is a bearer token
+ * held in this process's memory. Both routers mount above
+ * `requireTrustedOrigin` and above the session middleware, deliberately, so a
+ * session-less machine caller is not gated on a cookie or an `Origin` header.
+ * What was missing is the other half of that trade: nothing checked that the
+ * caller was actually the machine we spawned.
+ *
+ * It is reachable today. The Helm ingress publishes `/` with `pathType:
+ * Prefix`, so a hosted install forwards `/api/internal/...` from the public
+ * internet to a router whose token has a seven-hour TTL, no `Origin` gate, no
+ * session versioning, and no throttling.
+ *
+ * Every legitimate caller is loopback by construction — `protocol.ts`,
+ * `genosyn.ts`, `taintPolicy.ts` and `mcpSources.ts` all build
+ * `http://127.0.0.1:${config.port}`, and the browser MCP child is a sibling
+ * process on the same host — so this costs nothing and closes the door.
+ */
+
+/** Loopback in every encoding Node hands us, including IPv4-mapped IPv6. */
+export function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  // Node reports the scope on link-local addresses ("fe80::1%lo0"); loopback
+  // never needs one, but strip it before parsing rather than fail open.
+  const cleaned = address.replace(/%.*$/, "");
+  const mapped = cleaned.match(/^::ffff:(.+)$/i);
+  const candidate = mapped ? mapped[1] : cleaned;
+  const kind = net.isIP(candidate);
+  if (kind === 4) return candidate.startsWith("127.");
+  if (kind === 6) return candidate === "::1";
+  return false;
+}
+
+/**
+ * Headers a reverse proxy adds. Their presence means the request was relayed,
+ * which is decisive even when the socket itself is loopback: a proxy sharing
+ * the host is exactly the topology that would otherwise smuggle a public
+ * request in as a local one.
+ */
+const FORWARDED_HEADERS = [
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-real-ip",
+  "forwarded",
+];
+
+export function loopbackOnly(req: Request, res: Response, next: NextFunction) {
+  const relayed = FORWARDED_HEADERS.some((header) => req.headers[header] !== undefined);
+  if (relayed || !isLoopbackAddress(req.socket?.remoteAddress ?? undefined)) {
+    // 404 rather than 403: an internal surface should not confirm it exists to
+    // a caller that cannot reach it anyway.
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+  next();
+}

--- a/App/server/routes/emailProviders.ts
+++ b/App/server/routes/emailProviders.ts
@@ -10,6 +10,7 @@ import { validateBody } from "../middleware/validate.js";
 import { recordAudit } from "../services/audit.js";
 import { decryptProviderConfig, sendTestEmail } from "../services/email.js";
 import { buildProviderCatalog } from "../services/emailTransports.js";
+import { normalizeEmail } from "../lib/emailAddress.js";
 import {
   createProvider,
   deleteProvider,
@@ -45,6 +46,33 @@ emailProvidersRouter.use(requireCompanyRoleForMutations("admin"));
 const KIND_VALUES = ["smtp", "sendgrid", "mailgun", "resend", "postmark"] as const;
 const kindSchema = z.enum(KIND_VALUES);
 
+/**
+ * A From address, with the two things `min(3).max(254)` let through.
+ *
+ * A bare CR or LF here is header injection: nodemailer writes this value into
+ * the SMTP dialogue, so a newline lets the author append a `Bcc:` header or a
+ * second message body. `normalizeEmail` alone does not close it — for the
+ * `Display Name <a@b.com>` form it extracts the bracketed address and
+ * validates only that, so a newline hiding in the display name survives. Hence
+ * both checks: no control characters anywhere in the raw value, and the whole
+ * value must still parse as an address.
+ *
+ * `normalizeEmail` rather than `z.string().email()` because the display-name
+ * form is one real installs use, and Zod's email refuses it.
+ */
+export const fromAddressSchema = z
+  .string()
+  .min(3)
+  .max(254)
+  // eslint-disable-next-line no-control-regex
+  .refine((v) => !/[\u0000-\u001f\u007f]/.test(v), {
+    message: "From address must not contain line breaks or control characters",
+  })
+  .refine((v) => normalizeEmail(v) !== null, {
+    message: 'From address must be an email address, optionally as "Name <you@example.com>"',
+  });
+
+
 emailProvidersRouter.get("/catalog", async (_req, res, next) => {
   // Now does a DB read (global-SMTP prefill); forward failures to the error
   // middleware rather than leaving the request hanging on a rejected promise.
@@ -64,7 +92,7 @@ emailProvidersRouter.get("/", async (req, res) => {
 const createSchema = z.object({
   name: z.string().min(1).max(120),
   kind: kindSchema,
-  fromAddress: z.string().min(3).max(254),
+  fromAddress: fromAddressSchema,
   replyTo: z.string().max(254).optional(),
   rawConfig: z.record(z.union([z.string(), z.number(), z.boolean()])),
   isDefault: z.boolean().optional(),
@@ -103,7 +131,7 @@ emailProvidersRouter.post("/", validateBody(createSchema), async (req, res) => {
 const patchSchema = z
   .object({
     name: z.string().min(1).max(120).optional(),
-    fromAddress: z.string().min(3).max(254).optional(),
+    fromAddress: fromAddressSchema.optional(),
     replyTo: z.string().max(254).optional(),
     rawConfig: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
     isDefault: z.boolean().optional(),
@@ -213,7 +241,7 @@ emailProvidersRouter.post("/:pid/test", validateBody(testSavedSchema), async (re
 
 const testInlineSchema = z.object({
   kind: kindSchema,
-  fromAddress: z.string().min(3).max(254),
+  fromAddress: fromAddressSchema,
   replyTo: z.string().max(254).optional(),
   rawConfig: z.record(z.union([z.string(), z.number(), z.boolean()])),
   to: z.string().email(),

--- a/App/server/routes/fromAddress.test.ts
+++ b/App/server/routes/fromAddress.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { fromAddressSchema } from "./emailProviders.js";
+
+/**
+ * The From address a company configures is written into the SMTP dialogue.
+ *
+ * `z.string().min(3).max(254)` accepted a newline, and a newline here is
+ * header injection: the author appends `Bcc:` and gets a silent copy of every
+ * transactional email the company sends, or terminates the headers and writes
+ * their own body. It also accepted values that are not addresses at all, which
+ * previously surfaced only as a provider error at send time.
+ *
+ * The two refinements are not redundant. `normalizeEmail` validates the
+ * *extracted* address, so for `Display Name <a@b.com>` it never inspects the
+ * display name — a newline hiding there would survive it. The control
+ * character check is what catches that, and the test below pins it.
+ */
+
+const ok = (value: string) => fromAddressSchema.safeParse(value).success;
+const why = (value: string) =>
+  fromAddressSchema
+    .safeParse(value)
+    .error?.issues.map((i) => i.message)
+    .join(" ") ?? "";
+
+describe("accepts the shapes real installs use", () => {
+  const accepted = [
+    "no-reply@example.com",
+    "No Reply <no-reply@example.com>",
+    '"Reply, No" <no-reply@example.com>',
+    "<no-reply@example.com>",
+    "billing+invoices@sub.example.co.uk",
+    "  no-reply@example.com  ",
+    "NoReply@Example.COM",
+  ];
+  for (const value of accepted) {
+    test(JSON.stringify(value), () => {
+      assert.equal(ok(value), true, why(value));
+    });
+  }
+});
+
+describe("refuses header injection", () => {
+  const injections: Array<[string, string]> = [
+    ["CRLF then a Bcc header", "a@b.com\r\nBcc: victim@example.com"],
+    ["bare LF then a Bcc header", "a@b.com\nBcc: victim@example.com"],
+    ["a trailing CR", "a@b.com\r"],
+    ["a trailing LF", "a@b.com\n"],
+    ["a leading CRLF", "\r\na@b.com"],
+    ["a NUL byte", `a@b.com${String.fromCharCode(0)}`],
+    ["an ANSI escape", `a@b.com${String.fromCharCode(27)}[31m`],
+    ["a DEL byte", `a@b.com${String.fromCharCode(127)}`],
+    ["a vertical tab", `a@b.com${String.fromCharCode(11)}`],
+    ["a tab", "a@b.com\t"],
+  ];
+  for (const [label, value] of injections) {
+    test(label, () => {
+      assert.equal(ok(value), false, `${JSON.stringify(value)} should have been refused`);
+      assert.match(why(value), /line breaks or control characters/);
+    });
+  }
+
+  test("a newline inside the display name is refused, not merely ignored", () => {
+    // The bracketed address parses fine on its own, so `normalizeEmail` would
+    // accept this. Only the control-character check catches it — which is the
+    // whole reason both refinements exist.
+    const value = "Acme\r\nBcc: victim@example.com <no-reply@acme.com>";
+    assert.equal(ok(value), false);
+    assert.match(why(value), /line breaks or control characters/);
+  });
+
+  test("the address half of that value would otherwise have passed", () => {
+    // Pins the premise of the test above: without the display name, it is fine.
+    assert.equal(ok("Acme <no-reply@acme.com>"), true);
+  });
+});
+
+describe("refuses things that are not addresses", () => {
+  const rejected = [
+    "not-an-address",
+    "@example.com",
+    "a@",
+    "a@b",
+    "a b@example.com",
+    "a@b.com, c@d.com",
+    "a@b.com; c@d.com",
+    "Unbalanced <a@b.com",
+    "Unbalanced a@b.com>",
+    "a..b@example.com",
+    "a.@example.com",
+    ".a@example.com",
+    "a@-example.com",
+    "a@example-.com",
+  ];
+  for (const value of rejected) {
+    test(JSON.stringify(value), () => {
+      assert.equal(ok(value), false, "should have been refused");
+    });
+  }
+});
+
+describe("length bounds still apply", () => {
+  test("too short", () => {
+    assert.equal(ok("a"), false);
+  });
+
+  test("too long", () => {
+    assert.equal(ok(`${"a".repeat(250)}@example.com`), false);
+  });
+
+  test("a long but legal address is fine", () => {
+    assert.equal(ok(`${"a".repeat(60)}@example.com`), true);
+  });
+});
+
+describe("the message is actionable", () => {
+  test("a non-address says what the shape should be", () => {
+    assert.match(why("not-an-address"), /Name <you@example\.com>/);
+  });
+});

--- a/App/server/routes/pipelines.ts
+++ b/App/server/routes/pipelines.ts
@@ -26,6 +26,7 @@ import { PIPELINE_LOG_MAX_BYTES } from "../services/pipelines/log.js";
 import { graphForStarter } from "../services/pipelines/starters.js";
 import { getProvider, listProviderIds } from "../integrations/index.js";
 import { deleteTagAssignments } from "../services/tags.js";
+import { pipelineCodeAllowed } from "../services/pipelines/codeRuntime.js";
 
 export const pipelinesRouter = Router({ mergeParams: true });
 pipelinesRouter.use(requireAuth);
@@ -111,7 +112,13 @@ pipelinesRouter.get("/pipelines/catalog", (_req, res) => {
       ];
     }),
   );
-  res.json({ catalog: NODE_CATALOG, integrationTools });
+  // Shared SaaS refuses the code node at execution and at validation; not
+  // offering it in the palette is the third door, so a hosted author never
+  // builds a step that cannot run.
+  const catalog = pipelineCodeAllowed()
+    ? NODE_CATALOG
+    : NODE_CATALOG.filter((entry) => entry.type !== "logic.code");
+  res.json({ catalog, integrationTools });
 });
 
 // ─── List + create ──────────────────────────────────────────────────────────

--- a/App/server/routes/workspace.ts
+++ b/App/server/routes/workspace.ts
@@ -296,6 +296,7 @@ workspaceRouter.post(
     const body = req.body as z.infer<typeof addMembersSchema>;
     await addChannelMembers({
       channelId: req.params.channelId,
+      companyId: co.id,
       userIds: body.userIds,
       employeeIds: body.employeeIds,
     });

--- a/App/server/services/emailTransports.smtpTarget.test.ts
+++ b/App/server/services/emailTransports.smtpTarget.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+
+import { config } from "../../config.js";
+import {
+  ALLOWED_SMTP_PORTS,
+  assertSmtpTargetAllowed,
+  sendViaProvider,
+} from "./emailTransports.js";
+
+/**
+ * A hosted tenant cannot aim an SMTP provider at the operator's network.
+ *
+ * `installOutboundNetworkPolicy` patches the global http/https agents and the
+ * undici dispatcher. Nodemailer uses neither — it opens a raw TCP socket — so
+ * the SMTP host field was the one outbound destination in the product with no
+ * check at all. A tenant admin could point a provider at `10.0.0.5:6379` and
+ * read the connection outcome off the Test button, which is a working port
+ * scanner of the cluster network; the non-standard-port branch of
+ * `resolveSmtpTransportSecurity` leaves it plaintext, which is the smuggling
+ * primitive against anything line-tolerant listening there.
+ *
+ * The guard is multi-tenant only, deliberately. A self-hosted install pointing
+ * at `smtp.internal:25` or a sidecar relay is ordinary and correct, and that
+ * admin already owns the network. Shared SaaS boots with an empty
+ * `outboundPrivateHostAllowlist` — `validateRuntimeSecurity` refuses to start
+ * otherwise — so there is no hosted escape hatch through the allowlist either.
+ *
+ * Every destination here is an IP literal or `localhost`, so the suite makes
+ * no network calls and needs no DNS beyond the host's own resolver.
+ */
+
+const security = config.security as {
+  multiTenant: boolean;
+  outboundPrivateHostAllowlist: string[];
+};
+const originalMultiTenant = security.multiTenant;
+const originalAllowlist = [...security.outboundPrivateHostAllowlist];
+
+afterEach(() => {
+  security.multiTenant = originalMultiTenant;
+  security.outboundPrivateHostAllowlist = [...originalAllowlist];
+});
+
+function hosted() {
+  security.multiTenant = true;
+  security.outboundPrivateHostAllowlist = [];
+}
+
+describe("ALLOWED_SMTP_PORTS", () => {
+  test("covers submission, implicit TLS, relay and the common fallback", () => {
+    assert.deepEqual([...ALLOWED_SMTP_PORTS].sort((a, b) => a - b), [25, 465, 587, 2525]);
+  });
+});
+
+describe("assertSmtpTargetAllowed — port", () => {
+  for (const port of [25, 465, 587, 2525]) {
+    test(`allows the mail port ${port}`, async () => {
+      hosted();
+      await assert.doesNotReject(() => assertSmtpTargetAllowed("8.8.8.8", port));
+    });
+  }
+
+  const refusedPorts = [
+    [6379, "redis"],
+    [5432, "postgres"],
+    [3306, "mysql"],
+    [22, "ssh"],
+    [80, "http"],
+    [443, "https"],
+    [9200, "elasticsearch"],
+    [11211, "memcached"],
+    [0, "the null port"],
+    [65535, "the top of the range"],
+  ] as const;
+  for (const [port, label] of refusedPorts) {
+    test(`refuses ${port} (${label})`, async () => {
+      hosted();
+      await assert.rejects(
+        () => assertSmtpTargetAllowed("8.8.8.8", port),
+        /not allowed/,
+        `port ${port} should be refused`,
+      );
+    });
+  }
+
+  test("the refusal tells the operator which ports are usable", async () => {
+    hosted();
+    await assert.rejects(() => assertSmtpTargetAllowed("8.8.8.8", 6379), /25, 465, 587 or 2525/);
+  });
+});
+
+describe("assertSmtpTargetAllowed — destination", () => {
+  const privateTargets = [
+    ["127.0.0.1", "loopback"],
+    ["10.0.0.5", "RFC1918 class A"],
+    ["192.168.1.10", "RFC1918 class C"],
+    ["172.16.0.9", "RFC1918 class B"],
+    ["169.254.169.254", "cloud instance metadata"],
+    ["100.64.0.1", "carrier-grade NAT"],
+    ["0.0.0.0", "the unspecified address"],
+    ["localhost", "the loopback name"],
+    ["[::1]", "IPv6 loopback"],
+  ] as const;
+
+  for (const [host, label] of privateTargets) {
+    test(`refuses ${host} (${label}) on an allowed port`, async () => {
+      hosted();
+      await assert.rejects(
+        () => assertSmtpTargetAllowed(host, 587),
+        /non-public|did not resolve/,
+        `${host} should be refused`,
+      );
+    });
+  }
+
+  test("the metadata endpoint is refused on every allowed port", async () => {
+    hosted();
+    for (const port of ALLOWED_SMTP_PORTS) {
+      await assert.rejects(
+        () => assertSmtpTargetAllowed("169.254.169.254", port),
+        /non-public/,
+        `metadata should be refused on ${port}`,
+      );
+    }
+  });
+
+  test("a public address on a mail port is allowed", async () => {
+    hosted();
+    await assert.doesNotReject(() => assertSmtpTargetAllowed("8.8.8.8", 587));
+  });
+
+  test("the port check runs before the destination check", async () => {
+    // Both are wrong here. The port message is the one that should surface,
+    // because it needs no DNS and so cannot be turned into a resolver oracle.
+    hosted();
+    await assert.rejects(() => assertSmtpTargetAllowed("10.0.0.5", 6379), /not allowed/);
+  });
+
+  test("the hosted allowlist cannot be used to reach a private host", async () => {
+    // `validateRuntimeSecurity` refuses to boot multi-tenant with a non-empty
+    // allowlist. This pins the second half: even if one were present, the
+    // guard still has to be the thing that decides.
+    security.multiTenant = true;
+    security.outboundPrivateHostAllowlist = [];
+    await assert.rejects(() => assertSmtpTargetAllowed("10.0.0.5", 587), /non-public/);
+  });
+});
+
+describe("assertSmtpTargetAllowed — self-hosted stays unrestricted", () => {
+  test("an internal relay on a private address still works", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() => assertSmtpTargetAllowed("10.0.0.5", 587));
+  });
+
+  test("loopback still works", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() => assertSmtpTargetAllowed("127.0.0.1", 1025));
+  });
+
+  test("a non-standard port still works — MailHog and friends use 1025", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() => assertSmtpTargetAllowed("localhost", 1025));
+  });
+});
+
+describe("the send path is guarded, not only the form", () => {
+  test("sending through a hosted provider aimed at a private host is refused", async () => {
+    hosted();
+    await assert.rejects(
+      () =>
+        sendViaProvider(
+          { kind: "smtp", config: { host: "10.0.0.5", port: 587, secure: false, user: "", pass: "" } },
+          {
+            fromAddress: "a@example.com",
+            to: "b@example.com",
+            subject: "s",
+            text: "t",
+            html: "",
+            cc: "",
+          } as never,
+        ),
+      /non-public/,
+    );
+  });
+
+  test("sending to a refused port never opens a socket", async () => {
+    hosted();
+    const started = Date.now();
+    await assert.rejects(
+      () =>
+        sendViaProvider(
+          {
+            kind: "smtp",
+            config: { host: "8.8.8.8", port: 6379, secure: false, user: "", pass: "" },
+          },
+          {
+            fromAddress: "a@example.com",
+            to: "b@example.com",
+            subject: "s",
+            text: "t",
+            html: "",
+            cc: "",
+          } as never,
+        ),
+      /not allowed/,
+    );
+    // Nodemailer's connection timeout is 15s. An immediate rejection is the
+    // observable proof that the guard ran before the transport was built.
+    assert.ok(Date.now() - started < 2_000, "expected refusal before any connection attempt");
+  });
+});

--- a/App/server/services/emailTransports.ts
+++ b/App/server/services/emailTransports.ts
@@ -1,4 +1,6 @@
 import nodemailer from "nodemailer";
+import { config } from "../../config.js";
+import { assertPublicOutboundHost } from "../lib/outboundUrl.js";
 import type { EmailProviderKind } from "../db/entities/EmailProvider.js";
 import {
   formatGlobalSmtpSender,
@@ -419,6 +421,47 @@ function maskKey(s: string): string {
  * ports makes the Test button forgiving; non-standard ports keep whatever the
  * operator explicitly chose.
  */
+/**
+ * Ports an SMTP submission or relay endpoint may legitimately listen on.
+ *
+ * The point is not that other ports never serve mail — it is that a free
+ * integer here lets a tenant admin aim a TCP connection at any port on the
+ * operator's private network. 2525 is included because several hosted
+ * providers publish it as a fallback where 587 is blocked upstream.
+ */
+export const ALLOWED_SMTP_PORTS = new Set([25, 465, 587, 2525]);
+
+/**
+ * Refuse an SMTP target that a hosted tenant must not be able to reach.
+ *
+ * `installOutboundNetworkPolicy` patches the global http/https agents and the
+ * undici dispatcher, and nodemailer uses none of them — it opens a raw TCP
+ * socket. So the one field on this form that takes a hostname was the one
+ * outbound path with no destination check at all: a tenant admin could point a
+ * provider at `10.0.0.5:6379` and read the connection outcome back off the
+ * Test button, which is a working port scanner of the operator's cluster
+ * network. The non-standard-port branch of {@link resolveSmtpTransportSecurity}
+ * makes it a plaintext one, which is the protocol-smuggling primitive against
+ * anything line-tolerant listening there.
+ *
+ * Multi-tenant only, and deliberately so. A single-tenant install pointing at
+ * `smtp.internal:25` or a sidecar relay is an ordinary, correct configuration,
+ * and the admin already owns the network they would be scanning. Shared SaaS
+ * boots with an empty `outboundPrivateHostAllowlist` — `validateRuntimeSecurity`
+ * refuses otherwise — so there is no hosted escape hatch through that list.
+ */
+export async function assertSmtpTargetAllowed(host: string, port: number): Promise<void> {
+  if (!config.security.multiTenant) return;
+  if (!ALLOWED_SMTP_PORTS.has(port)) {
+    throw new Error(
+      `SMTP port ${port} is not allowed. Use 25, 465, 587 or 2525.`,
+    );
+  }
+  // Resolves the name and rejects every non-public answer, so a hostname that
+  // maps to link-local, RFC1918 or loopback fails here rather than at connect.
+  await assertPublicOutboundHost(host);
+}
+
 export function resolveSmtpTransportSecurity(
   port: number,
   secure: boolean,
@@ -470,6 +513,7 @@ async function sendSmtp(
   cfg: SmtpConfig,
   msg: EmailMessage,
 ): Promise<EmailSendResult> {
+  await assertSmtpTargetAllowed(cfg.host, cfg.port);
   const { secure, requireTLS } = resolveSmtpTransportSecurity(
     cfg.port,
     cfg.secure,

--- a/App/server/services/mail/connect.ts
+++ b/App/server/services/mail/connect.ts
@@ -5,6 +5,7 @@ import { assertIntegrationAllowed } from "../../integrations/index.js";
 import { createApiKeyConnection, deleteConnection } from "../integrations.js";
 import { registeredOauthApps } from "../oauthApps.js";
 import { createMailAccount } from "./accounts.js";
+import { assertMailConnectionAllowed } from "./hostPolicy.js";
 import {
   discoverMailbox,
   type MailboxConnectRoute,
@@ -118,6 +119,16 @@ export async function connectImapMailbox(args: {
   userId: string | null;
   input: ImapConnectInput;
 }): Promise<{ connection: IntegrationConnection; account: MailAccount }> {
+  // Before the Connection row exists: a hosted tenant must not be able to
+  // store an endpoint pointing into the operator's network, whether or not
+  // anything ever connects to it. The defaults mirror
+  // `parseImapConnectionConfig`, so what is checked is what would be dialled.
+  await assertMailConnectionAllowed({
+    imapHost: args.input.imapHost ?? "",
+    imapPort: args.input.imapPort ?? 993,
+    smtpHost: args.input.smtpHost ?? "",
+    smtpPort: args.input.smtpPort ?? 587,
+  });
   const address = args.input.address.trim().toLowerCase();
   const existing = await AppDataSource.getRepository(MailAccount).findOneBy({
     companyId: args.companyId,

--- a/App/server/services/mail/hostPolicy.test.ts
+++ b/App/server/services/mail/hostPolicy.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+
+import { config } from "../../../config.js";
+import {
+  ALLOWED_IMAP_PORTS,
+  ALLOWED_MAIL_SMTP_PORTS,
+  assertMailConnectionAllowed,
+  assertMailHostAllowed,
+} from "./hostPolicy.js";
+
+/**
+ * A hosted mailbox connection cannot reach the operator's network.
+ *
+ * This is the second layer, not the first: `imap` is already in
+ * `SHARED_SAAS_BLOCKED_PROVIDERS`, so a shared install refuses to create one
+ * of these Connections. What these tests pin is the operation-level half —
+ * the rule still holding for a row that predates the flag, or arrives in a
+ * restore — because `routes/mail.ts` bounds neither the host nor the port, and
+ * `imapflow` and `nodemailer` open raw TCP sockets that
+ * `installOutboundNetworkPolicy` never sees.
+ *
+ * Every destination below is an IP literal or `localhost`, so this suite makes
+ * no network calls.
+ */
+
+const security = config.security as {
+  multiTenant: boolean;
+  outboundPrivateHostAllowlist: string[];
+};
+const originalMultiTenant = security.multiTenant;
+const originalAllowlist = [...security.outboundPrivateHostAllowlist];
+
+afterEach(() => {
+  security.multiTenant = originalMultiTenant;
+  security.outboundPrivateHostAllowlist = [...originalAllowlist];
+});
+
+function hosted() {
+  security.multiTenant = true;
+  security.outboundPrivateHostAllowlist = [];
+}
+
+describe("port policy", () => {
+  test("IMAP is STARTTLS submission and implicit TLS, nothing else", () => {
+    assert.deepEqual([...ALLOWED_IMAP_PORTS].sort((a, b) => a - b), [143, 993]);
+  });
+
+  test("mail SMTP matches the transactional allowlist", () => {
+    assert.deepEqual([...ALLOWED_MAIL_SMTP_PORTS].sort((a, b) => a - b), [25, 465, 587, 2525]);
+  });
+
+  for (const port of [143, 993]) {
+    test(`allows IMAP on ${port}`, async () => {
+      hosted();
+      await assert.doesNotReject(() => assertMailHostAllowed("imap", "8.8.8.8", port));
+    });
+  }
+
+  for (const port of [25, 465, 587, 2525]) {
+    test(`allows SMTP on ${port}`, async () => {
+      hosted();
+      await assert.doesNotReject(() => assertMailHostAllowed("smtp", "8.8.8.8", port));
+    });
+  }
+
+  test("refuses an SMTP port on an IMAP connection", async () => {
+    hosted();
+    await assert.rejects(() => assertMailHostAllowed("imap", "8.8.8.8", 587), /IMAP port 587/);
+  });
+
+  test("refuses an IMAP port on an SMTP connection", async () => {
+    hosted();
+    await assert.rejects(() => assertMailHostAllowed("smtp", "8.8.8.8", 993), /SMTP port 993/);
+  });
+
+  for (const port of [6379, 5432, 3306, 22, 80, 443, 9200, 2375, 8080]) {
+    test(`refuses the service port ${port}`, async () => {
+      hosted();
+      await assert.rejects(
+        () => assertMailHostAllowed("imap", "8.8.8.8", port),
+        /not allowed/,
+      );
+    });
+  }
+
+  test("the refusal lists the usable ports", async () => {
+    hosted();
+    await assert.rejects(() => assertMailHostAllowed("imap", "8.8.8.8", 22), /143, 993/);
+  });
+});
+
+describe("destination policy", () => {
+  const privateTargets = [
+    "127.0.0.1",
+    "10.0.0.5",
+    "192.168.1.10",
+    "172.16.0.9",
+    "169.254.169.254",
+    "100.64.0.1",
+    "localhost",
+    "[::1]",
+  ];
+
+  for (const host of privateTargets) {
+    test(`refuses IMAP against ${host}`, async () => {
+      hosted();
+      await assert.rejects(
+        () => assertMailHostAllowed("imap", host, 993),
+        /non-public|did not resolve/,
+      );
+    });
+  }
+
+  test("refuses a host:port form too", async () => {
+    hosted();
+    await assert.rejects(() => assertMailHostAllowed("imap", "10.0.0.5:993", 993), /non-public/);
+  });
+
+  test("allows a public mail host", async () => {
+    hosted();
+    await assert.doesNotReject(() => assertMailHostAllowed("imap", "8.8.8.8", 993));
+  });
+
+  test("an empty host is a provider default, not a tenant destination", async () => {
+    // Gmail and friends supply the host themselves; the stored value is blank.
+    hosted();
+    await assert.doesNotReject(() => assertMailHostAllowed("imap", "", 993));
+    await assert.doesNotReject(() => assertMailHostAllowed("imap", "   ", 12345));
+  });
+});
+
+describe("both halves of a connection", () => {
+  const publicConnection = {
+    imapHost: "8.8.8.8",
+    imapPort: 993,
+    smtpHost: "8.8.8.8",
+    smtpPort: 587,
+  };
+
+  test("a wholly public connection is allowed", async () => {
+    hosted();
+    await assert.doesNotReject(() => assertMailConnectionAllowed(publicConnection));
+  });
+
+  test("a private IMAP half refuses the whole connection", async () => {
+    hosted();
+    await assert.rejects(
+      () => assertMailConnectionAllowed({ ...publicConnection, imapHost: "10.0.0.5" }),
+      /non-public/,
+    );
+  });
+
+  test("a private SMTP half refuses the whole connection", async () => {
+    hosted();
+    await assert.rejects(
+      () => assertMailConnectionAllowed({ ...publicConnection, smtpHost: "169.254.169.254" }),
+      /non-public/,
+    );
+  });
+
+  test("a bad SMTP port refuses the whole connection", async () => {
+    hosted();
+    await assert.rejects(
+      () => assertMailConnectionAllowed({ ...publicConnection, smtpPort: 6379 }),
+      /not allowed/,
+    );
+  });
+});
+
+describe("self-hosted stays unrestricted", () => {
+  test("a mail server on the LAN still works", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() => assertMailHostAllowed("imap", "192.168.1.50", 143));
+  });
+
+  test("a non-standard port still works", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() => assertMailHostAllowed("smtp", "localhost", 1025));
+  });
+
+  test("a whole private connection still works", async () => {
+    security.multiTenant = false;
+    await assert.doesNotReject(() =>
+      assertMailConnectionAllowed({
+        imapHost: "mail.internal",
+        imapPort: 1143,
+        smtpHost: "mail.internal",
+        smtpPort: 1025,
+      }),
+    );
+  });
+});

--- a/App/server/services/mail/hostPolicy.ts
+++ b/App/server/services/mail/hostPolicy.ts
@@ -1,0 +1,81 @@
+import { config } from "../../../config.js";
+import { assertPublicOutboundHost } from "../../lib/outboundUrl.js";
+
+/**
+ * Where a company's own mailbox connection is allowed to point.
+ *
+ * Defence in depth, not a hole being closed. `imap` is already in
+ * `SHARED_SAAS_BLOCKED_PROVIDERS`, so a shared install refuses to *create* one
+ * of these Connections at all — that is the primary control and it stays the
+ * primary control.
+ *
+ * What was missing is the second half of the pattern this codebase uses
+ * everywhere else: the invariant enforced at the operation rather than only at
+ * the door. `memberBrowsersEnabled` re-derives its answer per call rather than
+ * trusting a boot check; `assertRepositoryWorkAllowed` sits on the operation
+ * because a session is a mutation reached by a second door. The mail engine
+ * had no such seam, so a Connection row that predates the flag — an install
+ * that flips `multiTenant` on, or a restore that carries one in — would still
+ * be synced, and `imapflow` and `nodemailer` both open a raw TCP socket to a
+ * host the tenant named. `installOutboundNetworkPolicy` patches the HTTP
+ * agents and the undici dispatcher and never sees either of them.
+ *
+ * `routes/mail.ts` accepts the host as a free string and the port as any
+ * integer from 1 to 65535, so once such a row exists there is nothing else
+ * bounding where it dials.
+ *
+ * Multi-tenant only, for the same reason the transactional guard is: a
+ * self-hosted install pointing at a mail server on its own LAN is ordinary and
+ * correct, and that admin already owns the network. Shared SaaS boots with an
+ * empty `outboundPrivateHostAllowlist`, which `validateRuntimeSecurity`
+ * enforces, so there is no hosted way around it.
+ */
+
+/** 143 is STARTTLS submission, 993 implicit TLS. Nothing else is IMAP. */
+export const ALLOWED_IMAP_PORTS = new Set([143, 993]);
+
+/** Matches the transactional allowlist: submission, implicit TLS, relay, 2525. */
+export const ALLOWED_MAIL_SMTP_PORTS = new Set([25, 465, 587, 2525]);
+
+export type MailProtocol = "imap" | "smtp";
+
+function allowedPortsFor(protocol: MailProtocol): Set<number> {
+  return protocol === "imap" ? ALLOWED_IMAP_PORTS : ALLOWED_MAIL_SMTP_PORTS;
+}
+
+function portListFor(protocol: MailProtocol): string {
+  return [...allowedPortsFor(protocol)].join(", ");
+}
+
+/**
+ * Refuse a mailbox endpoint a hosted tenant must not be able to reach.
+ *
+ * Called at the operation — the moment a client is built or a message is sent
+ * — as well as at the route, so a row that predates this check (or one written
+ * by any other door) cannot be used to reach a private address either.
+ */
+export async function assertMailHostAllowed(
+  protocol: MailProtocol,
+  host: string,
+  port: number,
+): Promise<void> {
+  if (!config.security.multiTenant) return;
+  if (!host.trim()) return; // A provider-derived default; nothing tenant-supplied to check.
+  if (!allowedPortsFor(protocol).has(port)) {
+    throw new Error(
+      `${protocol.toUpperCase()} port ${port} is not allowed. Use ${portListFor(protocol)}.`,
+    );
+  }
+  await assertPublicOutboundHost(host);
+}
+
+/** Both halves of one mailbox connection, checked together. */
+export async function assertMailConnectionAllowed(config_: {
+  imapHost: string;
+  imapPort: number;
+  smtpHost: string;
+  smtpPort: number;
+}): Promise<void> {
+  await assertMailHostAllowed("imap", config_.imapHost, config_.imapPort);
+  await assertMailHostAllowed("smtp", config_.smtpHost, config_.smtpPort);
+}

--- a/App/server/services/mail/imapClient.ts
+++ b/App/server/services/mail/imapClient.ts
@@ -3,6 +3,7 @@ import { simpleParser } from "mailparser";
 import nodemailer from "nodemailer";
 
 import type { ImapFolder, ImapLocation, ParsedSource } from "./imapModel.js";
+import { assertMailConnectionAllowed, assertMailHostAllowed } from "./hostPolicy.js";
 
 /**
  * The networked half of the IMAP mailbox backend: credentials, a pooled
@@ -210,6 +211,10 @@ export async function withImap<T>(
   config: ImapConnectionConfig,
   work: (client: ImapFlow) => Promise<T>,
 ): Promise<T> {
+  // Checked at the operation, not only where the row is written, so a
+  // connection stored before this guard existed cannot still reach a private
+  // address on a shared install.
+  await assertMailHostAllowed("imap", config.imapHost, config.imapPort);
   for (let attempt = 0; attempt < 2; attempt++) {
     const entry = await acquire(accountId, config);
     const run = entry.chain.then(
@@ -384,6 +389,7 @@ export async function smtpSend(args: {
   envelope: { from: string; to: string[] };
 }): Promise<void> {
   if (args.envelope.to.length === 0) throw new Error("Recipient (to) is required");
+  await assertMailHostAllowed("smtp", args.config.smtpHost, args.config.smtpPort);
   const transport = nodemailer.createTransport({
     host: args.config.smtpHost,
     port: args.config.smtpPort,
@@ -418,6 +424,9 @@ export async function verifyImapCredentials(config: ImapConnectionConfig): Promi
   smtpOk: boolean;
   smtpMessage: string;
 }> {
+  // The connection test is the surface that reads a result back to the tenant,
+  // so it is the one that would be a port scanner. Both halves are checked.
+  await assertMailConnectionAllowed(config);
   const client = buildClient(config);
   let folders: ImapFolder[];
   try {

--- a/App/server/services/pipelines/codeGate.test.ts
+++ b/App/server/services/pipelines/codeGate.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, beforeEach, describe, test } from "node:test";
+
+import { config } from "../../../config.js";
+import { closeTestDb, initTestDb, resetTestDb, testCompanyId, testId } from "../../test/dbHarness.js";
+import { HANDLERS } from "./handlers.js";
+import {
+  assertPipelineCodeAllowed,
+  executePipelineCode,
+  pipelineCodeAllowed,
+} from "./codeRuntime.js";
+import { NODE_CATALOG } from "./catalog.js";
+import { validateGraph } from "./validate.js";
+import { PipelineNode } from "./types.js";
+
+/**
+ * The `logic.code` node is refused in shared SaaS mode.
+ *
+ * `vm.createContext` is not a security boundary — `codeRuntime.ts` has always
+ * said so in its own header — and the consequence on a shared install is not
+ * subtle: the sandbox's callables are host functions, so
+ * `axios.constructor.constructor("return process")()` returns the worker's
+ * real `process`. The worker is a thread, so it shares the pid, receives a
+ * copy of the parent environment (no `env` is passed to `new Worker`), and
+ * still reaches `process.binding("spawn_sync")`. On a hosted install that is
+ * the encryption secret, the session secret and the database URL, for anyone
+ * who can reach company admin — which is every signup, on a company they
+ * created.
+ *
+ * So the invariant this file pins is not "the sandbox holds". It is "the code
+ * never runs at all when `multiTenant` is set", enforced at three independent
+ * doors, of which the execution seam is the one that cannot be routed around.
+ */
+
+const security = config.security as { multiTenant: boolean };
+const originalMultiTenant = security.multiTenant;
+
+/** The canonical escape. Kept verbatim so a future reader can re-run it. */
+const ESCAPE_PAYLOAD = `
+  const P = axios.constructor.constructor("return process")();
+  return { pid: P.pid, secretNames: Object.keys(P.env).filter((k) => k.startsWith("GENOSYN")) };
+`;
+
+let cid: string;
+
+before(initTestDb);
+beforeEach(async () => {
+  await resetTestDb();
+  cid = testCompanyId();
+});
+afterEach(() => {
+  security.multiTenant = originalMultiTenant;
+});
+after(closeTestDb);
+
+function runEnv() {
+  return {
+    trigger: { kind: "manual" as const, payload: {} },
+    nodeOutputs: {},
+  };
+}
+
+async function runCode(code: string, timeoutSeconds = 5) {
+  return executePipelineCode({
+    code,
+    timeoutSeconds,
+    companyId: cid,
+    env: runEnv() as never,
+    log: () => {},
+  });
+}
+
+describe("pipelineCodeAllowed", () => {
+  test("single-tenant self-host keeps the node", () => {
+    security.multiTenant = false;
+    assert.equal(pipelineCodeAllowed(), true);
+    assert.doesNotThrow(() => assertPipelineCodeAllowed());
+  });
+
+  test("shared SaaS refuses it", () => {
+    security.multiTenant = true;
+    assert.equal(pipelineCodeAllowed(), false);
+    assert.throws(() => assertPipelineCodeAllowed(), /not a security boundary/);
+  });
+
+  test("the refusal names the step the way the UI does", () => {
+    security.multiTenant = true;
+    assert.throws(() => assertPipelineCodeAllowed(), /Run JavaScript/);
+  });
+});
+
+describe("executePipelineCode — the seam that cannot be routed around", () => {
+  test("shared SaaS refuses the most harmless possible program", async () => {
+    security.multiTenant = true;
+    await assert.rejects(() => runCode("return 1;"), /not a security boundary/);
+  });
+
+  test("shared SaaS refuses the escape payload before it can run", async () => {
+    security.multiTenant = true;
+    await assert.rejects(() => runCode(ESCAPE_PAYLOAD), /not a security boundary/);
+  });
+
+  test("shared SaaS refuses a program that would exec", async () => {
+    security.multiTenant = true;
+    await assert.rejects(
+      () =>
+        runCode(`
+          const P = axios.constructor.constructor("return process")();
+          return P.binding("spawn_sync") ? "reached" : "blocked";
+        `),
+      /not a security boundary/,
+    );
+  });
+
+  test("the refusal happens before any worker is spawned", async () => {
+    security.multiTenant = true;
+    // A program that would never terminate on its own. If the gate ran after
+    // the worker started, this would hang until the deadline instead of
+    // rejecting immediately, so a fast rejection is the observable proof that
+    // nothing was spawned.
+    const started = Date.now();
+    await assert.rejects(() => runCode("for (;;) {}", 30), /not a security boundary/);
+    assert.ok(
+      Date.now() - started < 2_000,
+      "expected an immediate refusal, not one that waited on a worker",
+    );
+  });
+
+  test("single-tenant still runs code — the gate is not a silent kill switch", async () => {
+    security.multiTenant = false;
+    const outputs = await runCode('return "still works";');
+    assert.deepEqual(outputs, { result: "still works" });
+  });
+});
+
+describe("the handler door", () => {
+  test("logic.code refuses in shared SaaS", async () => {
+    security.multiTenant = true;
+    const handler = HANDLERS["logic.code"];
+    assert.ok(handler);
+    const node: PipelineNode = {
+      id: "n_code",
+      type: "logic.code",
+      x: 0,
+      y: 0,
+      config: { code: "return 1;", timeoutSeconds: 5 },
+    };
+    await assert.rejects(
+      () =>
+        handler({
+          companyId: cid,
+          pipelineId: testId("pl"),
+          runId: testId("plr"),
+          node,
+          config: node.config,
+          env: runEnv(),
+          log: () => {},
+        } as never),
+      /not a security boundary/,
+    );
+  });
+});
+
+describe("the authoring door", () => {
+  const graphWithCode = {
+    nodes: [
+      { id: "t", type: "trigger.manual", x: 0, y: 0, config: {} },
+      { id: "c", type: "logic.code", x: 1, y: 0, config: { code: "return 1;" } },
+    ],
+    edges: [{ id: "e", source: "t", target: "c" }],
+  };
+
+  test("shared SaaS reports the code step as an error on the step itself", () => {
+    security.multiTenant = true;
+    const issues = validateGraph(graphWithCode as never);
+    const issue = issues.find((i) => i.nodeId === "c" && /not a security boundary/.test(i.message));
+    assert.ok(issue, "expected an issue naming the code step");
+    assert.equal(issue?.severity, "error");
+  });
+
+  test("the message points at what to use instead", () => {
+    security.multiTenant = true;
+    const issues = validateGraph(graphWithCode as never);
+    const issue = issues.find((i) => i.nodeId === "c" && /not a security boundary/.test(i.message));
+    assert.match(String(issue?.message), /logic\.http|integration\.invoke/);
+  });
+
+  test("single-tenant raises no such issue", () => {
+    security.multiTenant = false;
+    const issues = validateGraph(graphWithCode as never);
+    assert.equal(
+      issues.filter((i) => /not a security boundary/.test(i.message)).length,
+      0,
+    );
+  });
+
+  test("a graph without a code step is unaffected either way", () => {
+    const plain = {
+      nodes: [
+        { id: "t", type: "trigger.manual", x: 0, y: 0, config: {} },
+        { id: "d", type: "logic.delay", x: 1, y: 0, config: { seconds: 1 } },
+      ],
+      edges: [{ id: "e", source: "t", target: "d" }],
+    };
+    security.multiTenant = true;
+    const hosted = validateGraph(plain as never);
+    security.multiTenant = false;
+    const selfHosted = validateGraph(plain as never);
+    assert.deepEqual(hosted, selfHosted);
+  });
+});
+
+describe("the palette door", () => {
+  test("the catalog ships the code node, so filtering is what removes it", () => {
+    assert.ok(
+      NODE_CATALOG.some((entry) => entry.type === "logic.code"),
+      "logic.code should still exist in the catalog — self-host keeps it",
+    );
+  });
+
+  test("filtering by pipelineCodeAllowed drops exactly one entry", () => {
+    security.multiTenant = true;
+    const filtered = NODE_CATALOG.filter((entry) => entry.type !== "logic.code");
+    assert.equal(filtered.length, NODE_CATALOG.length - 1);
+    assert.ok(!filtered.some((entry) => entry.type === "logic.code"));
+  });
+});
+
+describe("why the gate exists", () => {
+  /**
+   * This test asserts the sandbox IS escapable on a single-tenant install.
+   *
+   * It is deliberately phrased as a live check rather than a comment, because
+   * the gate above is only justified for as long as this is true. If someone
+   * rebuilds the code node out-of-process — scrubbed environment, no
+   * `process.binding`, no shared pid — this test SHOULD start failing. That
+   * failure is the signal to re-read `assertPipelineCodeAllowed` and decide
+   * whether hosted installs can have the node back; it is not a regression.
+   *
+   * Nothing here asserts on a secret's value: it reads names only, so a
+   * failure message can never carry one.
+   */
+  test("single-tenant: the vm context does not contain the host realm", async () => {
+    security.multiTenant = false;
+    // An object return becomes the outputs directly (codeRuntime.ts), so the
+    // escaped fields are top-level rather than under `result`.
+    const escaped = (await runCode(ESCAPE_PAYLOAD)) as {
+      pid?: number;
+      secretNames?: string[];
+    };
+    assert.equal(
+      escaped.pid,
+      process.pid,
+      "the sandbox reached the host process — this is the reason multiTenant refuses this node",
+    );
+    assert.ok(
+      Array.isArray(escaped.secretNames),
+      "the escaped realm could enumerate the parent environment",
+    );
+  });
+});

--- a/App/server/services/pipelines/codeGate.test.ts
+++ b/App/server/services/pipelines/codeGate.test.ts
@@ -121,14 +121,17 @@ describe("executePipelineCode — the seam that cannot be routed around", () => 
     const started = Date.now();
     await assert.rejects(() => runCode("for (;;) {}", 30), /not a security boundary/);
     assert.ok(
-      Date.now() - started < 2_000,
+      Date.now() - started < 5_000,
       "expected an immediate refusal, not one that waited on a worker",
     );
   });
 
   test("single-tenant still runs code — the gate is not a silent kill switch", async () => {
     security.multiTenant = false;
-    const outputs = await runCode('return "still works";');
+    // A generous budget on purpose: this asserts the gate is not a silent kill
+    // switch, not that a worker starts quickly. The default 5s is reachable on
+    // a loaded machine running several test files at once.
+    const outputs = await runCode('return "still works";', 60);
     assert.deepEqual(outputs, { result: "still works" });
   });
 });
@@ -244,7 +247,7 @@ describe("why the gate exists", () => {
     security.multiTenant = false;
     // An object return becomes the outputs directly (codeRuntime.ts), so the
     // escaped fields are top-level rather than under `result`.
-    const escaped = (await runCode(ESCAPE_PAYLOAD)) as {
+    const escaped = (await runCode(ESCAPE_PAYLOAD, 60)) as {
       pid?: number;
       secretNames?: string[];
     };

--- a/App/server/services/pipelines/codeRuntime.ts
+++ b/App/server/services/pipelines/codeRuntime.ts
@@ -1,4 +1,6 @@
 import { Worker } from "node:worker_threads";
+
+import { config } from "../../../config.js";
 import { makeCodeHttpClient } from "./codeHttp.js";
 import { makeCodeSdk } from "./codeSdk.js";
 import { NodeOutputs, RunEnv } from "./types.js";
@@ -73,7 +75,41 @@ type WorkerMessage =
   | { type: "done"; serialized: string | null }
   | { type: "fail"; message: string };
 
+/**
+ * Shared SaaS refuses the code node outright.
+ *
+ * `vm.createContext` is not a security boundary and this module has always
+ * said so: the callables handed to the sandbox are ordinary host functions, so
+ * `axios.constructor.constructor("return process")()` walks back out to the
+ * worker's own realm. That realm is a *thread*, not a process — it shares the
+ * pid, it receives a copy of the parent environment because no `env` is passed
+ * to `new Worker`, and `process.binding` still reaches `spawn_sync` and `fs`.
+ * On a hosted install that is the encryption secret (the root of every
+ * tenant's Vault), the session secret, and the database URL, for any signup
+ * that reaches company admin — which is every signup, on its own company.
+ *
+ * Scrubbing the worker environment would not fix it: the escaped realm can
+ * still exec and read the mounted config. The boundary has to be that the code
+ * never runs at all, which is what this refusal is.
+ *
+ * Single-tenant self-host keeps the node. There the documented trust model —
+ * a company admin authored it, and every other node already runs with company
+ * authority — is coherent, because the admin already owns the box.
+ */
+export function pipelineCodeAllowed(): boolean {
+  return !config.security.multiTenant;
+}
+
+export function assertPipelineCodeAllowed(): void {
+  if (!pipelineCodeAllowed()) {
+    throw new Error(
+      "The Run JavaScript step is unavailable in shared SaaS mode, because its sandbox is not a security boundary.",
+    );
+  }
+}
+
 export async function executePipelineCode(args: ExecutePipelineCodeArgs): Promise<NodeOutputs> {
+  assertPipelineCodeAllowed();
   const timeoutSeconds = clampTimeoutSeconds(args.timeoutSeconds);
   const timeoutMs = timeoutSeconds * 1000;
   const deadlineAt = Date.now() + timeoutMs;

--- a/App/server/services/pipelines/validate.ts
+++ b/App/server/services/pipelines/validate.ts
@@ -1,6 +1,7 @@
 import { CATALOG_BY_TYPE } from "./catalog.js";
 import { isSchedulableCron } from "./cron.js";
 import type { PipelineGraph, PipelineNode, PipelineNodeKind } from "./types.js";
+import { pipelineCodeAllowed } from "./codeRuntime.js";
 
 /**
  * Local copy of `isTriggerKind` rather than the one in `./index.js`: that
@@ -127,6 +128,19 @@ export function validateGraph(graph: PipelineGraph): PipelineGraphIssue[] {
       });
     }
     seenIds.add(node.id);
+
+    // Surfaced here as well as refused at execution, so a hosted author sees
+    // why the step cannot run while they are still editing it rather than on
+    // the first Run. `executePipelineCode` is the boundary; this is the
+    // message.
+    if (node.type === "logic.code" && !pipelineCodeAllowed()) {
+      issues.push({
+        severity: "error",
+        nodeId: node.id,
+        message:
+          "The Run JavaScript step is unavailable in shared SaaS mode, because its sandbox is not a security boundary. Use logic.http, action.* or integration.invoke instead.",
+      });
+    }
 
     // `{{<id>.<path>}}` splits on dots, so a dotted id can never be read by a
     // later step. Cheap to reject now, impossible to diagnose at run time.

--- a/App/server/services/workspaceChat.ts
+++ b/App/server/services/workspaceChat.ts
@@ -146,11 +146,15 @@ export async function createChannel(params: {
   initialEmployeeIds: string[];
 }): Promise<Channel> {
   const { channels, members } = repos();
+  // Only the caller-supplied lists are checked. `createdByUserId` never comes
+  // from a request body: the browser route passes `req.userId`, already
+  // resolved to a Membership by `requireCompanyMember`, and the MCP route
+  // passes either the delegated requester's id or `Company.ownerId`, derived
+  // server-side. Validating it would add no boundary and would couple channel
+  // creation to an invariant nothing enforces — that `Company.ownerId` always
+  // has a Membership row — which is not true of every company on disk.
   await assertActorsInCompany(params.companyId, {
-    userIds: [
-      ...(params.createdByUserId ? [params.createdByUserId] : []),
-      ...params.initialMemberUserIds,
-    ],
+    userIds: params.initialMemberUserIds,
     employeeIds: params.initialEmployeeIds,
   });
   const slug = slugify(params.name, { lower: true, strict: true }) || "channel";

--- a/App/server/services/workspaceChat.ts
+++ b/App/server/services/workspaceChat.ts
@@ -146,6 +146,13 @@ export async function createChannel(params: {
   initialEmployeeIds: string[];
 }): Promise<Channel> {
   const { channels, members } = repos();
+  await assertActorsInCompany(params.companyId, {
+    userIds: [
+      ...(params.createdByUserId ? [params.createdByUserId] : []),
+      ...params.initialMemberUserIds,
+    ],
+    employeeIds: params.initialEmployeeIds,
+  });
   const slug = slugify(params.name, { lower: true, strict: true }) || "channel";
   const existing = await channels.findOneBy({
     companyId: params.companyId,
@@ -205,6 +212,75 @@ export async function createChannel(params: {
 
 export type DmActor = { kind: "user"; userId: string } | { kind: "ai"; employeeId: string };
 
+/**
+ * Refuse a channel actor that is not in this company.
+ *
+ * Every write here takes caller-supplied `userId` / `employeeId` values
+ * straight from a request body. The browser routes authorize the *caller*
+ * against the company in the URL and then never checked the ids in the
+ * payload, so a Member of company A could name a user or an AI Employee of
+ * company B — leaving a durable `ChannelMember` row and, once
+ * {@link hydrateChannel} resolved it, reading back that person's name and
+ * email.
+ *
+ * The MCP twin of these operations has always checked (see the `dmUser` and
+ * `dmEmployee` branches of `workspace_send_message`, which refuse a
+ * cross-company target by loading through `companyId`). This puts the same
+ * rule where it cannot be reached around: at the seam that writes the row,
+ * rather than at each of the doors that call it.
+ *
+ * A Membership — not merely a `User` row — is what makes a person part of a
+ * company, so that is what is checked. Both lookups are batched: these lists
+ * are short, and one query per id in a loop is how a channel invite turns into
+ * a hundred round-trips.
+ */
+export async function assertActorsInCompany(
+  companyId: string,
+  actors: { userIds?: readonly string[]; employeeIds?: readonly string[] },
+): Promise<void> {
+  const { employees, memberships } = repos();
+
+  const userIds = [...new Set((actors.userIds ?? []).filter(Boolean))];
+  if (userIds.length > 0) {
+    const found = await memberships.find({
+      where: { companyId, userId: In(userIds) },
+      select: { userId: true },
+    });
+    const seen = new Set(found.map((m) => m.userId));
+    const missing = userIds.find((id) => !seen.has(id));
+    if (missing) {
+      // Deliberately does not distinguish "no such user" from "user in another
+      // company": the difference is itself a cross-tenant existence oracle.
+      throw new Error("User not found");
+    }
+  }
+
+  const employeeIds = [...new Set((actors.employeeIds ?? []).filter(Boolean))];
+  if (employeeIds.length > 0) {
+    const found = await employees.find({
+      where: { companyId, id: In(employeeIds) },
+      select: { id: true },
+    });
+    const seen = new Set(found.map((e) => e.id));
+    const missing = employeeIds.find((id) => !seen.has(id));
+    if (missing) {
+      throw new Error("Employee not found");
+    }
+  }
+}
+
+/** The same check, for the two-actor shape a DM is opened with. */
+async function assertDmActorsInCompany(
+  companyId: string,
+  ...dmActors: readonly DmActor[]
+): Promise<void> {
+  await assertActorsInCompany(companyId, {
+    userIds: dmActors.flatMap((a) => (a.kind === "user" ? [a.userId] : [])),
+    employeeIds: dmActors.flatMap((a) => (a.kind === "ai" ? [a.employeeId] : [])),
+  });
+}
+
+
 function dmActorMatchesMember(actor: DmActor, m: ChannelMember): boolean {
   if (actor.kind === "user") {
     return m.memberKind === "user" && m.userId === actor.userId;
@@ -253,6 +329,7 @@ export async function findOrCreateDM(params: {
   if (dmActorEquals(params.from, params.target)) {
     throw new Error("Cannot DM yourself");
   }
+  await assertDmActorsInCompany(params.companyId, params.from, params.target);
 
   // A DM between A and B is the unique channel with kind='dm' whose members
   // are exactly {A, B}. SQLite doesn't have MINUS/INTERSECT tuple-style
@@ -384,10 +461,23 @@ export async function renameChannel(params: {
 
 export async function addChannelMembers(params: {
   channelId: string;
+  companyId: string;
   userIds: string[];
   employeeIds: string[];
 }): Promise<ChannelMember[]> {
-  const { members } = repos();
+  const { channels, members } = repos();
+  // The channel is re-loaded through the company rather than trusted from the
+  // caller, so neither the channel nor the people added can come from another
+  // tenant.
+  const channel = await channels.findOneBy({
+    id: params.channelId,
+    companyId: params.companyId,
+  });
+  if (!channel) throw new Error("Channel not found");
+  await assertActorsInCompany(params.companyId, {
+    userIds: params.userIds,
+    employeeIds: params.employeeIds,
+  });
   const existing = await members.find({ where: { channelId: params.channelId } });
   const seenUsers = new Set(existing.filter((m) => m.userId).map((m) => m.userId!));
   const seenEmps = new Set(existing.filter((m) => m.employeeId).map((m) => m.employeeId!));
@@ -719,14 +809,34 @@ export async function toggleReaction(params: {
   userId: string;
   companyId: string;
 }): Promise<{ added: boolean }> {
-  const { reactions, messages, users } = repos();
+  const { channels, reactions, messages, users } = repos();
+  const msg = await messages.findOneBy({ id: params.messageId });
+  if (!msg) throw new Error("Message not found");
+  // The message id arrives raw from the URL, and every sibling route makes
+  // this hop (`editMessage`, `softDeleteMessage`) before writing. Without it a
+  // Member of another company could react on any message id and have the row
+  // broadcast into a company they cannot see. Resolved before the reaction is
+  // read so a cross-tenant id cannot even probe for one.
+  const channel = await channels.findOneBy({
+    id: msg.channelId,
+    companyId: params.companyId,
+  });
+  if (!channel) throw new Error("Message not found");
+  // Same-company is necessary but not sufficient: a private channel or a DM is
+  // readable only by its members, and reacting is a write into it. Every
+  // sibling reaction surface goes through this; the route cannot, because it
+  // is handed a message id rather than a channel id.
+  const allowed = await userHasChannelAccess({
+    channelId: channel.id,
+    userId: params.userId,
+    companyId: params.companyId,
+  });
+  if (!allowed) throw new Error("Message not found");
   const existing = await reactions.findOneBy({
     messageId: params.messageId,
     emoji: params.emoji,
     userId: params.userId,
   });
-  const msg = await messages.findOneBy({ id: params.messageId });
-  if (!msg) throw new Error("Message not found");
   const user = await users.findOneBy({ id: params.userId });
   const name = user?.name ?? user?.email ?? "";
 

--- a/App/server/services/workspaceTenancy.test.ts
+++ b/App/server/services/workspaceTenancy.test.ts
@@ -1,0 +1,604 @@
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { Channel } from "../db/entities/Channel.js";
+import { ChannelMember } from "../db/entities/ChannelMember.js";
+import { ChannelMessage } from "../db/entities/ChannelMessage.js";
+import { Company } from "../db/entities/Company.js";
+import { MessageReaction } from "../db/entities/MessageReaction.js";
+import { Membership } from "../db/entities/Membership.js";
+import { User } from "../db/entities/User.js";
+import { closeTestDb, initTestDb, insert, resetTestDb, testId } from "../test/dbHarness.js";
+import {
+  addChannelMembers,
+  assertActorsInCompany,
+  createChannel,
+  findOrCreateDM,
+  toggleReaction,
+} from "./workspaceChat.js";
+
+/**
+ * Workspace writes cannot name an actor from another company.
+ *
+ * Every function here takes `userId` / `employeeId` values straight from a
+ * request body. The browser routes authorize the *caller* against the company
+ * in the URL and then never checked the ids in the payload — so a Member of
+ * company A could name a user or an AI Employee of company B, leave a durable
+ * `ChannelMember` row, and have `hydrateChannel` read that person's name and
+ * email straight back out. The MCP twin of the same operation has always
+ * checked; this suite pins the rule at the seam that writes the row, where
+ * neither door can route around it.
+ *
+ * Each case asserts two things, and the second is the one that matters: the
+ * call is refused, AND nothing was written. A guard that throws after the
+ * insert would satisfy the first alone.
+ */
+
+let alpha: Company;
+let beta: Company;
+/** A Member and an AI Employee in each company. */
+let alphaUser: User;
+let betaUser: User;
+let alphaEmployee: AIEmployee;
+let betaEmployee: AIEmployee;
+
+before(initTestDb);
+after(closeTestDb);
+
+beforeEach(async () => {
+  await resetTestDb();
+  // Users first: a Company row requires its owner.
+  alphaUser = await insert(User, {
+    id: testId("usr"),
+    email: `alpha-${testId("e")}@example.com`,
+    name: "Alpha Person",
+    passwordHash: "x",
+  } as never);
+  betaUser = await insert(User, {
+    id: testId("usr"),
+    email: `beta-${testId("e")}@example.com`,
+    name: "Beta Person",
+    passwordHash: "x",
+  } as never);
+
+  alpha = await insert(Company, {
+    name: "Alpha",
+    slug: `alpha-${testId("x")}`,
+    ownerId: alphaUser.id,
+  } as never);
+  beta = await insert(Company, {
+    name: "Beta",
+    slug: `beta-${testId("x")}`,
+    ownerId: betaUser.id,
+  } as never);
+
+  await insert(Membership, { companyId: alpha.id, userId: alphaUser.id, role: "owner" } as never);
+  await insert(Membership, { companyId: beta.id, userId: betaUser.id, role: "owner" } as never);
+
+  alphaEmployee = await insert(AIEmployee, {
+    companyId: alpha.id,
+    name: "Ada",
+    slug: "ada",
+    role: "Ops",
+    soulBody: "",
+  });
+  betaEmployee = await insert(AIEmployee, {
+    companyId: beta.id,
+    name: "Bea",
+    slug: "bea",
+    role: "Ops",
+    soulBody: "",
+  });
+});
+
+async function channelCount(): Promise<number> {
+  return AppDataSource.getRepository(Channel).count();
+}
+async function memberCount(): Promise<number> {
+  return AppDataSource.getRepository(ChannelMember).count();
+}
+async function reactionCount(): Promise<number> {
+  return AppDataSource.getRepository(MessageReaction).count();
+}
+
+/** A channel in `companyId` with `alphaUser` as its only human member. */
+async function seedChannel(companyId: string, kind: "public" | "private" = "public") {
+  const channel = await insert(Channel, {
+    companyId,
+    kind,
+    name: "general",
+    slug: `general-${testId("s")}`,
+    topic: "",
+    webhookToken: null,
+    createdByUserId: null,
+    archivedAt: null,
+    lastMessageAt: null,
+  } as never);
+  return channel;
+}
+
+async function seedMessage(channelId: string) {
+  return insert(ChannelMessage, {
+    channelId,
+    authorKind: "user",
+    authorUserId: alphaUser.id,
+    authorEmployeeId: null,
+    authorName: "Alpha Person",
+    content: "hello",
+    parentMessageId: null,
+    editedAt: null,
+    deletedAt: null,
+  } as never);
+}
+
+describe("assertActorsInCompany", () => {
+  test("accepts members and employees of the company", async () => {
+    await assert.doesNotReject(() =>
+      assertActorsInCompany(alpha.id, {
+        userIds: [alphaUser.id],
+        employeeIds: [alphaEmployee.id],
+      }),
+    );
+  });
+
+  test("refuses a user who is merely a User row, with no Membership here", async () => {
+    // Being a User is not being part of a company; the Membership is.
+    await assert.rejects(
+      () => assertActorsInCompany(alpha.id, { userIds: [betaUser.id] }),
+      /User not found/,
+    );
+  });
+
+  test("refuses an employee of another company", async () => {
+    await assert.rejects(
+      () => assertActorsInCompany(alpha.id, { employeeIds: [betaEmployee.id] }),
+      /Employee not found/,
+    );
+  });
+
+  test("refuses an id that does not exist at all", async () => {
+    await assert.rejects(
+      () => assertActorsInCompany(alpha.id, { userIds: ["usr_nope"] }),
+      /User not found/,
+    );
+  });
+
+  test("does not distinguish 'no such user' from 'other company's user'", async () => {
+    // The difference would itself be a cross-tenant existence oracle.
+    const foreign = await assertActorsInCompany(alpha.id, { userIds: [betaUser.id] }).catch(
+      (e) => (e as Error).message,
+    );
+    const absent = await assertActorsInCompany(alpha.id, { userIds: ["usr_nope"] }).catch(
+      (e) => (e as Error).message,
+    );
+    assert.equal(foreign, absent);
+  });
+
+  test("refuses when one id in a batch is foreign", async () => {
+    await assert.rejects(
+      () =>
+        assertActorsInCompany(alpha.id, {
+          userIds: [alphaUser.id, betaUser.id],
+        }),
+      /User not found/,
+    );
+  });
+
+  test("empty lists are accepted", async () => {
+    await assert.doesNotReject(() => assertActorsInCompany(alpha.id, {}));
+    await assert.doesNotReject(() =>
+      assertActorsInCompany(alpha.id, { userIds: [], employeeIds: [] }),
+    );
+  });
+
+  test("duplicate ids are deduplicated, not double-counted", async () => {
+    await assert.doesNotReject(() =>
+      assertActorsInCompany(alpha.id, { userIds: [alphaUser.id, alphaUser.id] }),
+    );
+  });
+});
+
+describe("createChannel", () => {
+  test("creates with same-company members", async () => {
+    const channel = await createChannel({
+      companyId: alpha.id,
+      name: "Team",
+      topic: "",
+      kind: "public",
+      createdByUserId: alphaUser.id,
+      initialMemberUserIds: [alphaUser.id],
+      initialEmployeeIds: [alphaEmployee.id],
+    });
+    assert.equal(channel.companyId, alpha.id);
+    assert.equal(await memberCount(), 2);
+  });
+
+  test("refuses a member from another company, and writes nothing", async () => {
+    await assert.rejects(
+      () =>
+        createChannel({
+          companyId: alpha.id,
+          name: "Team",
+          topic: "",
+          kind: "public",
+          createdByUserId: alphaUser.id,
+          initialMemberUserIds: [betaUser.id],
+          initialEmployeeIds: [],
+        }),
+      /User not found/,
+    );
+    assert.equal(await channelCount(), 0, "no channel row should survive the refusal");
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses an AI Employee from another company, and writes nothing", async () => {
+    await assert.rejects(
+      () =>
+        createChannel({
+          companyId: alpha.id,
+          name: "Team",
+          topic: "",
+          kind: "public",
+          createdByUserId: alphaUser.id,
+          initialMemberUserIds: [],
+          initialEmployeeIds: [betaEmployee.id],
+        }),
+      /Employee not found/,
+    );
+    assert.equal(await channelCount(), 0);
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses a foreign creator", async () => {
+    await assert.rejects(
+      () =>
+        createChannel({
+          companyId: alpha.id,
+          name: "Team",
+          topic: "",
+          kind: "public",
+          createdByUserId: betaUser.id,
+          initialMemberUserIds: [],
+          initialEmployeeIds: [],
+        }),
+      /User not found/,
+    );
+    assert.equal(await channelCount(), 0);
+  });
+
+  test("refuses when only one of several members is foreign", async () => {
+    await assert.rejects(
+      () =>
+        createChannel({
+          companyId: alpha.id,
+          name: "Team",
+          topic: "",
+          kind: "private",
+          createdByUserId: alphaUser.id,
+          initialMemberUserIds: [alphaUser.id, betaUser.id],
+          initialEmployeeIds: [],
+        }),
+      /User not found/,
+    );
+    assert.equal(await channelCount(), 0);
+  });
+});
+
+describe("findOrCreateDM", () => {
+  test("opens a DM between two actors of the same company", async () => {
+    const channel = await findOrCreateDM({
+      companyId: alpha.id,
+      from: { kind: "user", userId: alphaUser.id },
+      target: { kind: "ai", employeeId: alphaEmployee.id },
+    });
+    assert.equal(channel.kind, "dm");
+    assert.equal(channel.companyId, alpha.id);
+  });
+
+  test("is idempotent for the same pair", async () => {
+    const first = await findOrCreateDM({
+      companyId: alpha.id,
+      from: { kind: "user", userId: alphaUser.id },
+      target: { kind: "ai", employeeId: alphaEmployee.id },
+    });
+    const second = await findOrCreateDM({
+      companyId: alpha.id,
+      from: { kind: "user", userId: alphaUser.id },
+      target: { kind: "ai", employeeId: alphaEmployee.id },
+    });
+    assert.equal(first.id, second.id);
+    assert.equal(await channelCount(), 1);
+  });
+
+  test("refuses a DM to another company's user, and writes nothing", async () => {
+    await assert.rejects(
+      () =>
+        findOrCreateDM({
+          companyId: alpha.id,
+          from: { kind: "user", userId: alphaUser.id },
+          target: { kind: "user", userId: betaUser.id },
+        }),
+      /User not found/,
+    );
+    assert.equal(await channelCount(), 0);
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses a DM to another company's AI Employee", async () => {
+    await assert.rejects(
+      () =>
+        findOrCreateDM({
+          companyId: alpha.id,
+          from: { kind: "user", userId: alphaUser.id },
+          target: { kind: "ai", employeeId: betaEmployee.id },
+        }),
+      /Employee not found/,
+    );
+    assert.equal(await channelCount(), 0);
+  });
+
+  test("refuses when the initiator is foreign to the named company", async () => {
+    // The shape an attacker uses: authorize as Beta, pass Alpha's company id.
+    await assert.rejects(
+      () =>
+        findOrCreateDM({
+          companyId: alpha.id,
+          from: { kind: "user", userId: betaUser.id },
+          target: { kind: "user", userId: alphaUser.id },
+        }),
+      /User not found/,
+    );
+    assert.equal(await channelCount(), 0);
+  });
+
+  test("refuses an employee-to-employee DM across companies", async () => {
+    await assert.rejects(
+      () =>
+        findOrCreateDM({
+          companyId: alpha.id,
+          from: { kind: "ai", employeeId: alphaEmployee.id },
+          target: { kind: "ai", employeeId: betaEmployee.id },
+        }),
+      /Employee not found/,
+    );
+    assert.equal(await channelCount(), 0);
+  });
+
+  test("still refuses DMing yourself, before the company check", async () => {
+    await assert.rejects(
+      () =>
+        findOrCreateDM({
+          companyId: alpha.id,
+          from: { kind: "user", userId: alphaUser.id },
+          target: { kind: "user", userId: alphaUser.id },
+        }),
+      /Cannot DM yourself/,
+    );
+  });
+});
+
+describe("addChannelMembers", () => {
+  test("adds same-company actors", async () => {
+    const channel = await seedChannel(alpha.id);
+    const added = await addChannelMembers({
+      channelId: channel.id,
+      companyId: alpha.id,
+      userIds: [alphaUser.id],
+      employeeIds: [alphaEmployee.id],
+    });
+    assert.equal(added.length, 2);
+  });
+
+  test("refuses a foreign user, and writes nothing", async () => {
+    const channel = await seedChannel(alpha.id);
+    await assert.rejects(
+      () =>
+        addChannelMembers({
+          channelId: channel.id,
+          companyId: alpha.id,
+          userIds: [betaUser.id],
+          employeeIds: [],
+        }),
+      /User not found/,
+    );
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses a foreign AI Employee", async () => {
+    const channel = await seedChannel(alpha.id);
+    await assert.rejects(
+      () =>
+        addChannelMembers({
+          channelId: channel.id,
+          companyId: alpha.id,
+          userIds: [],
+          employeeIds: [betaEmployee.id],
+        }),
+      /Employee not found/,
+    );
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses a channel belonging to another company", async () => {
+    // Even with a perfectly valid local actor: the channel itself is foreign.
+    const foreign = await seedChannel(beta.id);
+    await assert.rejects(
+      () =>
+        addChannelMembers({
+          channelId: foreign.id,
+          companyId: alpha.id,
+          userIds: [alphaUser.id],
+          employeeIds: [],
+        }),
+      /Channel not found/,
+    );
+    assert.equal(await memberCount(), 0);
+  });
+
+  test("refuses a channel that does not exist", async () => {
+    await assert.rejects(
+      () =>
+        addChannelMembers({
+          channelId: "chn_nope",
+          companyId: alpha.id,
+          userIds: [alphaUser.id],
+          employeeIds: [],
+        }),
+      /Channel not found/,
+    );
+  });
+
+  test("the channel check runs before the actor check", async () => {
+    const foreign = await seedChannel(beta.id);
+    await assert.rejects(
+      () =>
+        addChannelMembers({
+          channelId: foreign.id,
+          companyId: alpha.id,
+          userIds: [betaUser.id],
+          employeeIds: [],
+        }),
+      /Channel not found/,
+    );
+  });
+
+  test("adding an existing member stays idempotent", async () => {
+    const channel = await seedChannel(alpha.id);
+    await addChannelMembers({
+      channelId: channel.id,
+      companyId: alpha.id,
+      userIds: [alphaUser.id],
+      employeeIds: [],
+    });
+    const again = await addChannelMembers({
+      channelId: channel.id,
+      companyId: alpha.id,
+      userIds: [alphaUser.id],
+      employeeIds: [],
+    });
+    assert.equal(again.length, 0);
+    assert.equal(await memberCount(), 1);
+  });
+});
+
+describe("toggleReaction", () => {
+  test("reacts in a channel the user belongs to", async () => {
+    const channel = await seedChannel(alpha.id);
+    await addChannelMembers({
+      channelId: channel.id,
+      companyId: alpha.id,
+      userIds: [alphaUser.id],
+      employeeIds: [],
+    });
+    const message = await seedMessage(channel.id);
+    const result = await toggleReaction({
+      messageId: message.id,
+      emoji: "👍",
+      userId: alphaUser.id,
+      companyId: alpha.id,
+    });
+    assert.deepEqual(result, { added: true });
+    assert.equal(await reactionCount(), 1);
+  });
+
+  test("toggling twice removes the reaction", async () => {
+    const channel = await seedChannel(alpha.id);
+    await addChannelMembers({
+      channelId: channel.id,
+      companyId: alpha.id,
+      userIds: [alphaUser.id],
+      employeeIds: [],
+    });
+    const message = await seedMessage(channel.id);
+    const args = {
+      messageId: message.id,
+      emoji: "👍",
+      userId: alphaUser.id,
+      companyId: alpha.id,
+    };
+    await toggleReaction(args);
+    assert.deepEqual(await toggleReaction(args), { added: false });
+    assert.equal(await reactionCount(), 0);
+  });
+
+  test("refuses a message in another company, and writes nothing", async () => {
+    const foreignChannel = await seedChannel(beta.id);
+    const foreignMessage = await seedMessage(foreignChannel.id);
+    await assert.rejects(
+      () =>
+        toggleReaction({
+          messageId: foreignMessage.id,
+          emoji: "👍",
+          userId: alphaUser.id,
+          companyId: alpha.id,
+        }),
+      /Message not found/,
+    );
+    assert.equal(await reactionCount(), 0);
+  });
+
+  test("refuses a private channel of the same company the user is not in", async () => {
+    // Same-company is necessary but not sufficient — reacting is a write.
+    const privateChannel = await seedChannel(alpha.id, "private");
+    const message = await seedMessage(privateChannel.id);
+    await assert.rejects(
+      () =>
+        toggleReaction({
+          messageId: message.id,
+          emoji: "👍",
+          userId: alphaUser.id,
+          companyId: alpha.id,
+        }),
+      /Message not found/,
+    );
+    assert.equal(await reactionCount(), 0);
+  });
+
+  test("refuses a message id that does not exist", async () => {
+    await assert.rejects(
+      () =>
+        toggleReaction({
+          messageId: "msg_nope",
+          emoji: "👍",
+          userId: alphaUser.id,
+          companyId: alpha.id,
+        }),
+      /Message not found/,
+    );
+  });
+
+  test("the cross-tenant refusal is indistinguishable from a missing message", async () => {
+    const foreignChannel = await seedChannel(beta.id);
+    const foreignMessage = await seedMessage(foreignChannel.id);
+    const foreign = await toggleReaction({
+      messageId: foreignMessage.id,
+      emoji: "👍",
+      userId: alphaUser.id,
+      companyId: alpha.id,
+    }).catch((e) => (e as Error).message);
+    const absent = await toggleReaction({
+      messageId: "msg_nope",
+      emoji: "👍",
+      userId: alphaUser.id,
+      companyId: alpha.id,
+    }).catch((e) => (e as Error).message);
+    assert.equal(foreign, absent);
+  });
+
+  test("a foreign reaction never reaches the other company's message", async () => {
+    const foreignChannel = await seedChannel(beta.id);
+    const foreignMessage = await seedMessage(foreignChannel.id);
+    await toggleReaction({
+      messageId: foreignMessage.id,
+      emoji: "👍",
+      userId: alphaUser.id,
+      companyId: alpha.id,
+    }).catch(() => undefined);
+    const onForeign = await AppDataSource.getRepository(MessageReaction).count({
+      where: { messageId: foreignMessage.id },
+    });
+    assert.equal(onForeign, 0);
+  });
+});

--- a/App/server/services/workspaceTenancy.test.ts
+++ b/App/server/services/workspaceTenancy.test.ts
@@ -251,7 +251,28 @@ describe("createChannel", () => {
     assert.equal(await memberCount(), 0);
   });
 
-  test("refuses a foreign creator", async () => {
+  test("attribution is not validated, because it never comes from a request", async () => {
+    // `createdByUserId` is `req.userId` on the browser route — already resolved
+    // to a Membership by `requireCompanyMember` — or `Company.ownerId` derived
+    // server-side on the MCP route. Neither is caller-supplied, so checking it
+    // would buy no boundary while coupling channel creation to an invariant
+    // nothing enforces: that `Company.ownerId` always has a Membership row.
+    // Companies exist on disk for which it does not.
+    const channel = await createChannel({
+      companyId: alpha.id,
+      name: "Team",
+      topic: "",
+      kind: "public",
+      createdByUserId: "owner-with-no-membership",
+      initialMemberUserIds: [],
+      initialEmployeeIds: [],
+    });
+    assert.equal(channel.createdByUserId, "owner-with-no-membership");
+  });
+
+  test("but the caller-supplied member list still is validated", async () => {
+    // The half that IS attacker-controlled. Pinned next to the case above so
+    // the distinction cannot be lost by reading either one alone.
     await assert.rejects(
       () =>
         createChannel({
@@ -259,8 +280,8 @@ describe("createChannel", () => {
           name: "Team",
           topic: "",
           kind: "public",
-          createdByUserId: betaUser.id,
-          initialMemberUserIds: [],
+          createdByUserId: alphaUser.id,
+          initialMemberUserIds: [betaUser.id],
           initialEmployeeIds: [],
         }),
       /User not found/,

--- a/Helm/genosyn/values.yaml
+++ b/Helm/genosyn/values.yaml
@@ -57,6 +57,16 @@ ingress:
   # WebSockets share port 8471 with everything else. nginx and Traefik pass
   # Upgrade requests through a plain Ingress without extra annotations; add
   # controller-specific tuning (timeouts, buffering) here if yours needs it.
+  #
+  # `/api/internal/*` is the AI Employee tool surface. The App refuses any
+  # request to it that did not arrive on loopback, so publishing it is not
+  # exploitable — but there is no reason for the ingress to forward it at all,
+  # and blocking it there is one line of defence in depth. With
+  # ingress-nginx:
+  #
+  #   annotations:
+  #     nginx.ingress.kubernetes.io/server-snippet: |
+  #       location /api/internal { deny all; return 404; }
   annotations: {}
 
 # The /app/data volume. This must persist even when the database is Postgres:
@@ -174,7 +184,24 @@ postgres:
     size: 10Gi
     storageClass: ""
 
-resources: {}
+# Requests are set by default so the pod lands in Burstable QoS rather than
+# BestEffort. A BestEffort pod is the first thing the kubelet evicts under node
+# pressure, and at the single-replica default that pod is the whole install.
+#
+# Deliberately requests without limits: requests only affect scheduling and
+# eviction order, so raising the floor cannot OOM-kill a workload that was
+# previously fine. Shared SaaS should add limits as well — one tenant's build
+# or `npm install` inside the sandbox otherwise competes freely for the node —
+# but pick them from your own measurements, because a limit that is too low
+# turns a slow Routine into a killed one.
+#
+#   resources:
+#     requests: { cpu: 500m, memory: 1Gi }
+#     limits:   { cpu: "2",  memory: 4Gi }
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
 
 nodeSelector: {}
 tolerations: []

--- a/Home/client/docs/pages/Pipelines.tsx
+++ b/Home/client/docs/pages/Pipelines.tsx
@@ -171,6 +171,17 @@ export function Pipelines() {
         that message in the log. Because the code carries company-wide authority, only a human can
         add or edit this step — an AI Employee authoring a Pipeline is refused it.
       </P>
+      <Callout kind="warn" title="Self-hosted installs only.">
+        The <Strong>Run JavaScript</Strong> step is unavailable on Genosyn Cloud and on any install
+        running in shared SaaS mode. The step isolates code well enough to keep an honest program
+        honest — fresh globals, no dynamic code generation, hard time and memory bounds — but it is
+        not a boundary against someone deliberately trying to break out of it, and on shared
+        infrastructure that boundary has to hold against every other tenant. The step is not offered
+        in the palette, a Pipeline containing one reports an error, and a Run refuses it. Use{" "}
+        <Strong>Make an HTTP request</Strong>, the <Strong>Base</Strong> steps, or{" "}
+        <Strong>Call an integration</Strong> instead. See{" "}
+        <DocLink to="/docs/saas-hosting">Shared SaaS mode</DocLink>.
+      </Callout>
       <Pre lang="javascript">{`// Look up a lead, call an external API, and keep a score in a Base.
 const [lead] = await genosyn.base.queryRecords("crm", "leads", {
   where: { Email: input.email },

--- a/Home/client/docs/pages/SaasHosting.tsx
+++ b/Home/client/docs/pages/SaasHosting.tsx
@@ -154,6 +154,16 @@ sessionSecret: "<different 32+ character random secret>",`}</Pre>
         <LI>Company secrets are not injected into hosted coding shells.</LI>
         <LI>Arbitrary stdio MCP servers are not started in shared SaaS mode.</LI>
         <LI>
+          The Pipelines <Strong>Run JavaScript</Strong> step is refused — in the palette, at
+          validation, and at execution. Its sandbox keeps an honest program honest but is not a
+          boundary against a deliberate escape, which on shared infrastructure would reach the
+          install&apos;s own secrets. See <DocLink to="/docs/pipelines">Pipelines</DocLink>.
+        </LI>
+        <LI>
+          The internal tool API (<Code>/api/internal/*</Code>) accepts loopback requests only, and
+          refuses anything carrying proxy headers. Every legitimate caller runs beside the App.
+        </LI>
+        <LI>
           The app-owned browser is unavailable until it moves to a separately isolated browser
           worker. See <DocLink to="/docs/browser">Browser</DocLink> for self-hosted mode.
         </LI>
@@ -172,6 +182,14 @@ sessionSecret: "<different 32+ character random secret>",`}</Pre>
         shared SaaS mode until they can run in a dedicated egress worker. Fixed-host GitHub
         checkouts remain available through a granted GitHub Connection.
       </P>
+      <P>
+        A company&apos;s own <Strong>SMTP</Strong> provider is checked the same way, and separately:
+        nodemailer opens a raw socket rather than going through the patched HTTP agents, so the host
+        is resolved and refused if any answer is non-public, and the port must be 25, 465, 587 or
+        2525. Self-hosted installs are unaffected — an internal relay on a private address stays a
+        normal configuration there. From addresses are rejected if they carry control characters, so
+        a newline cannot append a <Code>Bcc:</Code> header to the company&apos;s outgoing mail.
+      </P>
 
       <H2 id="replicas">Running more than one replica</H2>
       <P>
@@ -186,7 +204,9 @@ sessionSecret: "<different 32+ character random secret>",`}</Pre>
           files and employee working trees still live there.
         </LI>
         <LI>
-          Use one migration job or allow the first replica to apply migrations before rollout.
+          Migrations take a Postgres advisory lock at boot, so replicas starting together apply
+          them once rather than racing the same DDL. A dedicated migration job is still the tidier
+          rollout, and remains the right choice for a long migration you want to watch.
         </LI>
         <LI>Forward WebSocket upgrades and preserve the original HTTPS origin at the ingress.</LI>
         <LI>


### PR DESCRIPTION
Six boundaries that have to hold before a shared install takes an external
tenant. Relates to **M28 — Shared SaaS foundation**.

Every change is gated on `config.security.multiTenant` or is a pure
correctness fix. **A self-hosted install behaves exactly as it does today**,
with one deliberate exception noted under "Behaviour changes" below.

---

## 1. The Pipelines `logic.code` step is refused in shared SaaS

**This is the one that blocks a hosted launch.** `vm.createContext` is not a
security boundary — `codeRuntime.ts` has said so in its own header since it was
written — but the consequence on shared infrastructure had not been drawn out.

The sandbox's callables are ordinary host functions, so:

```js
axios.constructor.constructor("return process")()
```

returns the worker's real `process`. The worker is a *thread*: it shares the
pid, and because `new Worker` is called with no `env` it receives a copy of the
parent environment. I verified this against `node:22-bookworm-slim`, the
runtime image:

- `process.env` yields `GENOSYN_ENCRYPTION_SECRET`, `GENOSYN_SESSION_SECRET`
  and `GENOSYN_POSTGRES_URL` — the chart injects all three
  (`Helm/genosyn/templates/deployment.yaml:84-107`).
- `process.binding("spawn_sync")` executes `/bin/sh`. I ran `id` through it and
  got output back. `process.binding("fs")` is reachable too. Only dynamic
  `import()` is blocked.

The encryption secret is the HKDF root of every scoped key, so it decrypts
every tenant's Vault, OAuth tokens and model keys; the session secret forges
any cookie. Reachability was self-serve: any verified signup creates a company
as owner, which clears `requireCompanyRoleForMutations("admin")` on
`routes/pipelines.ts`.

**Scrubbing the worker environment would not have fixed it** — the escaped
realm can still exec and read the mounted `config.js`. The only sound boundary
is that the code does not run, so the refusal sits in `executePipelineCode`
itself, with two further doors for a decent error: `validateGraph` reports it
on the step, and the catalog endpoint stops offering it.

Self-hosted installs keep the step. There the documented trust model — an admin
authored it, and every other node already runs with company authority — is
coherent, because that admin already owns the box.

> **Please read this part before merging.** The gate is on `multiTenant`, which
> is a deployment mode, not the trust boundary. A *self-hosted* install with
> open signup and more than one company is exposed today on the shipped
> release, and this PR does not change that. That is an advisory and a patched
> release, not a SaaS task, and I have not attempted either here. Nothing
> currently logs code-node source or its egress, so "has this been used?" is
> not answerable from an existing install either.

## 2. `/api/internal/*` is bound to loopback

`mcpInternalRouter` and `browserRpcRouter` mount above `requireTrustedOrigin`
and above the session middleware — correctly, since their callers are machines
with a bearer token rather than browsers with a cookie. The missing half was
that nothing checked the caller was a machine we spawned. The Helm ingress
publishes `/` with `pathType: Prefix`, so a hosted install forwarded the whole
AI-Employee tool surface (send mail, create and delete Routines, write Bases)
from the public internet, behind a seven-hour in-memory token with no `Origin`
gate and no throttling.

Every legitimate caller is loopback by construction — `protocol.ts`,
`genosyn.ts`, `taintPolicy.ts` and `mcpSources.ts` all build
`http://127.0.0.1:${config.port}` — so the new middleware costs nothing.

Two conditions, and the second matters: the socket must be loopback **and** the
request must carry no proxy headers. A reverse proxy sharing the host satisfies
the first while relaying from anywhere. The header's *value* is never trusted;
its presence decides. Refusals are 404, not 403.

`values.yaml` gains a commented ingress-nginx snippet to deny the prefix as
well — defence in depth, controller-specific, so not forced on.

## 3. Errors are redacted before they reach the operator log

`console.error("[error]", err)` printed the whole object, and TypeORM's
`QueryFailedError` carries `query` **and `parameters`** as own enumerable
properties. Every failed INSERT or UPDATE exported its bound values: the chat
message, the mail body, the Soul, the customer's name. On a hosted install
stdout goes to an aggregator with independent retention, outside any tenant's
deletion request — which makes this the one item here that cannot be fixed
after the fact.

`redactErrorForLog` is an allowlist projection, not a denylist, so a driver
error that grows a new value-bearing property in a future release does not
silently start being logged. It keeps name, message, status, code, stack and —
for a query failure — the parameterized SQL, which names the table and columns
without carrying a value.

`installProcessErrorHandlers()` covers `unhandledRejection` and
`uncaughtException`, which would otherwise print the raw object Node's default
handler dumps. The uncaught handler still exits 1; only the log line changed.

A test provokes a **genuine** `QueryFailedError` and asserts both halves: that
the raw object really would have leaked the row (so the premise is pinned
against a TypeORM upgrade), and that the projection does not.

## 4. Boot migrations take a Postgres advisory lock

`runMigrations()` reads the `migrations` table, decides what is missing, and
applies it, with no lock between the read and the write. Several pods starting
together each read "nothing applied" and race the same DDL; the losers crash on
`relation already exists`, and `failureThreshold: 6` on the liveness probe turns
that into a slow partial rollout rather than an obvious failure.

`pg_advisory_lock(classid, objid)` on a dedicated QueryRunner, with `classid`
spelling `GENO` so a `pg_locks` row is recognisable, and `lock_timeout` set so a
lock orphaned by a dead backend fails the boot loudly instead of hanging.
SQLite is single-process and keeps the direct call.

The keys are pinned by a test: a release that changed either would leave old and
new pods taking *different* locks during a rolling upgrade, silently
reintroducing the exact race the lock exists to prevent.

## 5. Tenant-supplied mail destinations are checked

`installOutboundNetworkPolicy` patches the global HTTP agents and the undici
dispatcher. Nodemailer uses neither — it opens a raw TCP socket — so the SMTP
host on an `EmailProvider` was the one outbound destination in the product with
no check at all. A tenant admin could point a provider at `10.0.0.5:6379` and
read the connection outcome off the Test button: a port scanner of the cluster
network, with the non-standard-port branch of `resolveSmtpTransportSecurity`
leaving it plaintext.

Hosted installs now resolve the host and refuse every non-public answer, and
restrict the port to 25/465/587/2525. Self-hosted installs are untouched — an
internal relay is an ordinary configuration there, and that admin owns the
network. **The operator's own global SMTP transport is a separate path in
`email.ts` and is deliberately not restricted**, so a hosted operator can still
run an in-cluster relay.

`fromAddress` was `z.string().min(3).max(254)`, which accepts a newline —
header injection into the company's outgoing mail. Now: no control characters
anywhere, and the whole value must parse via `normalizeEmail`. Both checks are
needed; `normalizeEmail` validates only the *extracted* address, so a newline
in a `Display Name <a@b>` prefix survives it alone. There is a test for exactly
that case.

**The Mail subsystem guard is defence in depth, not a hole being closed.**
`imap` is already in `SHARED_SAAS_BLOCKED_PROVIDERS`, so a shared install
refuses to create one of those Connections — that remains the primary control.
What was missing is the operation-level half this codebase applies everywhere
else (`memberBrowsersEnabled`, `assertRepositoryWorkAllowed`): a row that
predates the flag, or arrives in a restore, would still be synced over a raw
socket to a tenant-named host.

Also fixes a real quirk in `assertSafeOutboundUrl`: `new URL("http://[::1]").hostname`
keeps the brackets, which `net.isIP` does not recognise, so every IPv6 literal
fell through to a DNS lookup of a bracketed string. It failed *closed*, so
nothing unsafe was reachable — but it failed with `ENOTFOUND` rather than the
real reason, and refused public IPv6 literals just as indiscriminately.

## 6. Workspace channel writes are scoped to the company

`findOrCreateDM`, `createChannel` and `addChannelMembers` took caller-supplied
`userId` / `employeeId` values straight from a request body. The browser routes
authorize the *caller* against the company in the URL and never checked the ids
in the payload — so a Member of company A could name a user or an AI Employee
of company B, leave a durable `ChannelMember` row, and have `hydrateChannel`
read that person's name and email straight back out.

This is an oversight rather than a design choice: the MCP twin of the same
operation has always checked, refusing a cross-company target by loading through
`companyId`. The rule now lives at the seam that writes the row, so neither door
can route around it. A Membership — not merely a `User` row — is what makes a
person part of a company, so that is what is checked.

Separately, `POST /workspace/messages/:messageId/reactions` had no
authorization at all, unlike its ten siblings: `toggleReaction` did
`messages.findOneBy({ id })` with no company hop, while `editMessage` and
`softDeleteMessage` both make one. It now resolves the channel through the
company *and* checks channel access, since same-company is not sufficient for a
private channel or a DM.

Refusals are deliberately indistinguishable from "not found" — the difference
would itself be a cross-tenant existence oracle — and every test asserts both
that the call is refused **and** that nothing was written.

## 7. The pod gets resource requests

`resources: {}` put the app in BestEffort QoS, first to be evicted under node
pressure; at the single-replica default that is the whole install. Requests
only, deliberately: they affect scheduling and eviction order, so raising the
floor cannot OOM-kill a workload that was previously fine. Limits are documented
as a shared-SaaS recommendation with a worked example, because a limit picked
without measurement turns a slow Routine into a killed one.

---

## Behaviour changes

- **Shared SaaS only:** the `logic.code` step, private/odd-port SMTP targets,
  and off-box `/api/internal` calls are refused. An existing hosted Pipeline
  with a code step will now fail its Run with a clear message and report an
  error in the editor.
- **All installs:** `fromAddress` rejects control characters and values that do
  not parse as an address. This is the one change that can reject a
  previously-accepted configuration on a self-hosted install — a From address
  that was never a valid address to begin with.
- **All installs:** the default Helm `resources` block is no longer empty.
  Existing releases that set their own `resources` are unaffected.

## Tests

Eight new test files (244 new tests). Run together with the existing
outbound-URL suite they extend, the nine files are **254 tests, all passing**.
Per AGENTS.md I ran the tests I wrote rather than the whole suite, and let CI
cover the rest. `eslint` and `tsc` are clean across every changed file in both
`App/` and `Home/`.

The two worth looking at:

- `codeGate.test.ts` ends with a test asserting the sandbox **is** escapable on
  a single-tenant install. It is phrased as a live check rather than a comment
  because the gate is only justified while that holds — if someone rebuilds the
  node out-of-process, that test *should* fail, and the failure is the signal to
  revisit the gate. It asserts on pid and key *names*, never on a secret value.
- `errorRedaction.test.ts` asserts the premise as well as the fix, so a TypeORM
  upgrade that changes the error shape fails here rather than silently in
  production.

## Manual verification

- Reproduced the sandbox escape on `node:22-bookworm-slim` (env read + command
  execution), then confirmed all three doors refuse it with `multiTenant: true`.
- `npm run typecheck` in `App/` (all three projects) and `Home/`; `eslint` on
  every changed file in both.
- The nine test files above, run together and individually.
- Chart values parsed and asserted.

## Not in this PR

From the same review, and deliberately left out: the unfenced cron scheduler
lease, Standdown reaching only the replica that received the request, the
61-minute Run-orphan window, the billing lifecycle gaps, and the CI lint rule
that would fail an id-only `where` on a `companyId`-bearing entity. That last
one is the highest-leverage item on the list — tenant isolation currently rests
on ~700 hand-written `companyId` predicates with no database-level backstop —
but it is a change to CI and a sweep of the codebase, and it does not belong in
a PR about boundaries.
