### PR TITLE
Stop leaking a database-sized snapshot every time a backup is killed

### DIFF
--- a/App/server/services/backups.test.ts
+++ b/App/server/services/backups.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
@@ -12,7 +13,14 @@ import {
   getEffectiveInstanceSecrets,
   resetInstanceSecretsCacheForTests,
 } from "../lib/instanceSecrets.js";
-import { backupFilePath, runBackup } from "./backups.js";
+import { AppDataSource } from "../db/datasource.js";
+import {
+  backupDir,
+  backupFilePath,
+  bootBackups,
+  runBackup,
+  sweepOrphanedStagingArtifacts,
+} from "./backups.js";
 
 type MutableConfig = {
   dataDir: string;
@@ -75,5 +83,335 @@ describe("backup archive generation", () => {
 
     const marker = archive.files.find((entry) => entry.path === "companies/release-lab/marker.txt");
     assert.equal((await marker?.buffer())?.toString("utf8"), "release proof");
+  });
+});
+
+/**
+ * Regression coverage for the staging-snapshot leak.
+ *
+ * Each run stages a `VACUUM INTO` copy of the database at
+ * `Backup/.staging-<id>.sqlite` before zipping it. That snapshot is the size of
+ * the whole database, and two things used to strand copies of it forever:
+ *
+ *   1. the cleanup ran only in `runBackupInner`'s `finally`, which a SIGKILL
+ *      (container restart, OOM killer) skips entirely — and nothing else ever
+ *      looked for the leftovers;
+ *   2. the cleanup unlinked only the `.sqlite`, so the rollback journal
+ *      `VACUUM INTO` writes beside it survived *every* run, successful or not.
+ *
+ * On a real install that reached 121 GB of stranded snapshots.
+ */
+
+/** Absolute path of a plausible staging snapshot nobody owns. */
+function orphanStagingPath(id = randomUUID()): string {
+  return path.join(backupDir(), `.staging-${id}.sqlite`);
+}
+
+async function writeFileEnsuringDir(abs: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, contents);
+}
+
+async function exists(abs: string): Promise<boolean> {
+  try {
+    await fs.stat(abs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listBackupDir(): Promise<string[]> {
+  try {
+    return (await fs.readdir(backupDir())).sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Run `fn` with the SQLite snapshot path enabled, restoring the driver after. */
+async function withSqliteDriver<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = mutable.db.driver;
+  mutable.db.driver = "sqlite";
+  try {
+    return await fn();
+  } finally {
+    mutable.db.driver = previous;
+  }
+}
+
+/**
+ * Replace `AppDataSource.createQueryRunner` so `VACUUM INTO` can be observed or
+ * subverted. Returns a restore function. The real runner still does the work
+ * unless `onVacuum` throws.
+ */
+function patchVacuum(onVacuum: (dest: string) => void | Promise<void>): () => void {
+  type Runner = ReturnType<typeof AppDataSource.createQueryRunner>;
+  const originalCreate = AppDataSource.createQueryRunner.bind(AppDataSource);
+  // better-sqlite3 hands back one shared query runner, so a wrapper installed
+  // on the instance outlives this patch unless every one is put back — left
+  // alone they stack, and a later test inherits this test's behaviour.
+  const wrapped: Array<{ runner: Runner; query: Runner["query"] }> = [];
+
+  (AppDataSource as unknown as { createQueryRunner: unknown }).createQueryRunner = () => {
+    const runner = originalCreate();
+    const originalQuery = runner.query.bind(runner);
+    wrapped.push({ runner, query: runner.query });
+    // Forward every argument: TypeORM passes a third `useStructuredResult`
+    // flag on the read path, and swallowing it breaks unrelated queries.
+    runner.query = async (...args: Parameters<Runner["query"]>) => {
+      const result = await originalQuery(...args);
+      const [sql, params] = args;
+      if (typeof sql === "string" && sql.includes("VACUUM INTO")) {
+        await onVacuum(String((params as unknown[] | undefined)?.[0] ?? ""));
+      }
+      return result;
+    };
+    return runner;
+  };
+
+  return () => {
+    (AppDataSource as unknown as { createQueryRunner: unknown }).createQueryRunner = originalCreate;
+    for (const entry of wrapped.reverse()) entry.runner.query = entry.query;
+    wrapped.length = 0;
+  };
+}
+
+describe("staging snapshot sweep", () => {
+  test("removes an orphaned staging snapshot left by a killed run", async () => {
+    const orphan = orphanStagingPath();
+    await writeFileEnsuringDir(orphan, "pretend 15GB snapshot");
+
+    assert.equal(sweepOrphanedStagingArtifacts(), 1);
+    assert.equal(await exists(orphan), false);
+  });
+
+  test("removes the SQLite sidecars that used to survive every run", async () => {
+    const base = orphanStagingPath();
+    const sidecars = ["-journal", "-wal", "-shm"].map((suffix) => `${base}${suffix}`);
+    await writeFileEnsuringDir(base, "snapshot");
+    for (const sidecar of sidecars) await writeFileEnsuringDir(sidecar, "sidecar");
+
+    assert.equal(sweepOrphanedStagingArtifacts(), 4);
+    for (const abs of [base, ...sidecars]) {
+      assert.equal(await exists(abs), false, `${path.basename(abs)} should be gone`);
+    }
+  });
+
+  test("sweeps a sidecar whose snapshot is already gone", async () => {
+    // Exactly the state the old cleanup left behind: the `.sqlite` was
+    // unlinked by the `finally`, the journal beside it was not.
+    const stranded = `${orphanStagingPath()}-journal`;
+    await writeFileEnsuringDir(stranded, "orphaned journal");
+
+    assert.equal(sweepOrphanedStagingArtifacts(), 1);
+    assert.equal(await exists(stranded), false);
+  });
+
+  test("clears a whole backlog of stranded snapshots in one pass", async () => {
+    const orphans = Array.from({ length: 9 }, () => orphanStagingPath());
+    for (const orphan of orphans) await writeFileEnsuringDir(orphan, "snapshot");
+
+    assert.equal(sweepOrphanedStagingArtifacts(), 9);
+    assert.deepEqual(await listBackupDir(), []);
+  });
+
+  test("never touches archives or unrelated files", async () => {
+    const keep = [
+      path.join(backupDir(), "backup-2026-08-21-145706.zip"),
+      path.join(backupDir(), "uploaded-2026-05-04-161705.zip"),
+      path.join(backupDir(), "backup-2026-09-02-195253.zip.part"),
+      path.join(backupDir(), "notes.txt"),
+      path.join(backupDir(), "staging-without-leading-dot.sqlite"),
+    ];
+    for (const abs of keep) await writeFileEnsuringDir(abs, "keep me");
+    const orphan = orphanStagingPath();
+    await writeFileEnsuringDir(orphan, "snapshot");
+
+    assert.equal(sweepOrphanedStagingArtifacts(), 1);
+    assert.equal(await exists(orphan), false);
+    for (const abs of keep) {
+      assert.equal(await exists(abs), true, `${path.basename(abs)} must survive the sweep`);
+    }
+  });
+
+  test("is idempotent and a no-op on a clean directory", async () => {
+    await writeFileEnsuringDir(orphanStagingPath(), "snapshot");
+    assert.equal(sweepOrphanedStagingArtifacts(), 1);
+    assert.equal(sweepOrphanedStagingArtifacts(), 0);
+    assert.equal(sweepOrphanedStagingArtifacts(), 0);
+  });
+
+  test("does not throw when the Backup directory does not exist", async () => {
+    await fs.rm(backupDir(), { recursive: true, force: true });
+    assert.equal(sweepOrphanedStagingArtifacts(), 0);
+  });
+});
+
+describe("backup run staging hygiene", () => {
+  test("leaves no staging artifact behind after a successful SQLite run", async () => {
+    getEffectiveInstanceSecrets();
+
+    const backup = await withSqliteDriver(() => runBackup("manual"));
+    assert.equal(backup.status, "completed");
+
+    const leftovers = (await listBackupDir()).filter((name) => name.startsWith(".staging-"));
+    assert.deepEqual(leftovers, [], `staging artifacts survived the run: ${leftovers.join(", ")}`);
+  });
+
+  test("removes the journal SQLite leaves beside the snapshot", async () => {
+    getEffectiveInstanceSecrets();
+
+    // Whether `VACUUM INTO` leaves a journal is a SQLite build detail, so plant
+    // one at the moment the snapshot lands rather than depending on it.
+    let stagedJournal = "";
+    const restore = patchVacuum(async (dest) => {
+      stagedJournal = `${dest}-journal`;
+      await fs.writeFile(stagedJournal, "rollback journal");
+    });
+
+    try {
+      const backup = await withSqliteDriver(() => runBackup("manual"));
+      assert.equal(backup.status, "completed");
+    } finally {
+      restore();
+    }
+
+    assert.notEqual(stagedJournal, "", "the VACUUM INTO patch never fired");
+    assert.equal(await exists(stagedJournal), false, "the staging journal was left behind");
+  });
+
+  test("still ships the snapshot as app.sqlite once cleanup is in play", async () => {
+    getEffectiveInstanceSecrets();
+    const marker = path.join(tempDir, "companies", "release-lab", "marker.txt");
+    await fs.writeFile(marker, "snapshot proof");
+
+    const backup = await withSqliteDriver(() => runBackup("manual"));
+    const archive = await unzipper.Open.file(backupFilePath(backup.filename));
+    const names = archive.files.map((entry) => entry.path);
+
+    assert.ok(names.includes("app.sqlite"), "the archive lost its database snapshot");
+    assert.ok(names.includes("companies/release-lab/marker.txt"));
+    assert.equal(
+      names.some((name) => name.includes(".staging-")),
+      false,
+      "staging artifacts must never be archived",
+    );
+  });
+
+  test("cleans up the snapshot when the run fails", async () => {
+    getEffectiveInstanceSecrets();
+
+    // Write the snapshot, then blow up — the shape of a run that dies after
+    // staging. The `finally` must still collect it.
+    const restore = patchVacuum(async (dest) => {
+      await fs.writeFile(dest, "half-staged snapshot");
+      await fs.writeFile(`${dest}-journal`, "rollback journal");
+      throw new Error("simulated snapshot failure");
+    });
+
+    try {
+      await assert.rejects(
+        withSqliteDriver(() => runBackup("manual")),
+        /simulated snapshot failure/,
+      );
+    } finally {
+      restore();
+    }
+
+    const leftovers = (await listBackupDir()).filter((name) => name.startsWith(".staging-"));
+    assert.deepEqual(leftovers, [], `failed run stranded: ${leftovers.join(", ")}`);
+  });
+
+  test("sweeps snapshots stranded by an earlier killed run before staging its own", async () => {
+    getEffectiveInstanceSecrets();
+    const stranded = Array.from({ length: 3 }, () => orphanStagingPath());
+    for (const orphan of stranded) await writeFileEnsuringDir(orphan, "snapshot from a dead run");
+
+    const backup = await runBackup("manual");
+    assert.equal(backup.status, "completed");
+
+    for (const orphan of stranded) {
+      assert.equal(await exists(orphan), false, `${path.basename(orphan)} should have been swept`);
+    }
+  });
+
+  test("refuses to sweep the snapshot of a run that is still in flight", async () => {
+    getEffectiveInstanceSecrets();
+
+    // Sweep from inside the run, at the one moment the live snapshot is on
+    // disk. Without the in-flight guard this deletes the file the run is about
+    // to archive.
+    let sweptDuringRun = -1;
+    let snapshotPresentDuringRun = false;
+    const restore = patchVacuum(async (dest) => {
+      snapshotPresentDuringRun = await exists(dest);
+      sweptDuringRun = sweepOrphanedStagingArtifacts();
+      assert.equal(await exists(dest), true, "the live snapshot was swept out from under the run");
+    });
+
+    let backup;
+    try {
+      backup = await withSqliteDriver(() => runBackup("manual"));
+    } finally {
+      restore();
+    }
+
+    assert.equal(snapshotPresentDuringRun, true, "expected a staged snapshot mid-run");
+    assert.equal(sweptDuringRun, 0, "the sweep must skip a live run's snapshot");
+    assert.equal(backup.status, "completed");
+
+    const archive = await unzipper.Open.file(backupFilePath(backup.filename));
+    assert.ok(archive.files.some((entry) => entry.path === "app.sqlite"));
+  });
+
+  test("releases the in-flight marker once the run is over", async () => {
+    getEffectiveInstanceSecrets();
+
+    let stagingPath = "";
+    const restore = patchVacuum((dest) => {
+      stagingPath = dest;
+    });
+    try {
+      await withSqliteDriver(() => runBackup("manual"));
+    } finally {
+      restore();
+    }
+    assert.notEqual(stagingPath, "", "never observed a staging path");
+
+    // A later run reusing that exact path must be sweepable, or a single
+    // backup would pin it as un-collectable for the life of the process.
+    await writeFileEnsuringDir(stagingPath, "debris reusing the old id");
+    assert.equal(sweepOrphanedStagingArtifacts(), 1);
+    assert.equal(await exists(stagingPath), false);
+  });
+});
+
+describe("boot recovery", () => {
+  test("sweeps snapshots stranded by a crash on the next boot", async () => {
+    // The production shape of the leak: the container is SIGKILLed part-way
+    // through a backup, so `runBackupInner`'s `finally` never runs. Restarting
+    // is the first opportunity to reclaim the space, and before this it was
+    // never taken — the snapshots simply accumulated, one per killed run.
+    const stranded = Array.from({ length: 4 }, () => orphanStagingPath());
+    for (const orphan of stranded) await writeFileEnsuringDir(orphan, "snapshot from a dead run");
+    const strandedJournal = `${stranded[0]}-journal`;
+    await writeFileEnsuringDir(strandedJournal, "rollback journal");
+
+    // A real archive alongside them must come through untouched.
+    getEffectiveInstanceSecrets();
+
+    // Under the SQLite driver throughout: that is what a self-hosted install
+    // runs, and it is the configuration whose scheduler leases are in-process.
+    const survivor = await withSqliteDriver(async () => {
+      const created = await runBackup("manual");
+      await bootBackups();
+      return created;
+    });
+
+    for (const orphan of [...stranded, strandedJournal]) {
+      assert.equal(await exists(orphan), false, `${path.basename(orphan)} survived boot`);
+    }
+    assert.equal(await exists(backupFilePath(survivor.filename)), true);
   });
 });

--- a/App/server/services/backups.test.ts
+++ b/App/server/services/backups.test.ts
@@ -145,7 +145,7 @@ async function withSqliteDriver<T>(fn: () => Promise<T>): Promise<T> {
  * subverted. Returns a restore function. The real runner still does the work
  * unless `onVacuum` throws.
  */
-function patchVacuum(onVacuum: (dest: string) => void | Promise<void>): () => void {
+function patchQuery(onQuery: (sql: string, params: unknown[]) => void | Promise<void>): () => void {
   type Runner = ReturnType<typeof AppDataSource.createQueryRunner>;
   const originalCreate = AppDataSource.createQueryRunner.bind(AppDataSource);
   // better-sqlite3 hands back one shared query runner, so a wrapper installed
@@ -162,8 +162,8 @@ function patchVacuum(onVacuum: (dest: string) => void | Promise<void>): () => vo
     runner.query = async (...args: Parameters<Runner["query"]>) => {
       const result = await originalQuery(...args);
       const [sql, params] = args;
-      if (typeof sql === "string" && sql.includes("VACUUM INTO")) {
-        await onVacuum(String((params as unknown[] | undefined)?.[0] ?? ""));
+      if (typeof sql === "string") {
+        await onQuery(sql, (params as unknown[] | undefined) ?? []);
       }
       return result;
     };
@@ -175,6 +175,13 @@ function patchVacuum(onVacuum: (dest: string) => void | Promise<void>): () => vo
     for (const entry of wrapped.reverse()) entry.runner.query = entry.query;
     wrapped.length = 0;
   };
+}
+
+/** {@link patchQuery} narrowed to the `VACUUM INTO` that stages the snapshot. */
+function patchVacuum(onVacuum: (dest: string) => void | Promise<void>): () => void {
+  return patchQuery(async (sql, params) => {
+    if (sql.includes("VACUUM INTO")) await onVacuum(String(params[0] ?? ""));
+  });
 }
 
 describe("staging snapshot sweep", () => {
@@ -413,5 +420,47 @@ describe("boot recovery", () => {
       assert.equal(await exists(orphan), false, `${path.basename(orphan)} survived boot`);
     }
     assert.equal(await exists(backupFilePath(survivor.filename)), true);
+  });
+});
+
+describe("staging snapshot lifetime", () => {
+  test("releases the snapshot as soon as the archive lands, not at the end of the run", async () => {
+    // The snapshot used to be held until the run's `finally`, which sits after
+    // off-box delivery and retention. Delivery streams the whole archive to a
+    // NAS or remote volume and can run for hours on a large install, so the
+    // snapshot doubled peak disk usage for that entire window — and anything
+    // that killed the process during it stranded a database-sized file.
+    getEffectiveInstanceSecrets();
+
+    let stagingPath = "";
+    let snapshotLiveAfterZip: boolean | null = null;
+    const restore = patchQuery(async (sql, params) => {
+      if (sql.includes("VACUUM INTO")) {
+        stagingPath = String(params[0] ?? "");
+        return;
+      }
+      // The first UPDATE of the backup row after the snapshot is staged is the
+      // one marking it completed — the first thing the run does once the zip
+      // is renamed into place, and well before delivery or retention.
+      if (!stagingPath || snapshotLiveAfterZip !== null) return;
+      if (/^\s*update/i.test(sql) && /backup/i.test(sql)) {
+        snapshotLiveAfterZip = await exists(stagingPath);
+      }
+    });
+
+    let backup;
+    try {
+      backup = await withSqliteDriver(() => runBackup("manual"));
+    } finally {
+      restore();
+    }
+
+    assert.notEqual(stagingPath, "", "never observed a staged snapshot");
+    assert.equal(snapshotLiveAfterZip, false, "the snapshot outlived the archive it was staged for");
+    assert.equal(backup.status, "completed");
+
+    // Releasing early must not cost the archive its database.
+    const archive = await unzipper.Open.file(backupFilePath(backup.filename));
+    assert.ok(archive.files.some((entry) => entry.path === "app.sqlite"));
   });
 });

--- a/App/server/services/backups.ts
+++ b/App/server/services/backups.ts
@@ -610,6 +610,14 @@ async function runBackupInner(kind: "manual" | "scheduled"): Promise<Backup> {
   try {
     await snapshotSqlite(stagingDbPath);
     await writeZip(outPath, stagingDbPath);
+    // The archive is written and renamed into place, and nothing below reads
+    // the snapshot again — so release it here rather than leaving it to the
+    // `finally`. Off-box delivery can stream a 20 GB archive for hours, and
+    // holding a database-sized snapshot across that doubles peak disk usage
+    // for the whole of it and widens the window in which a SIGKILL strands it.
+    // The `finally` still runs and is idempotent; this only makes it earlier.
+    removeStagingArtifact(stagingDbPath);
+    activeStagingPaths.delete(stagingDbPath);
     const size = fs.existsSync(outPath) ? fs.statSync(outPath).size : 0;
     row.sizeBytes = size;
     row.status = "completed";

--- a/App/server/services/backups.ts
+++ b/App/server/services/backups.ts
@@ -65,6 +65,22 @@ const ZipArchive = (
 const PART_SUFFIX = ".part";
 
 /**
+ * Prefix for the `VACUUM INTO` snapshot a run stages before zipping it.
+ * Hidden, and deliberately distinct from {@link PART_SUFFIX}, so
+ * {@link sweepOrphanedStagingArtifacts} can tell a stranded snapshot from a
+ * half-written archive without consulting the `backups` table.
+ */
+const STAGING_PREFIX = ".staging-";
+
+/**
+ * Sidecars SQLite can leave beside a database file. `VACUUM INTO` writes a
+ * rollback journal next to its destination, and the cleanup used to unlink
+ * only the `.sqlite` itself — so every single run, successful or not, left a
+ * `.staging-<id>.sqlite-journal` behind for good.
+ */
+const SQLITE_SIDECAR_SUFFIXES = ["-journal", "-wal", "-shm"] as const;
+
+/**
  * Hourly rather than daily so a window that lapses at 14:05 isn't enforced at
  * 03:00 the next morning. The prune is a cheap no-op when nothing is past the
  * cutoff.
@@ -84,6 +100,20 @@ let scheduledTask: ScheduledTask | null = null;
 let retentionTask: ScheduledTask | null = null;
 let runningBackup: Promise<Backup> | null = null;
 let runningPrune: Promise<number> | null = null;
+
+/**
+ * Staging paths owned by a run that is still in flight. {@link
+ * sweepOrphanedStagingArtifacts} consults this so it can never unlink the
+ * snapshot a live backup is part-way through zipping — the sweep runs from
+ * boot reconcile and from the start of each run, either of which could in
+ * principle overlap one.
+ *
+ * In-process is enough to be authoritative here: staging snapshots only exist
+ * under the SQLite driver ({@link snapshotSqlite} is a no-op otherwise), and
+ * that is the single-process self-hosted install. A Postgres deployment never
+ * stages one to begin with.
+ */
+const activeStagingPaths = new Set<string>();
 
 /**
  * True from the moment a restore is accepted until it finishes. Shared with
@@ -113,6 +143,82 @@ export function backupFilePath(filename: string): string {
 function ensureBackupDir(): void {
   fs.mkdirSync(backupDir(), { recursive: true });
   fs.chmodSync(backupDir(), 0o700);
+}
+
+/**
+ * Map a staging entry back to the snapshot path that owns it, so a sidecar and
+ * the `.sqlite` it belongs to answer {@link activeStagingPaths} identically.
+ */
+function stagingOwnerPath(abs: string): string {
+  for (const suffix of SQLITE_SIDECAR_SUFFIXES) {
+    if (abs.endsWith(suffix)) return abs.slice(0, -suffix.length);
+  }
+  return abs;
+}
+
+/**
+ * Unlink a staging snapshot together with every sidecar SQLite may have put
+ * beside it. Best-effort: this runs on the success path of a backup that has
+ * already been recorded, so a file that won't unlink must not fail the run.
+ */
+function removeStagingArtifact(stagingPath: string): void {
+  const paths = [stagingPath, ...SQLITE_SIDECAR_SUFFIXES.map((s) => `${stagingPath}${s}`)];
+  for (const p of paths) {
+    try {
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Delete staging snapshots that no live run owns.
+ *
+ * `runBackupInner` unlinks its own snapshot in a `finally`, but that block
+ * never executes if the process dies between `VACUUM INTO` and the end of the
+ * run — a SIGKILL from a container restart or the OOM killer, which is exactly
+ * what a backup of a large database invites. Each stranded snapshot is a full
+ * copy of the database, so they dwarf the archives they were staged for and
+ * accumulate silently until the volume fills.
+ *
+ * Called from {@link reconcileBackupHistory} (so a restart clears the debris)
+ * and at the top of each run (so an install that never restarts still recovers
+ * the space, at the one moment it is about to need it).
+ *
+ * Returns how many files were removed.
+ */
+export function sweepOrphanedStagingArtifacts(): number {
+  const dir = backupDir();
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  let bytes = 0;
+  for (const entry of entries) {
+    if (!entry.startsWith(STAGING_PREFIX)) continue;
+    const abs = path.join(dir, entry);
+    if (activeStagingPaths.has(stagingOwnerPath(abs))) continue;
+    try {
+      const size = fs.statSync(abs).size;
+      fs.unlinkSync(abs);
+      removed += 1;
+      bytes += size;
+    } catch {
+      // best-effort — a snapshot we can't unlink is retried on the next sweep
+    }
+  }
+
+  if (removed > 0) {
+    const mb = Math.round(bytes / (1024 * 1024));
+    // eslint-disable-next-line no-console
+    console.log(`[backups] swept ${removed} orphaned staging file(s), reclaiming ~${mb} MB`);
+  }
+  return removed;
 }
 
 /**
@@ -480,6 +586,10 @@ export async function runBackup(kind: "manual" | "scheduled"): Promise<Backup> {
 
 async function runBackupInner(kind: "manual" | "scheduled"): Promise<Backup> {
   ensureBackupDir();
+  // Reclaim debris from any previous run killed mid-flight before staging a
+  // fresh snapshot of our own. A long-lived install that never restarts would
+  // otherwise never sweep, and this is the moment the space is about to matter.
+  sweepOrphanedStagingArtifacts();
   const repo = AppDataSource.getRepository(Backup);
   const startedAt = new Date();
   const filename = `backup-${timestampSuffix(startedAt)}.zip`;
@@ -494,7 +604,8 @@ async function runBackupInner(kind: "manual" | "scheduled"): Promise<Backup> {
   await repo.save(row);
 
   const outPath = backupFilePath(filename);
-  const stagingDbPath = path.join(backupDir(), `.staging-${row.id}.sqlite`);
+  const stagingDbPath = path.join(backupDir(), `${STAGING_PREFIX}${row.id}.sqlite`);
+  activeStagingPaths.add(stagingDbPath);
 
   try {
     await snapshotSqlite(stagingDbPath);
@@ -550,11 +661,11 @@ async function runBackupInner(kind: "manual" | "scheduled"): Promise<Backup> {
     }
     throw err;
   } finally {
-    try {
-      if (fs.existsSync(stagingDbPath)) fs.unlinkSync(stagingDbPath);
-    } catch {
-      // best-effort
-    }
+    // Sidecars as well as the snapshot: `VACUUM INTO` leaves a rollback
+    // journal beside its destination, and unlinking only the `.sqlite` left
+    // one behind on every run.
+    removeStagingArtifact(stagingDbPath);
+    activeStagingPaths.delete(stagingDbPath);
   }
 
   return row;
@@ -567,7 +678,10 @@ async function runBackupInner(kind: "manual" | "scheduled"): Promise<Backup> {
  */
 async function snapshotSqlite(dest: string): Promise<void> {
   if (config.db.driver !== "sqlite") return;
-  if (fs.existsSync(dest)) fs.unlinkSync(dest);
+  // Clear the destination *and* its sidecars: `VACUUM INTO` refuses a path
+  // that already exists, and a journal stranded beside a fresh snapshot would
+  // be replayed into it the next time the file is opened.
+  removeStagingArtifact(dest);
   const runner = AppDataSource.createQueryRunner();
   try {
     await runner.query(`VACUUM INTO ?`, [dest]);
@@ -950,6 +1064,11 @@ async function reconcileBackupHistory(): Promise<void> {
   const dir = backupDir();
   if (!fs.existsSync(dir)) return;
   const repo = AppDataSource.getRepository(Backup);
+
+  // Snapshots stranded by a run that was killed before its `finally` could
+  // run. Nothing else ever collects these, and each one is the size of the
+  // whole database, so a restart is the first chance to get the space back.
+  sweepOrphanedStagingArtifacts();
 
   // Sweep debris from a backup killed mid-write. The `.part` name is what kept
   // it from being mistaken for an archive; nothing can resume one, so it is


### PR DESCRIPTION
## The bug

Every backup stages a `VACUUM INTO` copy of the database at
`Backup/.staging-<id>.sqlite`, zips it, and unlinks it in a `finally`. Two
things stranded those copies:

1. **A killed run never reaches its `finally`.** A SIGKILL between `VACUUM INTO`
   and the end of the run — container restart, OOM killer, exactly what a backup
   of a large database invites — skips the cleanup, and nothing else ever looked
   for the leftovers. `reconcileBackupHistory()` swept `.part` archives on boot
   but not staging snapshots, so each stranded copy stayed forever.
2. **The sidecars were never cleaned up at all.** The cleanup unlinked only the
   `.sqlite`; `VACUUM INTO` writes a rollback journal beside its destination, so
   a `.staging-<id>.sqlite-journal` survived *every* run, successful or not.

Each snapshot is the size of the whole database, so they dwarf the archives
they were staged for. Found on a live install that had accumulated **121 GB**
across 9 stranded snapshots dating back six weeks, plus ~20 orphaned journals,
having run its volume to 99% full — with a backup in flight that would have
failed on a full disk.

```
-rw-r--r-- 1 node node 14951124992 Aug 21 .staging-0c15ea85-….sqlite
-rw-r--r-- 1 node node 14926639104 Aug 20 .staging-30713ea5-….sqlite
-rw-r--r-- 1 node node 14867136512 Aug 17 .staging-4494627f-….sqlite
…                                          (9 in total, ~15 GB each)
```

## The fix

- `sweepOrphanedStagingArtifacts()` deletes staging artifacts no live run owns.
  Called from `reconcileBackupHistory()`, so a restart reclaims crash debris,
  and at the top of every run, so an install that never restarts still recovers
  the space — at the one moment it is about to need it.
- Cleanup now removes the snapshot *and* its `-journal` / `-wal` / `-shm`
  sidecars, on both the success and failure paths. `snapshotSqlite()` clears the
  same set before `VACUUM INTO`, so a stale journal can't be replayed into a
  fresh snapshot.
- An `activeStagingPaths` set keeps the sweep off the snapshot a live run is
  still zipping. In-process is authoritative here: staging snapshots only exist
  under the SQLite driver, which is the single-process self-hosted install — a
  Postgres deployment never stages one.

Behaviour is unchanged for everything else: archives, `.part` files, uploaded
archives, and unrelated files in `Backup/` are all left alone.

- **The snapshot is freed as soon as the archive lands**, instead of at the end
  of the run. It used to be held through off-box delivery and retention —
  delivery streams the whole archive to a NAS or remote volume, hours for a
  20 GB archive, and a database-sized snapshot sat beside the finished zip for
  all of it. That doubled peak disk during every backup and made the window a
  SIGKILL could strand the snapshot in as wide as the run itself. Observed on
  the live install: a completed 21 GB archive still holding its 15 GB snapshot
  15+ minutes after the zip was renamed into place. The `finally` stays as an
  idempotent backstop for the failure path.

## Tests

17 tests in `backups.test.ts` (was 1). Sweep semantics, run hygiene across the
success/failure paths, the crash-recovery boot path, and the in-flight safety
guard. The run-level tests exercise the real `VACUUM INTO` path against the
in-memory DB rather than stubbing the snapshot out.

Each part of the fix was verified to be load-bearing by reverting it and
confirming the matching tests fail:

| Reverted | Tests that fail |
| --- | --- |
| Both sweep call sites | `sweeps snapshots stranded by an earlier killed run…`, `sweeps snapshots stranded by a crash on the next boot` |
| Sidecar cleanup | `removes the journal SQLite leaves beside the snapshot`, `cleans up the snapshot when the run fails` |
| `activeStagingPaths` guard | `refuses to sweep the snapshot of a run that is still in flight` |
| Early release after `writeZip` | `releases the snapshot as soon as the archive lands…` |

## Checks run

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm test` — 7168 tests, 7158 pass, 9 skipped, 1 unrelated failure: a
  load-sensitive flake in `coding.test.ts`'s 250 ms per-file regex guard, which
  passes when that file is run on its own.

No migration (no schema change) and no docs update (no user-visible surface;
the only new output is a server log line when a sweep reclaims space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGpQWiJH3f7TDdY4BJX3ZY

