### PR TITLE
Make the employee work timeline human-readable

### DIFF
--- a/App/client/components/home/WorkTimelinePanel.test.ts
+++ b/App/client/components/home/WorkTimelinePanel.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { Company, Employee } from "../../lib/api.js";
+import { EmployeeWorkBubble, TeamSpotlight, WorkTimelinePanel } from "./WorkTimelinePanel.js";
+
+/**
+ * The App deliberately has no browser-like unit-test DOM. Server rendering is
+ * enough to pin the bubble's accessibility contract: it remains a real button,
+ * exposes selection and status without relying on colour, and keeps its large
+ * visual target even when the avatar falls back to initials.
+ */
+function renderBubble(
+  overrides: Partial<React.ComponentProps<typeof EmployeeWorkBubble>> = {},
+): string {
+  return renderToStaticMarkup(
+    React.createElement(EmployeeWorkBubble, {
+      name: "Rey",
+      role: "Customer support",
+      avatarSrc: null,
+      state: "working",
+      status: "Working now",
+      selected: true,
+      onSelect: () => undefined,
+      ...overrides,
+    }),
+  );
+}
+
+describe("employee work bubble", () => {
+  test("is a labelled selection button with human-readable status", () => {
+    const html = renderBubble();
+    assert.match(html, /^<button/);
+    assert.match(html, /type="button"/);
+    assert.match(html, /aria-pressed="true"/);
+    assert.match(html, /aria-label="Rey, Customer support, Working now"/);
+    assert.match(html, />Rey</);
+    assert.match(html, />Working now</);
+  });
+
+  test("keeps the avatar subtree out of the accessibility name", () => {
+    const html = renderBubble();
+    assert.match(html, /<span aria-hidden="true"[^>]*><span[^>]*aria-label="Rey"/);
+  });
+
+  test("animates only live status and exposes quiet status in words", () => {
+    assert.match(renderBubble(), /motion-safe:animate-pulse/);
+    const quiet = renderBubble({ state: "quiet", status: "Quiet today", selected: false });
+    assert.doesNotMatch(quiet, /motion-safe:animate-pulse/);
+    assert.match(quiet, /aria-pressed="false"/);
+    assert.match(quiet, /Quiet today/);
+  });
+});
+
+describe("team work loading states", () => {
+  const employee = {
+    id: "employee-1",
+    name: "Rey",
+    slug: "rey",
+    role: "Customer support",
+  } as Employee;
+
+  function renderStatus(status: "loading" | "unavailable"): string {
+    return renderToStaticMarkup(
+      React.createElement(TeamSpotlight, {
+        employees: [employee],
+        summaries: [],
+        workingCount: 0,
+        waitingCount: 0,
+        activeCount: 0,
+        status,
+        onSelect: () => undefined,
+      }),
+    );
+  }
+
+  test("never mistakes a pending request for a quiet team", () => {
+    const html = renderStatus("loading");
+    assert.match(html, /Loading your team&#x27;s work/);
+    assert.doesNotMatch(html, /No one is working/);
+  });
+
+  test("never mistakes a failed request for a quiet team", () => {
+    const html = renderStatus("unavailable");
+    assert.match(html, /Work status is unavailable/);
+    assert.doesNotMatch(html, /No one is working/);
+  });
+});
+
+const company = {
+  id: "company-1",
+  name: "Acme",
+  slug: "acme",
+} as Company;
+
+describe("employee work shell", () => {
+  test("puts a roster failure inline instead of silently hiding the panel", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WorkTimelinePanel, {
+        company,
+        employees: [],
+        employeeLoadError: "Could not load your AI employees.",
+        onOpenRun: () => undefined,
+      }),
+    );
+    assert.match(html, /AI employee work/);
+    assert.match(html, /Could not load your AI employees/);
+  });
+});

--- a/App/client/components/home/WorkTimelinePanel.tsx
+++ b/App/client/components/home/WorkTimelinePanel.tsx
@@ -2,21 +2,23 @@ import React from "react";
 import { Link } from "react-router-dom";
 import {
   AlarmClock,
+  ArrowUpRight,
   ChevronRight,
   CircleDashed,
-  Clock3,
   GitCommitHorizontal,
   Lightbulb,
+  MessageCircle,
   MessageSquare,
   Play,
   ShieldCheck,
+  UsersRound,
 } from "lucide-react";
 
 import { useLiveRefetch } from "@/components/CompanySocket";
 import { RunChecksChip, RunOutcomeChip, RunStatusChip } from "@/components/routines/RunViews";
 import { Avatar, employeeAvatarUrl } from "@/components/ui/Avatar";
+import { buttonClassName } from "@/components/ui/Button";
 import { FormError } from "@/components/ui/FormError";
-import { Select } from "@/components/ui/Select";
 import { Spinner } from "@/components/ui/Spinner";
 import { clsx } from "@/components/ui/clsx";
 import { api } from "@/lib/api";
@@ -24,252 +26,787 @@ import type { Company, Employee, WorkEntry, WorkEntryKind, WorkTimeline } from "
 import { errorMessage } from "@/lib/errors";
 import { shouldOpenEventInPlace } from "@/lib/inPlaceLink";
 import {
+  employeeWorkFocus,
+  employeeWorkStatusLabel,
   groupWorkByDay,
-  workClock,
+  humanizeWorkAction,
+  isWorkInsideWindow,
+  summarizeEmployeeWork,
+  workDisplayDetail,
+  workDisplayEntryCount,
+  workDisplayTitle,
   workEffectOverflowLabel,
   workEmptyTitle,
   workEntryHref,
   workOverflowLabel,
+  workRelativeTime,
   WORK_KIND_META,
 } from "@/lib/workTimeline";
+import type { EmployeeWorkState, EmployeeWorkSummary } from "@/lib/workTimeline";
 
 /**
- * Home's AI Employee work timeline — everything the roster did in the last 24
- * hours, newest first, with a picker to narrow it to one employee.
+ * Home's human-readable view of the AI workforce.
  *
- * ## Why this panel is not a queue
+ * The roster is the navigation. Every employee remains visible as a bubble,
+ * including on a quiet day, and each bubble says whether that person is
+ * working, waiting for input, recently active, or quiet. Selecting one keeps
+ * the employee in context: their current or latest work is featured beside a
+ * direct Check in action, with the server-written work timeline underneath.
  *
- * Every other panel on Home hides when it is empty because every other panel
- * is a queue, and an empty queue is not news. This one is a record. It sits
- * *below* the all-clear rather than inside it, because a night of clean
- * autonomous work and "Nothing needs you right now" are both true at once, and
- * folding the record into the queue predicate would hide the day behind the
- * sentence. It still hides itself when the window is genuinely empty — the
- * rule survives; only the reason it fires is different.
- *
- * The one exception is a deliberately chosen employee. Once the reader has
- * picked a name, a vanishing panel reads as a bug rather than as quiet, so a
- * selected employee with nothing to show gets a sentence saying so and keeps
- * its picker.
- *
- * ## Its own fetch, its own errors
- *
- * Home's own `reload` swallows failures so a transient blip never blanks the
- * page. That is right for an aggregate that is mostly counts and wrong here: a
- * silently empty timeline is indistinguishable from a quiet day, which is the
- * one thing this panel must never say by accident. So it owns its request, its
- * spinner, and an inline error — never a toast; there isn't one in this app.
+ * The timeline still owns its request and inline error. Home's aggregate load
+ * deliberately swallows transient failures; doing that here would make a
+ * failed request indistinguishable from an employee who did no work.
  */
 export function WorkTimelinePanel({
   company,
   employees,
+  employeeLoadError,
   onOpenRun,
 }: {
   company: Company;
-  /** Home already loads the roster for the todo peek pickers — reuse it. */
   employees: Employee[];
+  employeeLoadError?: string | null;
   onOpenRun: (entry: WorkEntry) => void;
 }) {
   const [employeeId, setEmployeeId] = React.useState("");
-  const [data, setData] = React.useState<WorkTimeline | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
+  const [rosterData, setRosterData] = React.useState<WorkTimeline | null>(null);
+  const [selectedData, setSelectedData] = React.useState<WorkTimeline | null>(null);
+  const [rosterError, setRosterError] = React.useState<string | null>(null);
+  const [selectedError, setSelectedError] = React.useState<string | null>(null);
+  const [clockIso, setClockIso] = React.useState(() => new Date().toISOString());
+  const rosterRequest = React.useRef(0);
+  const selectedRequest = React.useRef(0);
 
-  const load = React.useCallback(async () => {
-    const query = employeeId ? `?employeeId=${encodeURIComponent(employeeId)}` : "";
+  const loadRoster = React.useCallback(async () => {
+    const request = ++rosterRequest.current;
     try {
-      const next = await api.get<WorkTimeline>(
-        `/api/companies/${company.id}/work-timeline${query}`,
-      );
-      setData(next);
-      setError(null);
+      const next = await api.get<WorkTimeline>(`/api/companies/${company.id}/work-timeline`);
+      if (request !== rosterRequest.current) return;
+      setRosterData(next);
+      setRosterError(null);
     } catch (err) {
-      setError(errorMessage(err, "Could not load what your AI employees have been doing."));
+      if (request !== rosterRequest.current) return;
+      setRosterError(errorMessage(err, "Could not load your AI employees' recent work."));
     }
-  }, [company.id, employeeId]);
+  }, [company.id]);
+
+  const loadEmployee = React.useCallback(
+    async (nextEmployeeId: string) => {
+      const request = ++selectedRequest.current;
+      try {
+        const next = await api.get<WorkTimeline>(
+          `/api/companies/${company.id}/work-timeline?employeeId=${encodeURIComponent(nextEmployeeId)}`,
+        );
+        if (request !== selectedRequest.current) return;
+        setSelectedData(next);
+        setSelectedError(null);
+      } catch (err) {
+        if (request !== selectedRequest.current) return;
+        setSelectedError(errorMessage(err, "Could not load this employee's recent work."));
+      }
+    },
+    [company.id],
+  );
 
   React.useEffect(() => {
-    // Blank between employees so the body shows its spinner rather than one
-    // employee's work under another's name.
-    setData(null);
-    setError(null);
-    void load();
-  }, [load]);
+    selectedRequest.current += 1;
+    setEmployeeId("");
+    setRosterData(null);
+    setSelectedData(null);
+    setRosterError(null);
+    setSelectedError(null);
+    void loadRoster();
+  }, [loadRoster]);
+
+  React.useEffect(() => {
+    if (!employeeId) {
+      selectedRequest.current += 1;
+      setSelectedData(null);
+      setSelectedError(null);
+      return;
+    }
+    setSelectedData(null);
+    setSelectedError(null);
+    void loadEmployee(employeeId);
+  }, [employeeId, loadEmployee]);
+
+  const refresh = React.useCallback(() => {
+    void loadRoster();
+    if (employeeId) void loadEmployee(employeeId);
+  }, [employeeId, loadEmployee, loadRoster]);
 
   /**
-   * Deliberately not subscribed to `audit`. That kind is company-wide with no
-   * scope and ~150 write seams feed it, so it fires on essentially every
-   * mutation in the company. A Run finishing already publishes `run`, and the
-   * refetch brings its effects with it. There is no `conversation` kind in the
-   * registry, so chat rows arrive on the next matching frame or on tab focus.
+   * `audit` remains intentionally absent. It is a company-wide fire hose;
+   * completed Runs already publish `run`, and tab focus catches the few source
+   * rows without a dedicated resource frame.
    */
-  useLiveRefetch(["run", "routine", "approval", "employee"], load);
+  useLiveRefetch(
+    ["run", "routine", "approval", "employee", "repository", "employee_work"],
+    refresh,
+  );
 
-  const selected = employees.find((e) => e.id === employeeId) ?? null;
-  const entries = data?.entries ?? [];
+  React.useEffect(() => {
+    const onFocus = () => {
+      setClockIso(new Date().toISOString());
+      refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refresh]);
 
-  // Nothing chosen and nothing done: say nothing at all. This is the rule every
-  // Home panel follows, applied at the only point where it is true here.
-  if (!employeeId && data !== null && entries.length === 0 && !error) return null;
-  if (employees.length === 0) return null;
+  React.useEffect(() => {
+    setClockIso(new Date().toISOString());
+    // Relative labels and the rolling 24-hour cutoff are presentation state;
+    // advance them locally instead of polling the full timeline union.
+    const timer = window.setInterval(() => setClockIso(new Date().toISOString()), 60_000);
+    return () => window.clearInterval(timer);
+  }, [company.id]);
 
+  const selected = employees.find((employee) => employee.id === employeeId) ?? null;
+  React.useEffect(() => {
+    if (employeeId && employees.length > 0 && !selected) setEmployeeId("");
+  }, [employeeId, employees.length, selected]);
+
+  if (employees.length === 0) {
+    if (!employeeLoadError) return null;
+    return (
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-base font-semibold text-slate-950 dark:text-slate-50">
+          AI employee work
+        </h2>
+        <div className="mt-4">
+          <FormError message={employeeLoadError} />
+        </div>
+      </section>
+    );
+  }
+
+  const data = selected ? selectedData : rosterData;
+  const error = selected ? selectedError : rosterError;
+  const rosterEntries = rosterData?.entries ?? [];
+  const nowIso = clockIso;
+  const rosterSummaries = new Map(
+    (rosterData?.employeeSummaries ?? []).map((summary) => [summary.employeeId, summary]),
+  );
+  const summaries = employees.map((employee) =>
+    summarizeEmployeeWork(employee.id, rosterEntries, rosterSummaries.get(employee.id), { nowIso }),
+  );
+  const selectedRollup = selected
+    ? (selectedData?.employeeSummaries.find((summary) => summary.employeeId === selected.id) ??
+      rosterSummaries.get(selected.id))
+    : undefined;
+  const selectedSummary = selected
+    ? summarizeEmployeeWork(selected.id, selectedData?.entries ?? rosterEntries, selectedRollup, {
+        nowIso,
+      })
+    : null;
+  const rosterStatus: WorkDataStatus = rosterError
+    ? "unavailable"
+    : rosterData
+      ? "ready"
+      : "loading";
+  const selectedStatus: WorkDataStatus = selectedError
+    ? "unavailable"
+    : selectedData
+      ? "ready"
+      : rosterData
+        ? "ready"
+        : "loading";
+  const workingCount = summaries.filter((summary) => summary.state === "working").length;
+  const waitingCount = summaries.filter((summary) => summary.state === "waiting").length;
+  const activeCount = summaries.filter((summary) => summary.state !== "quiet").length;
+  const teamState: EmployeeWorkState = workingCount
+    ? "working"
+    : waitingCount
+      ? "waiting"
+      : activeCount
+        ? "recent"
+        : "quiet";
+  const teamStatus = workingCount
+    ? `${workingCount} working now`
+    : waitingCount
+      ? `${waitingCount} waiting for input`
+      : activeCount
+        ? `${activeCount} active today`
+        : "Quiet today";
+  const rawEntries = data?.entries ?? [];
+  const entries = rawEntries.filter((entry) => isWorkInsideWindow(entry.at, nowIso));
+  const displayEntryCount = data
+    ? workDisplayEntryCount(data.entryCount, rawEntries.length, entries.length, data.until, nowIso)
+    : 0;
   const groups = groupWorkByDay(entries);
-  const overflow = data ? workOverflowLabel(entries.length, data.entryCount) : null;
+  const overflow = data ? workOverflowLabel(entries.length, displayEntryCount) : null;
 
   return (
-    <section className="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-4 py-3 dark:border-slate-800">
-        <span className="text-slate-400 dark:text-slate-500">
-          <Clock3 size={15} />
-        </span>
-        <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-          {selected ? `What ${selected.name} did` : "What your AI employees did"}
-        </h2>
-        <span className="text-xs text-slate-400 dark:text-slate-500">Last 24 hours</span>
-        {data !== null && data.entryCount > 0 && (
-          <span className="rounded-full bg-slate-100 px-1.5 text-[10px] font-semibold tabular-nums text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-            {data.entryCount}
-          </span>
-        )}
-        <Select
-          aria-label="AI employee"
-          className="ml-auto h-8 w-44 text-xs"
-          containerClassName="ml-auto w-44"
-          value={employeeId}
-          onChange={(e) => setEmployeeId(e.target.value)}
+    <section
+      aria-labelledby="employee-work-title"
+      className="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900"
+    >
+      <div className="px-5 pb-5 pt-5 sm:px-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2
+              id="employee-work-title"
+              className="text-base font-semibold text-slate-950 dark:text-slate-50"
+            >
+              AI employee work
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              See who is working now, what changed, and where to check in.
+            </p>
+          </div>
+          <Link
+            to={`/c/${company.slug}/employees`}
+            className="inline-flex h-8 items-center gap-1 rounded-lg px-2 text-xs font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+          >
+            Manage employees <ChevronRight size={13} />
+          </Link>
+        </div>
+
+        <div
+          role="group"
+          aria-label="Choose an AI employee"
+          className="-mx-2 mt-5 flex gap-1 overflow-x-auto px-2 pb-1"
         >
-          <option value="">All AI employees</option>
-          {employees.map((e) => (
-            <option key={e.id} value={e.id}>
-              {e.name}
-            </option>
-          ))}
-        </Select>
-        <Link
-          to={
-            selected
-              ? `/c/${company.slug}/employees/${selected.slug}`
-              : `/c/${company.slug}/employees`
-          }
-          className="flex shrink-0 items-center gap-0.5 text-xs text-indigo-600 hover:underline dark:text-indigo-400"
-        >
-          {selected ? "Open employee" : "All employees"} <ChevronRight size={12} />
-        </Link>
+          <TeamWorkBubble
+            selected={!selected}
+            state={rosterStatus === "ready" ? teamState : "quiet"}
+            status={
+              rosterStatus === "ready"
+                ? teamStatus
+                : rosterStatus === "loading"
+                  ? "Loading work"
+                  : "Status unavailable"
+            }
+            onSelect={() => setEmployeeId("")}
+          />
+          {employees.map((employee, index) => {
+            const summary = summaries[index];
+            return (
+              <EmployeeWorkBubble
+                key={employee.id}
+                name={employee.name}
+                role={employee.role}
+                avatarSrc={employeeAvatarUrl(company.id, employee.id, employee.avatarKey)}
+                state={rosterStatus === "ready" ? summary.state : "quiet"}
+                status={
+                  rosterStatus === "ready"
+                    ? employeeWorkStatusLabel(summary, nowIso)
+                    : rosterStatus === "loading"
+                      ? "Loading work"
+                      : "Status unavailable"
+                }
+                selected={employee.id === employeeId}
+                onSelect={() => setEmployeeId(employee.id)}
+              />
+            );
+          })}
+        </div>
       </div>
 
-      {error ? (
-        <div className="px-4 py-4">
-          <FormError message={error} />
-        </div>
-      ) : data === null ? (
-        <div className="flex min-h-[10rem] items-center justify-center">
-          <Spinner size={20} />
-        </div>
-      ) : entries.length === 0 ? (
-        <div className="flex min-h-[10rem] flex-col items-center justify-center gap-1.5 px-6 py-8 text-center">
-          <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
-            {workEmptyTitle(selected?.name ?? null, 24)}
-          </span>
-          <span className="max-w-sm text-xs text-slate-500 dark:text-slate-400">
-            Routine runs, chat replies, repository work, approvals they asked for, and the lessons
-            they took away all appear here as they happen.
-          </span>
-        </div>
-      ) : (
-        <div className="max-h-[32rem] overflow-y-auto">
-          {groups.map((group) => (
-            <div key={group.key}>
-              <div className="sticky top-0 z-10 border-b border-slate-100 bg-slate-50/90 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500 backdrop-blur dark:border-slate-800 dark:bg-slate-800/80 dark:text-slate-400">
-                {group.label}
-              </div>
-              <ul className="divide-y divide-slate-50 dark:divide-slate-800/60">
-                {group.items.map((entry, index) => (
-                  <TimelineRow
-                    key={entry.id}
-                    company={company}
-                    entry={entry}
-                    showEmployee={!employeeId}
-                    lastInGroup={index === group.items.length - 1}
-                    onOpenRun={onOpenRun}
-                  />
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      )}
+      <div className="border-t border-slate-100 dark:border-slate-800">
+        <div className="grid lg:grid-cols-[19rem_minmax(0,1fr)]">
+          <div className="border-b border-slate-100 bg-slate-50/70 p-5 lg:border-b-0 lg:border-r dark:border-slate-800 dark:bg-slate-950/30">
+            {selected && selectedSummary ? (
+              <EmployeeSpotlight
+                company={company}
+                employee={selected}
+                summary={selectedSummary}
+                nowIso={nowIso}
+                status={selectedStatus}
+              />
+            ) : (
+              <TeamSpotlight
+                employees={employees}
+                summaries={summaries}
+                workingCount={workingCount}
+                waitingCount={waitingCount}
+                activeCount={activeCount}
+                status={rosterStatus}
+                onSelect={setEmployeeId}
+              />
+            )}
+          </div>
 
-      {overflow && (
-        <div className="border-t border-slate-100 px-4 py-2 text-center text-[11px] text-slate-400 dark:border-slate-800 dark:text-slate-500">
-          {overflow}
+          <div className="min-w-0">
+            <div className="flex min-h-14 flex-wrap items-center gap-x-2 gap-y-1 border-b border-slate-100 px-5 py-3 dark:border-slate-800">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {selected ? `${selected.name}'s recent work` : "Recent work"}
+              </h3>
+              <span className="text-xs text-slate-400 dark:text-slate-500">Last 24 hours</span>
+              {data !== null && displayEntryCount > 0 && (
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold tabular-nums text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                  {displayEntryCount}
+                </span>
+              )}
+            </div>
+
+            {error ? (
+              <div className="px-5 py-5">
+                <FormError message={error} />
+              </div>
+            ) : data === null ? (
+              <div className="flex min-h-64 items-center justify-center" aria-label="Loading work">
+                <Spinner size={20} />
+              </div>
+            ) : entries.length === 0 ? (
+              <div className="flex min-h-64 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-500">
+                  <CircleDashed size={18} />
+                </span>
+                <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                  {workEmptyTitle(selected?.name ?? null, 24)}
+                </span>
+                <span className="max-w-sm text-xs leading-5 text-slate-500 dark:text-slate-400">
+                  Routine runs, conversations, repository work, and meaningful changes will appear
+                  here as they happen.
+                </span>
+              </div>
+            ) : (
+              <div className="max-h-[38rem] overflow-y-auto">
+                {groups.map((group) => (
+                  <div key={group.key}>
+                    <div className="sticky top-0 z-10 border-b border-slate-100 bg-slate-50/95 px-5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500 backdrop-blur dark:border-slate-800 dark:bg-slate-800/95 dark:text-slate-400">
+                      {group.label}
+                    </div>
+                    <ul className="divide-y divide-slate-100 dark:divide-slate-800/80">
+                      {group.items.map((entry, index) => (
+                        <TimelineRow
+                          key={entry.id}
+                          company={company}
+                          entry={entry}
+                          nowIso={nowIso}
+                          showEmployee={!selected}
+                          lastInGroup={index === group.items.length - 1}
+                          onOpenRun={onOpenRun}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {overflow && (
+              <div className="border-t border-slate-100 px-5 py-2.5 text-center text-[11px] text-slate-400 dark:border-slate-800 dark:text-slate-500">
+                {overflow}
+              </div>
+            )}
+          </div>
         </div>
-      )}
+      </div>
     </section>
   );
 }
 
-const KIND_ICON: Record<WorkEntryKind, React.ReactNode> = {
-  run: <Play size={13} />,
-  chat: <MessageSquare size={13} />,
-  work_session: <GitCommitHorizontal size={13} />,
-  approval: <ShieldCheck size={13} />,
-  wakeup: <AlarmClock size={13} />,
-  lesson: <Lightbulb size={13} />,
-  effect: <CircleDashed size={13} />,
+const STATE_DOT: Record<EmployeeWorkState, string> = {
+  working: "bg-emerald-500 ring-emerald-100 dark:ring-emerald-900",
+  waiting: "bg-amber-500 ring-amber-100 dark:ring-amber-900",
+  recent: "bg-sky-500 ring-sky-100 dark:ring-sky-900",
+  quiet: "bg-slate-300 ring-slate-100 dark:bg-slate-600 dark:ring-slate-800",
 };
 
-/**
- * One row: a chip on a rail, the headline, and a meta line under it.
- *
- * The rail is drawn per row and skipped on the last of a day group rather than
- * as one continuous border on the list — a single border would overhang the
- * sticky day header that follows it.
- */
+const STATE_PILL: Record<EmployeeWorkState, string> = {
+  working:
+    "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:ring-emerald-500/20",
+  waiting:
+    "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-300 dark:ring-amber-500/20",
+  recent:
+    "bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-500/10 dark:text-sky-300 dark:ring-sky-500/20",
+  quiet:
+    "bg-slate-100 text-slate-600 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+};
+
+type WorkDataStatus = "loading" | "ready" | "unavailable";
+
+/** Exported so the roster's accessible contract can be rendered in Node tests. */
+export function EmployeeWorkBubble({
+  name,
+  role,
+  avatarSrc,
+  state,
+  status,
+  selected,
+  onSelect,
+}: {
+  name: string;
+  role: string;
+  avatarSrc: string | null;
+  state: EmployeeWorkState;
+  status: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-label={`${name}, ${role}, ${status}`}
+      onClick={onSelect}
+      className={clsx(
+        "group flex w-[7.25rem] shrink-0 flex-col items-center rounded-xl px-2 py-2 text-center transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40",
+        selected
+          ? "bg-indigo-50/80 dark:bg-indigo-500/10"
+          : "hover:bg-slate-50 dark:hover:bg-slate-800/60",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={clsx(
+          "relative rounded-full p-1 ring-2 transition",
+          selected
+            ? "bg-white ring-indigo-500 dark:bg-slate-900"
+            : "bg-transparent ring-transparent group-hover:ring-slate-200 dark:group-hover:ring-slate-700",
+        )}
+      >
+        <Avatar name={name} kind="ai" size="xl" src={avatarSrc} />
+        <span
+          aria-hidden="true"
+          className={clsx(
+            "absolute bottom-1 right-1 h-3.5 w-3.5 rounded-full border-2 border-white ring-2 dark:border-slate-900",
+            STATE_DOT[state],
+            state === "working" && "motion-safe:animate-pulse",
+          )}
+        />
+      </span>
+      <span className="mt-2 w-full truncate text-xs font-semibold text-slate-900 dark:text-slate-100">
+        {name}
+      </span>
+      <span className="mt-0.5 w-full truncate text-[10px] text-slate-500 dark:text-slate-400">
+        {status}
+      </span>
+    </button>
+  );
+}
+
+function TeamWorkBubble({
+  selected,
+  state,
+  status,
+  onSelect,
+}: {
+  selected: boolean;
+  state: EmployeeWorkState;
+  status: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-label={`Everyone, ${status}`}
+      onClick={onSelect}
+      className={clsx(
+        "group flex w-[7.25rem] shrink-0 flex-col items-center rounded-xl px-2 py-2 text-center transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40",
+        selected
+          ? "bg-indigo-50/80 dark:bg-indigo-500/10"
+          : "hover:bg-slate-50 dark:hover:bg-slate-800/60",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={clsx(
+          "relative flex h-[4.5rem] w-[4.5rem] items-center justify-center rounded-full bg-slate-100 text-slate-600 ring-2 transition dark:bg-slate-800 dark:text-slate-300",
+          selected
+            ? "ring-indigo-500"
+            : "ring-transparent group-hover:ring-slate-200 dark:group-hover:ring-slate-700",
+        )}
+      >
+        <UsersRound size={25} />
+        <span
+          aria-hidden="true"
+          className={clsx(
+            "absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ring-2 dark:border-slate-900",
+            STATE_DOT[state],
+            state === "working" && "motion-safe:animate-pulse",
+          )}
+        />
+      </span>
+      <span className="mt-2 text-xs font-semibold text-slate-900 dark:text-slate-100">
+        Everyone
+      </span>
+      <span className="mt-0.5 w-full truncate text-[10px] text-slate-500 dark:text-slate-400">
+        {status}
+      </span>
+    </button>
+  );
+}
+
+function EmployeeSpotlight({
+  company,
+  employee,
+  summary,
+  nowIso,
+  status: dataStatus,
+}: {
+  company: Company;
+  employee: Employee;
+  summary: EmployeeWorkSummary;
+  nowIso: string;
+  status: WorkDataStatus;
+}) {
+  const focus = dataStatus === "ready" ? employeeWorkFocus(summary) : null;
+  const focusDetail = focus ? workDisplayDetail(focus) : "";
+  const status =
+    dataStatus === "ready"
+      ? employeeWorkStatusLabel(summary, nowIso)
+      : dataStatus === "loading"
+        ? "Loading work"
+        : "Status unavailable";
+  const displayState = dataStatus === "ready" ? summary.state : "quiet";
+  const focusLabel =
+    summary.state === "working"
+      ? "Current work"
+      : summary.state === "waiting"
+        ? "Waiting on"
+        : "Most recent";
+  const base = `/c/${company.slug}/employees/${employee.slug}`;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3">
+        <span aria-hidden="true">
+          <Avatar
+            name={employee.name}
+            kind="ai"
+            size="xl"
+            src={employeeAvatarUrl(company.id, employee.id, employee.avatarKey)}
+          />
+        </span>
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold text-slate-950 dark:text-slate-50">
+            {employee.name}
+          </h3>
+          <p className="truncate text-xs text-slate-500 dark:text-slate-400">{employee.role}</p>
+        </div>
+      </div>
+
+      <span
+        className={clsx(
+          "mt-4 inline-flex w-fit items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset",
+          STATE_PILL[displayState],
+        )}
+      >
+        <span className={clsx("h-1.5 w-1.5 rounded-full", STATE_DOT[displayState])} />
+        {status}
+      </span>
+
+      <div className="mt-5 min-h-28 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
+          {dataStatus !== "ready" ? "Work status" : focus ? focusLabel : "Today"}
+        </p>
+        {dataStatus !== "ready" ? (
+          <p className="mt-2 text-sm leading-5 text-slate-500 dark:text-slate-400">
+            {dataStatus === "loading"
+              ? "Checking current and recent work…"
+              : "Recent work could not be loaded."}
+          </p>
+        ) : focus ? (
+          <>
+            <p className="mt-2 text-sm font-medium leading-5 text-slate-900 dark:text-slate-100">
+              {workDisplayTitle(focus)}
+            </p>
+            {focusDetail && (
+              <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                {focusDetail}
+              </p>
+            )}
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              {WORK_KIND_META[focus.kind].label} · {workRelativeTime(focus.at, nowIso)}
+            </p>
+          </>
+        ) : (
+          <p className="mt-2 text-sm leading-5 text-slate-500 dark:text-slate-400">
+            No recorded work in the last 24 hours.
+          </p>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2 lg:mt-auto lg:pt-5">
+        <Link to={`${base}/chat`} className={buttonClassName({ size: "sm" })}>
+          <MessageCircle size={14} /> Check in
+        </Link>
+        <Link
+          to={`${base}/settings`}
+          className={buttonClassName({ variant: "secondary", size: "sm" })}
+        >
+          Employee details <ArrowUpRight size={13} />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/** Exported so loading and failure copy can be pinned without a browser DOM. */
+export function TeamSpotlight({
+  employees,
+  summaries,
+  workingCount,
+  waitingCount,
+  activeCount,
+  status,
+  onSelect,
+}: {
+  employees: Employee[];
+  summaries: EmployeeWorkSummary[];
+  workingCount: number;
+  waitingCount: number;
+  activeCount: number;
+  status: WorkDataStatus;
+  onSelect: (employeeId: string) => void;
+}) {
+  const working = summaries.filter((summary) => summary.state === "working");
+  const headline =
+    status === "loading"
+      ? "Loading your team's work…"
+      : status === "unavailable"
+        ? "Work status is unavailable"
+        : workingCount
+          ? `${workingCount} ${workingCount === 1 ? "employee is" : "employees are"} working now`
+          : waitingCount
+            ? `${waitingCount} ${waitingCount === 1 ? "employee needs" : "employees need"} input`
+            : "No one is working right now";
+
+  return (
+    <div className="flex h-full flex-col">
+      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-indigo-600 ring-1 ring-indigo-100 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/20">
+        <UsersRound size={18} />
+      </span>
+      <h3 className="mt-4 text-base font-semibold text-slate-950 dark:text-slate-50">Your team</h3>
+      <p className="mt-1 text-sm leading-5 text-slate-600 dark:text-slate-300">{headline}</p>
+      {status === "ready" ? (
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {activeCount} of {employees.length} working, waiting, or recently active
+        </p>
+      ) : (
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {status === "loading"
+            ? "Checking current and recent work."
+            : "The timeline request did not complete."}
+        </p>
+      )}
+
+      {status === "ready" && working.length > 0 ? (
+        <div className="mt-5 space-y-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
+            Working now
+          </p>
+          {working.slice(0, 3).map((summary) => {
+            const employee = employees.find((row) => row.id === summary.employeeId);
+            if (!employee || !summary.currentEntry) return null;
+            return (
+              <button
+                key={summary.employeeId}
+                type="button"
+                onClick={() => onSelect(summary.employeeId)}
+                className="block w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-left transition hover:border-indigo-200 hover:bg-indigo-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-indigo-500/30 dark:hover:bg-indigo-500/5"
+              >
+                <span className="block truncate text-xs font-semibold text-slate-900 dark:text-slate-100">
+                  {employee.name}
+                </span>
+                <span className="mt-0.5 block truncate text-[11px] text-slate-500 dark:text-slate-400">
+                  {summary.currentEntry.title}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-5 rounded-xl border border-dashed border-slate-200 px-3 py-3 text-xs leading-5 text-slate-500 dark:border-slate-700 dark:text-slate-400">
+          {status === "ready"
+            ? "Select an employee above to see their latest work and start a check-in."
+            : status === "loading"
+              ? "Employee bubbles will update as soon as work is loaded."
+              : "You can still select an employee above and check in directly."}
+        </p>
+      )}
+    </div>
+  );
+}
+
+const KIND_ICON: Record<WorkEntryKind, React.ReactNode> = {
+  run: <Play size={14} />,
+  chat: <MessageSquare size={14} />,
+  work_session: <GitCommitHorizontal size={14} />,
+  approval: <ShieldCheck size={14} />,
+  wakeup: <AlarmClock size={14} />,
+  lesson: <Lightbulb size={14} />,
+  effect: <CircleDashed size={14} />,
+};
+
 function TimelineRow({
   company,
   entry,
+  nowIso,
   showEmployee,
   lastInGroup,
   onOpenRun,
 }: {
   company: Company;
   entry: WorkEntry;
+  nowIso: string;
   showEmployee: boolean;
   lastInGroup: boolean;
   onOpenRun: (entry: WorkEntry) => void;
 }) {
   const meta = WORK_KIND_META[entry.kind];
   const href = workEntryHref(entry, company.slug);
-  const effectOverflow = workEffectOverflowLabel(entry);
+  const shownEffects = entry.effects.slice(0, 3);
+  const effectOverflow = workEffectOverflowLabel(entry, shownEffects.length);
+  const displayDetail = workDisplayDetail(entry);
+  const absoluteTime = new Date(entry.at);
+  const absoluteLabel = Number.isNaN(absoluteTime.getTime())
+    ? undefined
+    : absoluteTime.toLocaleString();
 
   const body = (
     <>
       {!lastInGroup && (
-        // `left` is the row's own padding (1rem) plus half the 28px chip
-        // (0.875rem); `top` clears the chip; the negative `bottom` carries the
-        // line across the divider into the next row's padding so it meets the
-        // chip below instead of stopping short of it.
         <span
           aria-hidden="true"
-          className="absolute -bottom-3.5 left-[1.875rem] top-[2.625rem] w-px bg-slate-200 dark:bg-slate-700"
+          className="absolute -bottom-4 left-9 top-12 w-px bg-slate-200 dark:bg-slate-700"
         />
       )}
       <span
         aria-hidden="true"
         title={meta.label}
         className={clsx(
-          "relative z-10 mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1",
+          "relative z-10 mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ring-1",
           meta.tone,
         )}
       >
         {KIND_ICON[entry.kind]}
       </span>
       <span className="min-w-0 flex-1">
-        {/* Wraps rather than shrinks: a run carries up to three chips, and on a
-            phone `flex-1` on the title let them squeeze it to nothing. The
-            basis is the width below which the chips move to their own line. */}
-        <span className="flex flex-wrap items-center gap-2">
-          <span className="min-w-0 grow basis-48 truncate text-sm text-slate-900 dark:text-slate-100">
-            {entry.title}
+        <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-slate-500 dark:text-slate-400">
+          {showEmployee && (
+            <>
+              <span className="flex min-w-0 items-center gap-1 font-medium text-slate-700 dark:text-slate-300">
+                <span aria-hidden="true">
+                  <Avatar
+                    name={entry.employee.name}
+                    kind="ai"
+                    size="xs"
+                    src={employeeAvatarUrl(company.id, entry.employee.id, entry.employee.avatarKey)}
+                  />
+                </span>
+                <span className="truncate">{entry.employee.name}</span>
+              </span>
+              <span aria-hidden="true">·</span>
+            </>
+          )}
+          <span>{meta.label}</span>
+          <span aria-hidden="true">·</span>
+          <time dateTime={entry.at} title={absoluteLabel} className="tabular-nums">
+            {workRelativeTime(entry.at, nowIso)}
+          </time>
+        </span>
+
+        <span className="mt-1.5 flex flex-wrap items-start gap-2">
+          <span className="min-w-0 grow basis-48 text-sm font-medium leading-5 text-slate-900 dark:text-slate-100">
+            {workDisplayTitle(entry)}
           </span>
           {entry.run && <RunStatusChip status={entry.run.status} size="xs" />}
           {entry.run?.outcomeVerdict && (
@@ -283,59 +820,54 @@ function TimelineRow({
             <RunChecksChip verdict={entry.run.checksVerdict} size="xs" />
           )}
         </span>
-        <span className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400 dark:text-slate-500">
-          <span className="tabular-nums">{workClock(entry.at)}</span>
-          {showEmployee && (
-            <span className="flex items-center gap-1">
-              <Avatar
-                name={entry.employee.name}
-                kind="ai"
-                size="xs"
-                src={employeeAvatarUrl(company.id, entry.employee.id, entry.employee.avatarKey)}
-              />
-              {entry.employee.name}
-            </span>
-          )}
-          {entry.detail && <span className="truncate">{entry.detail}</span>}
-        </span>
-        {entry.effects.length > 0 && (
-          <span className="mt-2 block border-l border-slate-100 pl-3 dark:border-slate-800">
-            {entry.effects.map((effect, i) => (
+
+        {displayDetail && (
+          <span className="mt-1 block text-xs leading-5 text-slate-500 dark:text-slate-400">
+            {displayDetail}
+          </span>
+        )}
+
+        {shownEffects.length > 0 && (
+          <span className="mt-3 block space-y-1.5 rounded-lg bg-slate-50 px-3 py-2.5 dark:bg-slate-800/60">
+            {shownEffects.map((effect, index) => (
               <span
-                key={`${effect.at}-${effect.action}-${i}`}
-                className="mt-1 flex items-center gap-2 text-[11px] first:mt-0"
+                key={`${effect.at}-${effect.action}-${index}`}
+                className="flex items-start gap-2 text-[11px] leading-4"
               >
-                <code className="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-                  {effect.action}
-                </code>
-                {(effect.targetLabel || effect.targetType) && (
-                  <span className="truncate text-slate-500 dark:text-slate-400">
-                    {effect.targetLabel || effect.targetType}
-                  </span>
-                )}
+                <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-slate-400 dark:bg-slate-500" />
+                <span className="text-slate-600 dark:text-slate-300">
+                  {humanizeWorkAction(effect.action, effect.targetType)}
+                  {effect.targetLabel && (
+                    <span className="text-slate-400 dark:text-slate-500">
+                      {` · ${effect.targetLabel}`}
+                    </span>
+                  )}
+                </span>
               </span>
             ))}
             {effectOverflow && (
-              <span className="mt-1 block text-[11px] text-slate-400 dark:text-slate-500">
+              <span className="block pl-3 text-[11px] text-slate-400 dark:text-slate-500">
                 {effectOverflow}
               </span>
             )}
           </span>
         )}
       </span>
+      {href && (
+        <ChevronRight
+          aria-hidden="true"
+          size={15}
+          className="mt-2 shrink-0 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-500 dark:text-slate-600 dark:group-hover:text-slate-400"
+        />
+      )}
     </>
   );
 
   const rowClass =
-    "relative flex gap-3 px-4 py-3 transition-colors hover:bg-slate-50/70 dark:hover:bg-slate-800/40";
+    "group relative flex gap-3 px-5 py-4 transition-colors hover:bg-slate-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500/40 dark:hover:bg-slate-800/40";
 
-  if (!href) {
-    return <li className={rowClass}>{body}</li>;
-  }
+  if (!href) return <li className={rowClass}>{body}</li>;
 
-  // A run opens the Routines page's own viewer over Home; everything else is an
-  // ordinary navigation. Either way the anchor survives, so ⌘-click, middle
-  // click and the status-bar preview all keep working.
   return (
     <li>
       <Link

--- a/App/client/lib/api.ts
+++ b/App/client/lib/api.ts
@@ -3048,6 +3048,8 @@ export type WorkEntry = {
   kind: WorkEntryKind;
   at: string;
   endedAt: string | null;
+  /** Explicit source-backed live state. Never infer this from `endedAt` alone. */
+  active: boolean;
   employee: WorkEmployeeRef;
   title: string;
   detail: string;
@@ -3058,6 +3060,16 @@ export type WorkEntry = {
   effectCount: number;
 };
 
+export type WorkEntryDigest = Pick<WorkEntry, "id" | "kind" | "at" | "title" | "detail" | "active">;
+
+export type WorkEmployeeSummary = {
+  employeeId: string;
+  entryCount: number;
+  latest: WorkEntryDigest | null;
+  current: WorkEntryDigest | null;
+  waiting: WorkEntryDigest | null;
+};
+
 export type WorkTimeline = {
   since: string;
   until: string;
@@ -3066,6 +3078,8 @@ export type WorkTimeline = {
   entries: WorkEntry[];
   /** Entries in the window before `limit` sliced them. */
   entryCount: number;
+  /** Pre-response-limit rollups, so the 40 visible rows cannot crowd a bubble out. */
+  employeeSummaries: WorkEmployeeSummary[];
 };
 
 // ───────────────────────── System Health ────────────────────────────────

--- a/App/client/lib/workTimeline.test.ts
+++ b/App/client/lib/workTimeline.test.ts
@@ -1,17 +1,29 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
-import type { WorkEntry, WorkEntryKind } from "./api.js";
+import type { WorkEmployeeSummary, WorkEntry, WorkEntryKind } from "./api.js";
 import {
+  employeeWorkFocus,
+  employeeWorkStatusLabel,
   groupWorkByDay,
+  humanizeWorkAction,
+  isWorkEntryActive,
+  isWorkInsideWindow,
+  isWorkEntryWaiting,
+  summarizeEmployeeWork,
   workClock,
   workDayKey,
   workDayLabel,
+  workDetailLabel,
+  workDisplayDetail,
+  workDisplayEntryCount,
+  workDisplayTitle,
   workEffectOverflowLabel,
   workEmptyTitle,
   workEntryHref,
   workEntrySummary,
   workOverflowLabel,
+  workRelativeTime,
   WORK_ENTRY_KINDS,
   WORK_KIND_META,
 } from "./workTimeline.js";
@@ -35,6 +47,7 @@ function entryOf(over: Partial<WorkEntry> = {}): WorkEntry {
     kind: "run",
     at: new Date().toISOString(),
     endedAt: null,
+    active: false,
     employee: {
       id: "e1f6c1a2-0000-4000-8000-000000000002",
       name: "Rey",
@@ -146,6 +159,287 @@ describe("clock", () => {
   });
 });
 
+describe("employee work state", () => {
+  test("uses the explicit live flag rather than treating every open-ended row as active", () => {
+    for (const kind of ["chat", "wakeup", "lesson", "effect"] as WorkEntryKind[]) {
+      assert.equal(isWorkEntryActive(entryOf({ kind, endedAt: null, active: false })), false, kind);
+    }
+    assert.equal(isWorkEntryActive(entryOf({ kind: "chat", active: true })), true);
+    assert.equal(isWorkEntryActive(entryOf({ kind: "work_session", active: true })), true);
+    assert.equal(isWorkEntryActive(entryOf({ active: true })), true);
+  });
+
+  test("recognises only an undecided pending Approval as waiting", () => {
+    const pending = entryOf({ kind: "approval", run: null, detail: "pending", endedAt: null });
+    assert.equal(isWorkEntryWaiting(pending), true);
+    assert.equal(isWorkEntryWaiting(entryOf({ ...pending, detail: "approved" })), false);
+    assert.equal(
+      isWorkEntryWaiting(entryOf({ ...pending, endedAt: "2026-09-03T09:00:00.000Z" })),
+      false,
+    );
+    assert.equal(isWorkEntryWaiting(entryOf({ ...pending, kind: "chat" })), false);
+  });
+
+  test("filters to one employee and preserves the server's newest-first row", () => {
+    const reyNew = entryOf({ id: "new", title: "Newest" });
+    const reyOld = entryOf({ id: "old", title: "Older" });
+    const kaz = entryOf({
+      id: "other",
+      employee: { ...reyNew.employee, id: "kaz", name: "Kaz", slug: "kaz" },
+    });
+    const summary = summarizeEmployeeWork(reyNew.employee.id, [reyNew, kaz, reyOld]);
+    assert.equal(summary.entryCount, 2);
+    assert.equal(summary.latestEntry?.id, "new");
+    assert.equal(summary.state, "recent");
+  });
+
+  test("working takes precedence over waiting and merely recent work", () => {
+    const latest = entryOf({ id: "latest" });
+    const waiting = entryOf({
+      id: "waiting",
+      kind: "approval",
+      run: null,
+      detail: "pending",
+      endedAt: null,
+    });
+    const current = entryOf({ id: "current", active: true });
+    const summary = summarizeEmployeeWork(latest.employee.id, [latest, waiting, current]);
+    assert.equal(summary.state, "working");
+    assert.equal(summary.currentEntry?.id, "current");
+    assert.equal(summary.waitingEntry?.id, "waiting");
+    assert.equal(summary.latestEntry?.id, "latest");
+  });
+
+  test("waiting takes precedence over recent work when nothing is running", () => {
+    const latest = entryOf({ id: "latest" });
+    const waiting = entryOf({
+      id: "waiting",
+      kind: "approval",
+      run: null,
+      detail: "pending",
+      endedAt: null,
+    });
+    assert.equal(summarizeEmployeeWork(latest.employee.id, [latest, waiting]).state, "waiting");
+  });
+
+  test("an employee with no visible rows is quiet only when no server rollup says otherwise", () => {
+    const quiet = summarizeEmployeeWork("quiet", []);
+    assert.equal(quiet.state, "quiet");
+    assert.equal(quiet.entryCount, 0);
+
+    const digest = {
+      id: "run:hidden",
+      kind: "run" as const,
+      at: "2026-09-03T08:00:00.000Z",
+      title: "Ran the close",
+      detail: "",
+      active: true,
+    };
+    const rollup: WorkEmployeeSummary = {
+      employeeId: "quiet",
+      entryCount: 41,
+      latest: digest,
+      current: digest,
+      waiting: null,
+    };
+    const rolledUp = summarizeEmployeeWork("quiet", [], rollup);
+    assert.equal(rolledUp.state, "working");
+    assert.equal(rolledUp.entryCount, 41);
+    assert.equal(rolledUp.currentEntry?.id, "run:hidden");
+  });
+
+  test("resolves rollup digests back to the full visible row when possible", () => {
+    const row = entryOf({ id: "run:visible", active: true });
+    const rollup: WorkEmployeeSummary = {
+      employeeId: row.employee.id,
+      entryCount: 1,
+      latest: row,
+      current: row,
+      waiting: null,
+    };
+    const summary = summarizeEmployeeWork(row.employee.id, [row], rollup);
+    assert.equal(summary.currentEntry, row);
+    assert.equal(summary.latestEntry, row);
+  });
+
+  test("does not replace a live Chat digest with a terminal row from the same conversation", () => {
+    const visible = entryOf({
+      id: "chat:conversation-1",
+      kind: "chat",
+      run: null,
+      active: false,
+      title: "Replied in Launch plan",
+    });
+    const live = {
+      id: visible.id,
+      kind: "chat" as const,
+      at: "2026-09-03T11:00:00.000Z",
+      title: "Working on Launch plan",
+      detail: "Comparing risks · 60%",
+      active: true,
+    };
+    const rollup: WorkEmployeeSummary = {
+      employeeId: visible.employee.id,
+      entryCount: 1,
+      latest: visible,
+      current: live,
+      waiting: null,
+    };
+    const summary = summarizeEmployeeWork(visible.employee.id, [visible], rollup);
+    assert.equal(summary.state, "working");
+    assert.equal(summary.currentEntry, live);
+    assert.equal(summary.currentEntry.title, "Working on Launch plan");
+  });
+
+  test("ages terminal work out of the rolling window without hiding old current work", () => {
+    const nowIso = "2026-09-03T12:00:00.000Z";
+    const old = entryOf({ at: "2026-09-02T11:59:59.000Z" });
+    const recent = summarizeEmployeeWork(old.employee.id, [old], undefined, { nowIso });
+    assert.equal(recent.state, "quiet");
+    assert.equal(recent.latestEntry, null);
+
+    const current = summarizeEmployeeWork(old.employee.id, [{ ...old, active: true }], undefined, {
+      nowIso,
+    });
+    assert.equal(current.state, "working");
+  });
+
+  test("focus follows current work, then a waiting gate, then the latest row", () => {
+    const latest = entryOf({ id: "latest" });
+    const waiting = entryOf({ id: "waiting", kind: "approval", run: null });
+    const current = entryOf({ id: "current", active: true });
+    const base = summarizeEmployeeWork(latest.employee.id, [latest]);
+    assert.equal(employeeWorkFocus(base)?.id, "latest");
+    assert.equal(employeeWorkFocus({ ...base, waitingEntry: waiting })?.id, "waiting");
+    assert.equal(
+      employeeWorkFocus({ ...base, waitingEntry: waiting, currentEntry: current })?.id,
+      "current",
+    );
+    assert.equal(employeeWorkFocus({ ...base, latestEntry: null }), null);
+  });
+});
+
+describe("relative work copy", () => {
+  const now = "2026-09-03T12:00:00.000Z";
+  const before = (ms: number) => new Date(new Date(now).getTime() - ms).toISOString();
+
+  test("uses human time at the minute and hour boundaries", () => {
+    assert.equal(workRelativeTime(before(0), now), "Just now");
+    assert.equal(workRelativeTime(before(59_999), now), "Just now");
+    assert.equal(workRelativeTime(before(60_000), now), "1m ago");
+    assert.equal(workRelativeTime(before(59 * 60_000), now), "59m ago");
+    assert.equal(workRelativeTime(before(60 * 60_000), now), "1h ago");
+    assert.equal(workRelativeTime(before(23 * 3_600_000), now), "23h ago");
+  });
+
+  test("uses days before falling back to a calendar date", () => {
+    assert.equal(workRelativeTime(before(24 * 3_600_000), now), "1d ago");
+    assert.equal(workRelativeTime(before(6 * DAY), now), "6d ago");
+    const sevenDaysAgo = before(7 * DAY);
+    assert.equal(workRelativeTime(sevenDaysAgo, now), new Date(sevenDaysAgo).toLocaleDateString());
+  });
+
+  test("handles future and malformed timestamps without awkward negative copy", () => {
+    assert.equal(workRelativeTime("2026-09-03T12:05:00.000Z", now), "Just now");
+    assert.equal(workRelativeTime("not-a-date", now), "");
+    assert.equal(workRelativeTime(before(1000), "not-a-date"), "");
+  });
+
+  test("labels all four bubble states", () => {
+    const row = entryOf({ at: before(2 * 3_600_000) });
+    const recent = summarizeEmployeeWork(row.employee.id, [row]);
+    assert.equal(employeeWorkStatusLabel(recent, now), "Active 2h ago");
+    assert.equal(
+      employeeWorkStatusLabel({ ...recent, state: "working", currentEntry: row }, now),
+      "Working now",
+    );
+    assert.equal(
+      employeeWorkStatusLabel({ ...recent, state: "waiting", waitingEntry: row }, now),
+      "Waiting for input",
+    );
+    assert.equal(
+      employeeWorkStatusLabel({ ...recent, state: "quiet", latestEntry: null }, now),
+      "Quiet today",
+    );
+  });
+});
+
+describe("rolling work window", () => {
+  const now = "2026-09-03T12:00:00.000Z";
+
+  test("keeps the boundary and ages out the moment before it", () => {
+    assert.equal(isWorkInsideWindow("2026-09-02T12:00:00.000Z", now), true);
+    assert.equal(isWorkInsideWindow("2026-09-02T11:59:59.999Z", now), false);
+  });
+
+  test("fails open for malformed or future timestamps", () => {
+    assert.equal(isWorkInsideWindow("not-a-date", now), true);
+    assert.equal(isWorkInsideWindow("2026-09-03T12:01:00.000Z", now), true);
+  });
+
+  test("drops an unknowable hidden total after the server snapshot ages", () => {
+    assert.equal(workDisplayEntryCount(100, 40, 40, now, now), 100);
+    assert.equal(workDisplayEntryCount(100, 40, 30, now, "2026-09-03T12:01:00.000Z"), 30);
+    assert.equal(workDisplayEntryCount(100, 40, 30, "not-a-date", now), 30);
+  });
+});
+
+describe("human-readable effects", () => {
+  test("turns known ledger verbs into plain language", () => {
+    assert.equal(humanizeWorkAction("invoice.create", "invoice"), "Created invoice");
+    assert.equal(humanizeWorkAction("mail/send", "mail_message"), "Sent mail message");
+    assert.equal(humanizeWorkAction("todo:comment", "todo"), "Commented on todo");
+  });
+
+  test("humanises camelCase, snake_case, and kebab-case targets", () => {
+    assert.equal(
+      humanizeWorkAction("customer.update", "customerProfile"),
+      "Updated customer profile",
+    );
+    assert.equal(
+      humanizeWorkAction("customer.update", "customer_profile"),
+      "Updated customer profile",
+    );
+    assert.equal(
+      humanizeWorkAction("customer.update", "customer-profile"),
+      "Updated customer profile",
+    );
+  });
+
+  test("keeps unknown operations readable and derives a missing target", () => {
+    assert.equal(humanizeWorkAction("billing.reconcile", "bank_account"), "Reconcile bank account");
+    assert.equal(humanizeWorkAction("note.publish", ""), "Published note");
+    assert.equal(humanizeWorkAction("archive", ""), "Archived record");
+  });
+
+  test("turns Approval status tokens into human copy without rewriting other detail", () => {
+    assert.equal(
+      workDetailLabel(entryOf({ kind: "approval", detail: "pending" })),
+      "Waiting for input",
+    );
+    assert.equal(
+      workDetailLabel(entryOf({ kind: "approval", detail: "execution_failed" })),
+      "Approved action failed",
+    );
+    assert.equal(
+      workDetailLabel(entryOf({ kind: "run", detail: "manual trigger" })),
+      "manual trigger",
+    );
+  });
+
+  test("turns a standalone Effect into a readable action with its subject underneath", () => {
+    const effect = entryOf({
+      kind: "effect",
+      run: null,
+      title: "INV-4001",
+      detail: "invoice.create",
+    });
+    assert.equal(workDisplayTitle(effect), "Created invoice");
+    assert.equal(workDisplayDetail(effect), "INV-4001");
+    assert.equal(workDisplayTitle(entryOf()), "Ran Nightly digest");
+  });
+});
+
 describe("destinations", () => {
   test("a run deep-links to its own row in the routine's history", () => {
     const href = workEntryHref(entryOf(), "acme");
@@ -222,10 +516,7 @@ describe("kind metadata", () => {
 
 describe("summaries", () => {
   test("names the employee when the whole roster is on screen", () => {
-    assert.equal(
-      workEntrySummary(entryOf(), { withEmployee: true }),
-      "Rey — Ran Nightly digest",
-    );
+    assert.equal(workEntrySummary(entryOf(), { withEmployee: true }), "Rey — Ran Nightly digest");
   });
 
   test("drops the name once one employee is the subject", () => {
@@ -258,7 +549,33 @@ describe("overflow and empty copy", () => {
           })),
         }),
       ),
-      "3 more",
+      "3 more changes",
+    );
+  });
+
+  test("counts from what the UI displayed when it deliberately shows fewer effects", () => {
+    assert.equal(
+      workEffectOverflowLabel(
+        entryOf({
+          effectCount: 8,
+          effects: Array.from({ length: 8 }, () => ({
+            action: "invoice.create",
+            targetType: "invoice",
+            targetId: null,
+            targetLabel: "INV-1",
+            at: new Date().toISOString(),
+          })),
+        }),
+        3,
+      ),
+      "5 more changes",
+    );
+  });
+
+  test("uses singular copy for one withheld effect", () => {
+    assert.equal(
+      workEffectOverflowLabel(entryOf({ effectCount: 1, effects: [] })),
+      "1 more change",
     );
   });
 

--- a/App/client/lib/workTimeline.ts
+++ b/App/client/lib/workTimeline.ts
@@ -1,4 +1,4 @@
-import type { WorkEntry, WorkEntryKind } from "./api";
+import type { WorkEmployeeSummary, WorkEntry, WorkEntryDigest, WorkEntryKind } from "./api";
 
 /**
  * The presentation rules behind Home's AI Employee work timeline.
@@ -38,7 +38,7 @@ export const WORK_KIND_META: Record<WorkEntryKind, WorkKindMeta> = {
     tone: "bg-violet-50 text-violet-600 ring-violet-100 dark:bg-violet-500/10 dark:text-violet-300 dark:ring-violet-500/20",
   },
   approval: {
-    label: "Approval asked",
+    label: "Approval required",
     tone: "bg-amber-50 text-amber-600 ring-amber-100 dark:bg-amber-500/10 dark:text-amber-300 dark:ring-amber-500/20",
   },
   wakeup: {
@@ -67,6 +67,234 @@ export const WORK_ENTRY_KINDS: readonly WorkEntryKind[] = [
 ];
 
 export type WorkDayGroup = { key: string; label: string; items: WorkEntry[] };
+
+/**
+ * The small set of states Home needs to describe an employee at a glance.
+ *
+ * `working` is intentionally narrow: a missing `endedAt` does not make an
+ * ordinary chat reply, Wakeup, or ledger row live forever. Only source rows
+ * that carry an explicit in-flight state qualify. A pending Approval is
+ * separate because the employee is waiting for a Member, not still working.
+ */
+export type EmployeeWorkState = "working" | "waiting" | "recent" | "quiet";
+
+export type EmployeeWorkSummary = {
+  employeeId: string;
+  state: EmployeeWorkState;
+  /** The newest explicitly in-flight row, when there is one. */
+  currentEntry: WorkEntryDigest | null;
+  /** The newest pending Approval, when there is one. */
+  waitingEntry: WorkEntryDigest | null;
+  /** The newest row of any kind. */
+  latestEntry: WorkEntryDigest | null;
+  entryCount: number;
+};
+
+/** Whether a row represents work that is still happening right now. */
+export function isWorkEntryActive(entry: WorkEntry): boolean {
+  return entry.active;
+}
+
+/** Whether the employee has stopped at a human gate and is waiting. */
+export function isWorkEntryWaiting(entry: WorkEntry): boolean {
+  return (
+    entry.kind === "approval" &&
+    entry.endedAt === null &&
+    entry.detail.trim().toLowerCase() === "pending"
+  );
+}
+
+/**
+ * One employee's status from a newest-first timeline response.
+ *
+ * Working takes precedence over waiting: an employee can have an old pending
+ * Approval and still be making progress elsewhere. Waiting takes precedence
+ * over merely recent work so the roster does not make a human gate look idle.
+ */
+export function summarizeEmployeeWork(
+  employeeId: string,
+  entries: WorkEntry[],
+  rollup?: WorkEmployeeSummary,
+  window?: { nowIso: string; hours?: number },
+): EmployeeWorkSummary {
+  const own = entries.filter((entry) => entry.employee.id === employeeId);
+  const resolveDigest = (
+    value: WorkEntryDigest | null,
+    matches: (entry: WorkEntry) => boolean = () => true,
+  ): WorkEntryDigest | null =>
+    value ? (own.find((entry) => entry.id === value.id && matches(entry)) ?? value) : null;
+  const currentEntry = rollup
+    ? resolveDigest(rollup.current, (entry) => entry.active === rollup.current?.active)
+    : (own.find(isWorkEntryActive) ?? null);
+  const waitingEntry = rollup
+    ? resolveDigest(rollup.waiting, isWorkEntryWaiting)
+    : (own.find(isWorkEntryWaiting) ?? null);
+  const latest = rollup ? resolveDigest(rollup.latest) : (own[0] ?? null);
+  const latestEntry =
+    latest && window && !isWorkInsideWindow(latest.at, window.nowIso, window.hours) ? null : latest;
+  const state: EmployeeWorkState = currentEntry
+    ? "working"
+    : waitingEntry
+      ? "waiting"
+      : latestEntry
+        ? "recent"
+        : "quiet";
+  return {
+    employeeId,
+    state,
+    currentEntry,
+    waitingEntry,
+    latestEntry,
+    entryCount: rollup?.entryCount ?? own.length,
+  };
+}
+
+/** Whether a timestamp still belongs in the rolling work-history window. */
+export function isWorkInsideWindow(atIso: string, nowIso: string, hours = 24): boolean {
+  const at = new Date(atIso).getTime();
+  const now = new Date(nowIso).getTime();
+  if (Number.isNaN(at) || Number.isNaN(now)) return true;
+  return at >= now - hours * 60 * 60 * 1000;
+}
+
+/**
+ * Count the rows the rolling list can still claim truthfully.
+ *
+ * At the server's snapshot time, `total` includes hidden rows beyond the
+ * response limit. Once the local clock advances, their timestamps are unknown.
+ * If one visible row has aged out, every hidden row is older; even before that,
+ * a hidden row may already have crossed the boundary. Fall back to the visible
+ * count instead of showing a precise but stale overflow total.
+ */
+export function workDisplayEntryCount(
+  total: number,
+  returned: number,
+  visible: number,
+  snapshotUntilIso: string,
+  nowIso: string,
+): number {
+  const snapshotUntil = new Date(snapshotUntilIso).getTime();
+  const now = new Date(nowIso).getTime();
+  if (Number.isNaN(snapshotUntil) || Number.isNaN(now) || now > snapshotUntil) return visible;
+  return Math.max(visible, total - (returned - visible));
+}
+
+/** The row Home should feature when an employee bubble is selected. */
+export function employeeWorkFocus(summary: EmployeeWorkSummary): WorkEntryDigest | null {
+  return summary.currentEntry ?? summary.waitingEntry ?? summary.latestEntry;
+}
+
+/** Short relative time for a timeline row, deterministic when `nowIso` is supplied. */
+export function workRelativeTime(iso: string, nowIso = new Date().toISOString()): string {
+  const at = new Date(iso).getTime();
+  const now = new Date(nowIso).getTime();
+  if (Number.isNaN(at) || Number.isNaN(now)) return "";
+  const elapsed = Math.max(0, now - at);
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+/** The status line underneath one employee bubble. */
+export function employeeWorkStatusLabel(
+  summary: EmployeeWorkSummary,
+  nowIso = new Date().toISOString(),
+): string {
+  switch (summary.state) {
+    case "working":
+      return "Working now";
+    case "waiting":
+      return "Waiting for input";
+    case "recent": {
+      const relative = summary.latestEntry
+        ? workRelativeTime(summary.latestEntry.at, nowIso).toLowerCase()
+        : "";
+      return relative ? `Active ${relative}` : "Active today";
+    }
+    case "quiet":
+      return "Quiet today";
+  }
+}
+
+const ACTION_VERBS: Record<string, string> = {
+  add: "Added",
+  approve: "Approved",
+  archive: "Archived",
+  assign: "Assigned",
+  cancel: "Cancelled",
+  comment: "Commented on",
+  complete: "Completed",
+  connect: "Connected",
+  create: "Created",
+  delete: "Deleted",
+  disconnect: "Disconnected",
+  download: "Downloaded",
+  edit: "Updated",
+  invoke: "Used",
+  issue: "Issued",
+  link: "Linked",
+  read: "Read",
+  move: "Moved",
+  publish: "Published",
+  reject: "Rejected",
+  remove: "Removed",
+  restore: "Restored",
+  schedule: "Scheduled",
+  send: "Sent",
+  unlink: "Unlinked",
+  update: "Updated",
+  upload: "Uploaded",
+  use: "Used",
+  write: "Updated",
+};
+
+function readableWords(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[._-]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/** Turn an effect-ledger action such as `invoice.create` into reader-facing copy. */
+export function humanizeWorkAction(action: string, targetType: string): string {
+  const actionParts = action.split(/[.:/]/).filter(Boolean);
+  const operation = readableWords(actionParts.at(-1) ?? action);
+  const target = readableWords(targetType || actionParts.at(-2) || "record");
+  const verb =
+    ACTION_VERBS[operation] ?? `${operation.charAt(0).toUpperCase()}${operation.slice(1)}`;
+  return [verb, target].filter(Boolean).join(" ");
+}
+
+/** Reader-facing detail copy where a source stores a compact status token. */
+export function workDetailLabel(entry: Pick<WorkEntry, "kind" | "detail">): string {
+  if (entry.kind !== "approval") return entry.detail;
+  const approval: Record<string, string> = {
+    pending: "Waiting for input",
+    executing: "Applying the approved action",
+    approved: "Approved",
+    execution_failed: "Approved action failed",
+    rejected: "Rejected",
+    expired: "Expired",
+  };
+  return approval[entry.detail.trim().toLowerCase()] ?? readableWords(entry.detail);
+}
+
+/** Human-first title for a timeline row, including standalone Effects. */
+export function workDisplayTitle(entry: Pick<WorkEntry, "kind" | "title" | "detail">): string {
+  return entry.kind === "effect" ? humanizeWorkAction(entry.detail, "") : entry.title;
+}
+
+/** Supporting row copy after compact source tokens have been translated. */
+export function workDisplayDetail(entry: Pick<WorkEntry, "kind" | "title" | "detail">): string {
+  if (entry.kind === "effect") return entry.title === entry.detail ? "" : entry.title;
+  return workDetailLabel(entry);
+}
 
 export function workDayKey(d: Date): string {
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
@@ -168,11 +396,14 @@ export function workOverflowLabel(shown: number, total: number): string | null {
   return `Showing the ${shown} most recent of ${total}`;
 }
 
-/** "3 more" under a capped effects strip; null when nothing was withheld. */
-export function workEffectOverflowLabel(entry: WorkEntry): string | null {
-  const hidden = entry.effectCount - entry.effects.length;
+/** "3 more changes" under a capped effects strip; null when nothing was withheld. */
+export function workEffectOverflowLabel(
+  entry: WorkEntry,
+  shown = entry.effects.length,
+): string | null {
+  const hidden = entry.effectCount - shown;
   if (hidden <= 0) return null;
-  return `${hidden} more`;
+  return `${hidden} more ${hidden === 1 ? "change" : "changes"}`;
 }
 
 /** The empty-state line, which depends on whether a name was chosen. */

--- a/App/client/pages/Home.tsx
+++ b/App/client/pages/Home.tsx
@@ -75,12 +75,12 @@ import { clsx } from "../components/ui/clsx";
  * todos assigned to me, reviews waiting on my sign-off, pending approvals,
  * and unread channels. Every card deep-links into the full section.
  *
- * **Every panel here hides itself when it has nothing.** Each one is a queue,
- * and an empty queue is not news — a card that spends a grid slot to say
- * "nothing is waiting on you" pushes the things that *are* waiting further
- * down, and six of them turn a quiet day into a wall of reassurance nobody
- * reads. The decision stack and the failure alert have always worked this way;
- * the rest now match. When every panel is empty {@link AllClear} says it once.
+ * Every queue here hides itself when it has nothing. An empty queue is not
+ * news — a card that spends a grid slot to say "nothing is waiting on you"
+ * pushes the things that *are* waiting further down. When every queue is empty
+ * {@link AllClear} says it once. The AI employee work panel is not a
+ * queue: its bubble roster remains useful on a quiet day as the quickest way
+ * to see an employee and check in.
  */
 
 const PUSH_PROMPT_DISMISSED_KEY = "genosyn.pushPromptDismissed";
@@ -114,11 +114,15 @@ export default function HomePage({ company, me }: { company: Company; me: Me }) 
   const background = useBackgroundAction();
 
   // The todo peek needs the company's people to fill its assignee and reviewer
-  // pickers. Fetched once beside the Home payload rather than on each open, so
-  // the modal has them the moment it appears; both are small reads and a
-  // failure just leaves the pickers listing nobody.
+  // pickers and the employee bubble roster. Fetched beside the Home payload
+  // rather than on each open, so the modal has them the moment it appears;
+  // both are small reads. Resource events keep the roster current.
+  // The work panel owns the roster's inline failure state, while the optional
+  // modal pickers simply remain empty.
   const [employees, setEmployees] = React.useState<Employee[]>([]);
+  const [employeesError, setEmployeesError] = React.useState<string | null>(null);
   const [members, setMembers] = React.useState<Member[]>([]);
+  const peopleRequest = React.useRef(0);
 
   const reload = React.useCallback(async () => {
     try {
@@ -135,21 +139,32 @@ export default function HomePage({ company, me }: { company: Company; me: Me }) 
     reload();
   }, [reload]);
 
-  React.useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const [emps, mems] = await Promise.all([
-        api.get<Employee[]>(`/api/companies/${company.id}/employees`).catch(() => [] as Employee[]),
-        api.get<Member[]>(`/api/companies/${company.id}/members`).catch(() => [] as Member[]),
-      ]);
-      if (cancelled) return;
-      setEmployees(emps);
-      setMembers(mems);
-    })();
-    return () => {
-      cancelled = true;
-    };
+  const reloadPeople = React.useCallback(async () => {
+    const request = ++peopleRequest.current;
+    const [emps, mems] = await Promise.allSettled([
+      api.get<Employee[]>(`/api/companies/${company.id}/employees`),
+      api.get<Member[]>(`/api/companies/${company.id}/members`),
+    ]);
+    if (request !== peopleRequest.current) return;
+    if (emps.status === "fulfilled") {
+      setEmployees(emps.value);
+      setEmployeesError(null);
+    } else {
+      setEmployees([]);
+      setEmployeesError(errorMessage(emps.reason, "Could not load your AI employees."));
+    }
+    setMembers(mems.status === "fulfilled" ? mems.value : []);
   }, [company.id]);
+
+  React.useEffect(() => {
+    setEmployees([]);
+    setEmployeesError(null);
+    setMembers([]);
+    void reloadPeople();
+    return () => {
+      peopleRequest.current += 1;
+    };
+  }, [reloadPeople]);
 
   // Live-refresh when something lands in my bell, and on tab focus so the
   // page is current when the user comes back to it.
@@ -162,15 +177,19 @@ export default function HomePage({ company, me }: { company: Company; me: Me }) 
     }
   });
   React.useEffect(() => {
-    const onFocus = () => reload();
+    const onFocus = () => {
+      void reload();
+      void reloadPeople();
+    };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
-  }, [reload]);
+  }, [reload, reloadPeople]);
   // The stack is the first thing on the page, so it has to be current: a
   // teammate answering in another tab should empty it here without a refresh.
   // `tldr_question` keeps the Discuss badge honest — a card asked from the
   // TLDRs page changes this count without touching the briefing row.
   useLiveRefetch(["decision", "tldr", "tldr_question"], reload);
+  useLiveRefetch("employee", reloadPeople);
 
   function dismissTldr(item: TldrItem) {
     const originalIndex = data?.tldrs.findIndex((row) => row.id === item.id) ?? -1;
@@ -245,6 +264,7 @@ export default function HomePage({ company, me }: { company: Company; me: Me }) 
             <WorkTimelinePanel
               company={company}
               employees={employees}
+              employeeLoadError={employeesError}
               onOpenRun={(entry) => setOverlay({ kind: "workRun", entry })}
             />
           </>
@@ -423,8 +443,9 @@ function HomeOverlayHost({
  * queue, and {@link AllClear} says the queues are empty — which stays true on a
  * night the roster worked straight through. Folding the timeline in here would
  * either hide a full day's work behind "Nothing needs you right now" or quietly
- * change what that sentence means. It keeps the rule the panels follow — it
- * hides itself when its own window is empty — and applies it to its own data.
+ * change what that sentence means. Its bubble roster deliberately stays below
+ * the all-clear even when the work window itself is empty, because choosing a
+ * teammate and checking in is still useful.
  */
 function hasAnythingToShow(data: HomeData): boolean {
   return (

--- a/App/server/routes/workTimeline.test.ts
+++ b/App/server/routes/workTimeline.test.ts
@@ -109,8 +109,22 @@ type TimelineBody = {
   since: string;
   until: string;
   employeeId: string | null;
-  entries: { id: string; kind: string }[];
+  entries: {
+    id: string;
+    kind: string;
+    at: string;
+    title: string;
+    detail: string;
+    active: boolean;
+  }[];
   entryCount: number;
+  employeeSummaries: {
+    employeeId: string;
+    entryCount: number;
+    latest: { id: string; active: boolean } | null;
+    current: { id: string; active: boolean } | null;
+    waiting: { id: string; active: boolean } | null;
+  }[];
 };
 
 async function seedRun(): Promise<void> {
@@ -167,6 +181,23 @@ describe("work timeline responses", () => {
     assert.equal(body.employeeId, null);
     assert.equal(body.entryCount, 1);
     assert.equal(body.entries[0].kind, "run");
+    assert.equal(body.entries[0].active, false);
+    assert.deepEqual(body.employeeSummaries, [
+      {
+        employeeId: employee.id,
+        entryCount: 1,
+        latest: {
+          id: body.entries[0].id,
+          kind: "run",
+          at: body.entries[0].at,
+          title: "Ran Nightly digest",
+          detail: "",
+          active: false,
+        },
+        current: null,
+        waiting: null,
+      },
+    ]);
     assert.equal(
       new Date(body.until).getTime() - new Date(body.since).getTime(),
       24 * 60 * 60 * 1000,
@@ -193,6 +224,10 @@ describe("work timeline responses", () => {
     assert.equal(status, 200);
     assert.equal(body.employeeId, employee.id);
     assert.equal(body.entryCount, 1);
+    assert.deepEqual(
+      body.employeeSummaries.map((row) => row.employeeId),
+      [employee.id],
+    );
   });
 });
 

--- a/App/server/services/chatTurnProgress.test.ts
+++ b/App/server/services/chatTurnProgress.test.ts
@@ -1,17 +1,54 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { createChatTurnProgressRecorder } from "./chatTurnProgress.js";
+import {
+  createChatTurnProgressRecorder,
+  createProgressRefreshNotifier,
+} from "./chatTurnProgress.js";
+
+describe("progress refresh notifier", () => {
+  test("leads immediately and trails with the newest suppressed milestone", async () => {
+    const notifiedAt: number[] = [];
+    const notifier = createProgressRefreshNotifier({
+      notify: () => notifiedAt.push(Date.now()),
+      intervalMs: 20,
+    });
+
+    notifier.report();
+    notifier.report();
+    notifier.report();
+    assert.equal(notifiedAt.length, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    assert.equal(notifiedAt.length, 2);
+    notifier.cancel();
+  });
+
+  test("cancels a trailing refresh and contains subscriber errors", async () => {
+    let attempts = 0;
+    const notifier = createProgressRefreshNotifier({
+      notify: () => {
+        attempts += 1;
+        throw new Error("socket closed");
+      },
+      intervalMs: 20,
+    });
+
+    assert.doesNotThrow(() => notifier.report());
+    notifier.report();
+    notifier.cancel();
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    assert.equal(attempts, 1);
+  });
+});
 
 describe("chat turn progress recorder", () => {
   test("persists milestones in order and forwards them immediately", async () => {
     const persisted: number[] = [];
+    const persistedEvents: number[] = [];
     const forwarded: number[] = [];
     const repository = {
-      update: async (
-        _criteria: unknown,
-        patch: { progressPercent?: number | null },
-      ) => {
+      update: async (_criteria: unknown, patch: { progressPercent?: number | null }) => {
         await Promise.resolve();
         persisted.push(patch.progressPercent ?? 0);
         return { generatedMaps: [], raw: [], affected: 1 };
@@ -21,6 +58,7 @@ describe("chat turn progress recorder", () => {
       repository,
       messageId: "message-1",
       onProgress: (progress) => forwarded.push(progress.percent),
+      onPersisted: (progress) => persistedEvents.push(progress.percent),
     });
 
     recorder.report({ percent: 15, label: "Inspecting records" });
@@ -28,8 +66,26 @@ describe("chat turn progress recorder", () => {
 
     assert.deepEqual(forwarded, [15, 70]);
     assert.deepEqual(persisted, []);
+    assert.deepEqual(persistedEvents, []);
     await recorder.flush();
     assert.deepEqual(persisted, [15, 70]);
+    assert.deepEqual(persistedEvents, [15, 70]);
+  });
+
+  test("only announces milestones that still belong to the working turn", async () => {
+    const persistedEvents: number[] = [];
+    const recorder = createChatTurnProgressRecorder({
+      repository: {
+        update: async () => ({ generatedMaps: [], raw: [], affected: 0 }),
+      },
+      messageId: "message-overtaken",
+      onPersisted: (progress) => persistedEvents.push(progress.percent),
+    });
+
+    recorder.report({ percent: 55, label: "Overtaken work" });
+    await recorder.flush();
+
+    assert.deepEqual(persistedEvents, []);
   });
 
   test("contains subscriber and persistence failures", async () => {
@@ -44,6 +100,9 @@ describe("chat turn progress recorder", () => {
       onProgress: () => {
         throw new Error("stream closed");
       },
+      onPersisted: () => {
+        throw new Error("socket closed");
+      },
       onPersistenceError: (error) => errors.push(error),
     });
 
@@ -51,5 +110,24 @@ describe("chat turn progress recorder", () => {
     await recorder.flush();
 
     assert.equal(errors.length, 1);
+  });
+
+  test("contains live-refresh subscriber failures after a successful write", async () => {
+    const errors: unknown[] = [];
+    const recorder = createChatTurnProgressRecorder({
+      repository: {
+        update: async () => ({ generatedMaps: [], raw: [], affected: 1 }),
+      },
+      messageId: "message-3",
+      onPersisted: () => {
+        throw new Error("socket closed");
+      },
+      onPersistenceError: (error) => errors.push(error),
+    });
+
+    recorder.report({ percent: 80, label: "Finishing" });
+    await recorder.flush();
+
+    assert.deepEqual(errors, []);
   });
 });

--- a/App/server/services/chatTurnProgress.ts
+++ b/App/server/services/chatTurnProgress.ts
@@ -5,6 +5,48 @@ import type { AgentProgress } from "./agent/types.js";
 type ProgressMessageRepository = Pick<Repository<ConversationMessage>, "update">;
 
 /**
+ * Lead with an immediate refresh, then guarantee one trailing refresh for the
+ * newest milestone received during the quieting interval.
+ */
+export function createProgressRefreshNotifier(options: { notify: () => void; intervalMs: number }) {
+  let lastNotifiedAt = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const notify = () => {
+    lastNotifiedAt = Date.now();
+    try {
+      options.notify();
+    } catch {
+      // A live-refresh subscriber must not escape from a timer or fail work.
+    }
+  };
+
+  const report = () => {
+    const elapsed = Date.now() - lastNotifiedAt;
+    if (lastNotifiedAt === 0 || elapsed >= options.intervalMs) {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      notify();
+      return;
+    }
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      notify();
+    }, options.intervalMs - elapsed);
+    timer.unref?.();
+  };
+
+  return {
+    report,
+    cancel: () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+    },
+  };
+}
+
+/**
  * Serializes progress writes for one durable working message.
  *
  * The model-facing callback is synchronous, but database writes are not. A
@@ -18,6 +60,7 @@ export function createChatTurnProgressRecorder(options: {
   messageId: string;
   workerId?: string;
   onProgress?: (progress: AgentProgress) => void;
+  onPersisted?: (progress: AgentProgress) => void;
   onPersistenceError?: (error: unknown) => void;
 }) {
   let pending = Promise.resolve();
@@ -31,7 +74,7 @@ export function createChatTurnProgressRecorder(options: {
 
     pending = pending
       .then(async () => {
-        await options.repository.update(
+        const updated = await options.repository.update(
           {
             id: options.messageId,
             status: "working",
@@ -42,6 +85,12 @@ export function createChatTurnProgressRecorder(options: {
             progressLabel: progress.label,
           },
         );
+        if (updated.affected !== 1) return;
+        try {
+          options.onPersisted?.(progress);
+        } catch {
+          // A live-refresh subscriber is best effort, just like a stream subscriber.
+        }
       })
       .catch((error) => {
         try {

--- a/App/server/services/durableChatTurns.ts
+++ b/App/server/services/durableChatTurns.ts
@@ -18,14 +18,15 @@ import {
   streamChatWithEmployee,
 } from "./chat.js";
 import { createChatTurnContextUsageRecorder } from "./chatTurnContextUsage.js";
-import { createChatTurnProgressRecorder } from "./chatTurnProgress.js";
+import {
+  createChatTurnProgressRecorder,
+  createProgressRefreshNotifier,
+} from "./chatTurnProgress.js";
 import { historicalAttachmentSummaries, inlineAttachmentsForMessage } from "./attachmentText.js";
+import { emitResourceChange } from "./resourceEvents.js";
 import { captureTurnActionsForAuthority } from "./turnActions.js";
 import { bindAttachmentsToMessage } from "./uploads.js";
-import {
-  EmployeeWorkloadBusyError,
-  releaseChatWorkloadLeaseByOwner,
-} from "./workloadLeases.js";
+import { EmployeeWorkloadBusyError, releaseChatWorkloadLeaseByOwner } from "./workloadLeases.js";
 
 const MAX_REPLAY_TURNS = 20;
 const TURN_LEASE_MS = 15_000;
@@ -33,6 +34,7 @@ const TURN_HEARTBEAT_MS = 5_000;
 const RECOVERY_POLL_MS = 5_000;
 const BUSY_RETRY_MS = 15_000;
 const MAX_RECOVERIES_PER_SWEEP = 10;
+const WORK_PROGRESS_EVENT_INTERVAL_MS = 30_000;
 
 export type DurableChatTurnCallbacks = {
   onChunk?: (chunk: string) => void;
@@ -94,7 +96,7 @@ export async function enqueueDurableChatTurn(args: {
   assistantMessage: ConversationMessage;
   userAttachments: Attachment[];
 }> {
-  return AppDataSource.transaction(async (manager) => {
+  const turn = await AppDataSource.transaction(async (manager) => {
     const conversationRepo = manager.getRepository(Conversation);
     const messageRepo = manager.getRepository(ConversationMessage);
     const [conversation, requester, membership] = await Promise.all([
@@ -162,6 +164,27 @@ export async function enqueueDurableChatTurn(args: {
       userAttachments,
     };
   });
+  emitResourceChange(args.companyId, "employee_work", args.employeeId);
+  return turn;
+}
+
+/** Best-effort live refresh for terminal paths that no longer hold the employee row. */
+async function emitConversationWorkChange(conversationId: string): Promise<void> {
+  try {
+    const conversation = await AppDataSource.getRepository(Conversation).findOne({
+      where: { id: conversationId },
+      select: ["employeeId"],
+    });
+    if (!conversation) return;
+    const employee = await AppDataSource.getRepository(AIEmployee).findOne({
+      where: { id: conversation.employeeId },
+      select: ["id", "companyId"],
+    });
+    if (employee) emitResourceChange(employee.companyId, "employee_work", employee.id);
+  } catch {
+    // The durable row is already final. A missed refresh heals on focus; it
+    // must never turn completed employee work into a failed chat response.
+  }
 }
 
 /**
@@ -221,6 +244,15 @@ export async function executeDurableChatTurn(
   let lostClaim = false;
   let interrupted = false;
   let renewing = false;
+  let workScope: { companyId: string; employeeId: string } | null = null;
+  const workProgressEvents = createProgressRefreshNotifier({
+    intervalMs: WORK_PROGRESS_EVENT_INTERVAL_MS,
+    notify: () => {
+      if (workScope) {
+        emitResourceChange(workScope.companyId, "employee_work", workScope.employeeId);
+      }
+    },
+  });
 
   const loseClaim = () => {
     lostClaim = true;
@@ -272,6 +304,7 @@ export async function executeDurableChatTurn(
     messageId: claimedMessage.id,
     workerId,
     onProgress: callbacks.onProgress,
+    onPersisted: workProgressEvents.report,
     onPersistenceError: (error) => {
       // eslint-disable-next-line no-console
       console.error(
@@ -306,6 +339,10 @@ export async function executeDurableChatTurn(
         callbacks,
       );
     }
+    workScope = {
+      companyId: context.employee.companyId,
+      employeeId: context.employee.id,
+    };
 
     const deadline =
       claimedMessage.turnDeadlineAt ??
@@ -514,6 +551,7 @@ export async function executeDurableChatTurn(
 
     context.conversation.updatedAt = new Date();
     await AppDataSource.getRepository(Conversation).save(context.conversation);
+    emitResourceChange(context.employee.companyId, "employee_work", context.employee.id);
     const finalMessage = await messageRepo.findOneByOrFail({
       id: claimedMessage.id,
     });
@@ -543,6 +581,7 @@ export async function executeDurableChatTurn(
       callbacks,
     );
   } finally {
+    workProgressEvents.cancel();
     clearInterval(heartbeat);
     activeClaimAborters.delete(claimedMessage.id);
     activeTurnInterrupters.delete(claimedMessage.id);
@@ -586,6 +625,8 @@ export async function interruptDurableChatTurn(
   // the lease of a worker that died mid-turn, which is exactly the state a
   // Member is usually reacting to when they reach for Stop.
   await releaseChatWorkloadLeaseByOwner(messageId);
+  const message = await repo.findOne({ where: { id: messageId }, select: ["conversationId"] });
+  if (message) await emitConversationWorkChange(message.conversationId);
   return "interrupted";
 }
 
@@ -766,6 +807,7 @@ async function finalizeInterruptedTurn(
   if (!conversation) return "completed";
   conversation.updatedAt = new Date();
   await AppDataSource.getRepository(Conversation).save(conversation);
+  await emitConversationWorkChange(conversation.id);
   const finalMessage = await repo.findOneByOrFail({ id: message.id });
   safeFinalCallback(callbacks, {
     message: finalMessage,
@@ -810,6 +852,7 @@ async function finalizeInfrastructureError(
   if (!conversation) return "completed";
   conversation.updatedAt = new Date();
   await AppDataSource.getRepository(Conversation).save(conversation);
+  await emitConversationWorkChange(conversation.id);
   const finalMessage = await repo.findOneByOrFail({ id: message.id });
   safeFinalCallback(callbacks, {
     message: finalMessage,

--- a/App/server/services/employeeWorkTimeline.test.ts
+++ b/App/server/services/employeeWorkTimeline.test.ts
@@ -83,9 +83,7 @@ beforeEach(async () => {
 });
 
 /** The timeline as the ordinary Member sees it, unless told otherwise. */
-async function timeline(
-  overrides: Partial<Parameters<typeof getEmployeeWorkTimeline>[0]> = {},
-) {
+async function timeline(overrides: Partial<Parameters<typeof getEmployeeWorkTimeline>[0]> = {}) {
   return getEmployeeWorkTimeline({
     companyId: company.id,
     userId: member.id,
@@ -195,12 +193,67 @@ describe("work timeline window", () => {
     assert.equal(span, 48 * HOUR);
   });
 
-  test("windows a run on when it started, not on whether it is still going", async () => {
-    // A run that began before the window and has not finished is not "today's
-    // work"; it is yesterday's, still in flight. The Journal is where a reader
-    // goes for the whole life of a long run.
-    await run({ startedAt: ago(30 * HOUR), status: "running", finishedAt: null, exitCode: null });
-    assert.equal((await timeline()).entryCount, 0);
+  test("keeps an old running Run out of recent history but marks the employee as working now", async () => {
+    const oldRun = await run({
+      startedAt: ago(30 * HOUR),
+      status: "running",
+      finishedAt: null,
+      exitCode: null,
+    });
+    const result = await timeline();
+    const summary = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(result.entryCount, 0);
+    assert.equal(summary.current?.id, `run:${oldRun.id}`);
+    assert.equal(summary.current?.active, true);
+  });
+
+  test("marks an old durable Chat turn as current without moving it into recent history", async () => {
+    const conv = await conversation();
+    await assistantMessage(conv.id, {
+      status: "working",
+      createdAt: ago(30 * HOUR),
+      updatedAt: ago(30 * HOUR),
+      progressLabel: "Still reconciling",
+      progressPercent: 80,
+    });
+    const result = await timeline();
+    const summary = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(result.entryCount, 0);
+    assert.equal(summary.current?.id, `chat:${conv.id}`);
+    assert.equal(summary.current?.detail, "Still reconciling · 80%");
+  });
+
+  test("marks old Repository work as current without moving it into recent history", async () => {
+    const session = await insert(RepositoryWorkSession, {
+      companyId: company.id,
+      repositoryId: testId("repo"),
+      employeeId: employee.id,
+      title: "Long migration",
+      instruction: "move the records",
+      status: "running",
+    });
+    const turn = await insert(RepositoryWorkSessionTurn, {
+      companyId: company.id,
+      sessionId: session.id,
+      ordinal: 1,
+      instruction: "move the records",
+      status: "running",
+      finishedAt: null,
+      createdAt: ago(30 * HOUR),
+    });
+    const result = await timeline();
+    const summary = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(result.entryCount, 0);
+    assert.equal(summary.current?.id, `work_session:${turn.id}`);
+  });
+
+  test("keeps an old unresolved Approval visible as waiting without changing recent history", async () => {
+    const pending = await approval({ requestedAt: ago(30 * HOUR) });
+    const result = await timeline();
+    const summary = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(result.entryCount, 0);
+    assert.equal(summary.waiting?.id, `approval:${pending.id}`);
+    assert.equal(summary.waiting?.title, "Approval required: Submit the form");
   });
 });
 
@@ -287,6 +340,30 @@ describe("work timeline sources", () => {
     assert.equal(result.entries[0].run?.routineId, routine.id);
   });
 
+  test("marks only a running Run as live, even when terminal rows have no finish timestamp", async () => {
+    const statuses = [
+      "running",
+      "completed",
+      "failed",
+      "skipped",
+      "timeout",
+      "interrupted",
+    ] as const;
+    const expected = new Map<string, boolean>();
+    for (const [index, status] of statuses.entries()) {
+      const row = await run({
+        status,
+        startedAt: ago((index + 1) * 10 * 60 * 1000),
+        finishedAt: null,
+        exitCode: status === "completed" ? 0 : null,
+      });
+      expected.set(`run:${row.id}`, status === "running");
+    }
+    const result = await timeline();
+    for (const entry of result.entries)
+      assert.equal(entry.active, expected.get(entry.id), entry.id);
+  });
+
   test("collapses many replies in one conversation into a single entry", async () => {
     const conv = await conversation();
     await assistantMessage(conv.id, { createdAt: ago(3 * HOUR) });
@@ -297,6 +374,63 @@ describe("work timeline sources", () => {
     assert.deepEqual(kinds(result.entries), ["chat"]);
     assert.equal(result.entries[0].detail, "3 replies");
     assert.equal(result.entries[0].title, "Replied in Invoice chase");
+  });
+
+  test("marks a durable chat turn as current work and carries its safe progress", async () => {
+    const conv = await conversation();
+    await assistantMessage(conv.id, {
+      status: "working",
+      progressPercent: 40,
+      progressLabel: "Researching the customer",
+    });
+
+    const result = await timeline();
+    const entry = result.entries[0];
+    assert.equal(entry.kind, "chat");
+    assert.equal(entry.active, true);
+    assert.equal(entry.endedAt, null);
+    assert.equal(entry.title, "Working on Invoice chase");
+    assert.equal(entry.detail, "Researching the customer · 40%");
+    assert.equal(
+      result.employeeSummaries.find((row) => row.employeeId === employee.id)?.current?.id,
+      entry.id,
+    );
+  });
+
+  test("does not disclose another Member's live conversation or progress", async () => {
+    const conv = await conversation({
+      ownerUserId: owner.id,
+      title: "Confidential acquisition",
+    });
+    await assistantMessage(conv.id, {
+      status: "working",
+      progressPercent: 70,
+      progressLabel: "Reading the confidential offer",
+    });
+
+    const asMember = await timeline();
+    assert.equal(asMember.entries[0].active, true);
+    assert.equal(asMember.entries[0].title, "Working on a private conversation");
+    assert.equal(asMember.entries[0].detail, "Working on a reply");
+    assert.ok(!JSON.stringify(asMember.employeeSummaries).includes("confidential"));
+
+    const asOwner = await timeline({ userId: owner.id, role: "owner" });
+    assert.equal(asOwner.entries[0].title, "Working on Confidential acquisition");
+    assert.equal(asOwner.entries[0].detail, "Reading the confidential offer · 70%");
+  });
+
+  test("marks a finished conversation as recent rather than live", async () => {
+    const conv = await conversation();
+    const finishedAt = ago(5 * 60 * 1000);
+    await assistantMessage(conv.id, {
+      status: "ok",
+      createdAt: ago(3 * HOUR),
+      updatedAt: finishedAt,
+    });
+    const entry = (await timeline()).entries[0];
+    assert.equal(entry.active, false);
+    assert.ok(entry.endedAt);
+    assert.equal(entry.at, finishedAt.toISOString());
   });
 
   test("says 'reply' in the singular for one turn", async () => {
@@ -325,11 +459,21 @@ describe("work timeline sources", () => {
     assert.equal((await timeline()).entries[0].detail, "1 reply · telegram");
   });
 
-  test("an approval the employee asked for is work", async () => {
+  test("an action that requires Approval appears as work waiting on the system gate", async () => {
     await approval();
     const result = await timeline();
     assert.deepEqual(kinds(result.entries), ["approval"]);
+    assert.equal(result.entries[0].title, "Approval required: Submit the form");
     assert.equal(result.entries[0].detail, "pending");
+  });
+
+  test("a decided Approval remains recent work but is no longer waiting", async () => {
+    await approval({ status: "approved", decidedAt: ago(30 * 60 * 1000) });
+    const result = await timeline();
+    const summary = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(summary.entryCount, 1);
+    assert.equal(summary.waiting, null);
+    assert.equal(summary.current, null);
   });
 
   test("a fired wakeup appears; a pending or cancelled one does not", async () => {
@@ -429,6 +573,11 @@ describe("work timeline sources", () => {
     const result = await timeline();
     assert.deepEqual(kinds(result.entries), ["work_session"]);
     assert.equal(result.entries[0].detail, "in progress");
+    assert.equal(result.entries[0].active, true);
+    assert.equal(
+      result.employeeSummaries.find((row) => row.employeeId === employee.id)?.current?.id,
+      result.entries[0].id,
+    );
   });
 });
 
@@ -508,7 +657,8 @@ describe("work timeline ordering and limits", () => {
   test("orders mixed kinds strictly newest first", async () => {
     await run({ startedAt: ago(3 * HOUR) });
     const conv = await conversation();
-    await assistantMessage(conv.id, { createdAt: ago(2 * HOUR) });
+    const chatAt = ago(2 * HOUR);
+    await assistantMessage(conv.id, { createdAt: chatAt, updatedAt: chatAt });
     await approval({ requestedAt: ago(HOUR) });
 
     const result = await timeline();
@@ -523,6 +673,60 @@ describe("work timeline ordering and limits", () => {
     assert.equal(result.entryCount, 5);
     const [newest, next] = result.entries;
     assert.ok(newest.at > next.at, `${newest.at} should be newer than ${next.at}`);
+  });
+
+  test("rolls up every employee before the visible timeline is sliced", async () => {
+    const quiet = await insert(AIEmployee, {
+      companyId: company.id,
+      name: "Mina",
+      slug: "mina",
+      role: "Research",
+      soulBody: "",
+    });
+    const otherRoutine = await insert(Routine, {
+      employeeId: other.id,
+      name: "Ledger close",
+      slug: "ledger-close",
+      cronExpr: "0 4 * * *",
+      body: "",
+    });
+    const activeRun = await insert(Run, {
+      routineId: otherRoutine.id,
+      status: "running",
+      logContent: "",
+      triggerKind: "schedule",
+      startedAt: ago(3 * HOUR),
+      exitCode: null,
+      finishedAt: null,
+    });
+    const pending = await approval({ requestedAt: ago(2 * HOUR) });
+    const latest = await run({ startedAt: ago(HOUR) });
+
+    const result = await timeline({ limit: 1 });
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.entries[0].id, `run:${latest.id}`);
+    assert.equal(result.employeeSummaries.length, 3);
+
+    const reyActivity = result.employeeSummaries.find((row) => row.employeeId === employee.id)!;
+    assert.equal(reyActivity.entryCount, 2);
+    assert.equal(reyActivity.latest?.id, `run:${latest.id}`);
+    assert.equal(reyActivity.waiting?.id, `approval:${pending.id}`);
+    assert.equal(reyActivity.current, null);
+
+    const kazActivity = result.employeeSummaries.find((row) => row.employeeId === other.id)!;
+    assert.equal(kazActivity.current?.id, `run:${activeRun.id}`);
+    assert.equal(kazActivity.current?.active, true);
+
+    assert.deepEqual(
+      result.employeeSummaries.find((row) => row.employeeId === quiet.id),
+      {
+        employeeId: quiet.id,
+        entryCount: 0,
+        latest: null,
+        current: null,
+        waiting: null,
+      },
+    );
   });
 
   test("narrows to one employee across every source", async () => {
@@ -550,6 +754,10 @@ describe("work timeline ordering and limits", () => {
     const mine = await timeline({ employeeId: employee.id });
     assert.deepEqual(kinds(mine.entries), ["run"]);
     assert.equal(mine.employeeId, employee.id);
+    assert.deepEqual(
+      mine.employeeSummaries.map((row) => row.employeeId),
+      [employee.id],
+    );
   });
 
   test("an employee id from another company narrows to nothing rather than 404ing", async () => {
@@ -646,7 +854,9 @@ describe("work timeline visibility", () => {
   test("hides vault ledger rows from a Member and shows them to an admin", async () => {
     await auditRow({ action: "vault.item.use", targetType: "vault_item", targetLabel: "AWS root" });
 
-    assert.equal((await timeline()).entryCount, 0);
+    const asMember = await timeline();
+    assert.equal(asMember.entryCount, 0);
+    assert.ok(asMember.employeeSummaries.every((row) => row.entryCount === 0));
     assert.equal((await timeline({ userId: owner.id, role: "owner" })).entryCount, 1);
   });
 

--- a/App/server/services/employeeWorkTimeline.ts
+++ b/App/server/services/employeeWorkTimeline.ts
@@ -145,6 +145,8 @@ export type WorkEntry = {
   at: string;
   /** When it ended, where the source records one. Null while still in flight. */
   endedAt: string | null;
+  /** Explicit source-backed live state. Never infer this from `endedAt` alone. */
+  active: boolean;
   employee: WorkEmployeeRef;
   /** One line naming the work. Server-written, or redacted on the way out. */
   title: string;
@@ -158,6 +160,23 @@ export type WorkEntry = {
   effectCount: number;
 };
 
+/**
+ * The small, pre-limit preview Home needs for one employee bubble.
+ *
+ * Returning this separately matters when one noisy employee fills the
+ * response's visible timeline slice: the rest of the roster must not be
+ * labelled quiet merely because their newest row was number 41.
+ */
+export type WorkEntryDigest = Pick<WorkEntry, "id" | "kind" | "at" | "title" | "detail" | "active">;
+
+export type WorkEmployeeSummary = {
+  employeeId: string;
+  entryCount: number;
+  latest: WorkEntryDigest | null;
+  current: WorkEntryDigest | null;
+  waiting: WorkEntryDigest | null;
+};
+
 export type WorkTimeline = {
   /** Start of the window, inclusive. */
   since: string;
@@ -168,6 +187,8 @@ export type WorkTimeline = {
   entries: WorkEntry[];
   /** Entries in the window before `limit` sliced them. */
   entryCount: number;
+  /** One truthful pre-limit rollup for every employee in this response. */
+  employeeSummaries: WorkEmployeeSummary[];
 };
 
 /** The product promise: what the roster did today. */
@@ -272,6 +293,7 @@ export async function getEmployeeWorkTimeline(params: {
     employeeId,
     entries: [],
     entryCount: 0,
+    employeeSummaries: [],
   };
 
   // An employee id from another company narrows to nothing rather than 404ing.
@@ -312,59 +334,140 @@ export async function getEmployeeWorkTimeline(params: {
   const sessionById = new Map(sessions.map((s) => [s.id, s]));
 
   const take = WORK_TIMELINE_SOURCE_CAP;
-  const [runs, auditRows, chatTurns, approvals, wakeups, lessons, sessionTurns] =
-    await Promise.all([
-      routines.length
-        ? AppDataSource.getRepository(Run).find({
-            where: { routineId: In([...routineById.keys()]), startedAt: MoreThanOrEqual(since) },
-            order: { startedAt: "DESC" },
-            take,
-          })
-        : Promise.resolve([] as Run[]),
-      AppDataSource.getRepository(AuditEvent).find({
-        where: { companyId, actorEmployeeId: In(empIds), createdAt: MoreThanOrEqual(since) },
-        order: { createdAt: "DESC", id: "DESC" },
-        take,
-      }),
-      conversations.length
-        ? AppDataSource.getRepository(ConversationMessage).find({
-            where: {
+  const [
+    runs,
+    activeRuns,
+    auditRows,
+    chatTurns,
+    activeChatTurns,
+    approvals,
+    pendingApprovals,
+    wakeups,
+    lessons,
+    sessionTurns,
+    activeSessionTurns,
+  ] = await Promise.all([
+    routines.length
+      ? AppDataSource.getRepository(Run).find({
+          where: { routineId: In([...routineById.keys()]), startedAt: MoreThanOrEqual(since) },
+          order: { startedAt: "DESC" },
+          take,
+        })
+      : Promise.resolve([] as Run[]),
+    routines.length
+      ? AppDataSource.getRepository(Run).find({
+          where: { routineId: In([...routineById.keys()]), status: "running" },
+          select: [
+            "id",
+            "routineId",
+            "startedAt",
+            "status",
+            "triggerKind",
+            "attempt",
+            "missedSlots",
+          ],
+          order: { startedAt: "DESC" },
+        })
+      : Promise.resolve([] as Run[]),
+    AppDataSource.getRepository(AuditEvent).find({
+      where: { companyId, actorEmployeeId: In(empIds), createdAt: MoreThanOrEqual(since) },
+      order: { createdAt: "DESC", id: "DESC" },
+      take,
+    }),
+    conversations.length
+      ? AppDataSource.getRepository(ConversationMessage).find({
+          where: [
+            {
               conversationId: In([...convById.keys()]),
               role: "assistant",
               createdAt: MoreThanOrEqual(since),
             },
-            order: { createdAt: "DESC" },
-            take,
-          })
-        : Promise.resolve([] as ConversationMessage[]),
-      AppDataSource.getRepository(Approval).find({
-        where: { companyId, employeeId: In(empIds), requestedAt: MoreThanOrEqual(since) },
-        order: { requestedAt: "DESC" },
-        take,
-      }),
-      AppDataSource.getRepository(EmployeeWakeup).find({
-        where: {
-          companyId,
-          employeeId: In(empIds),
-          status: "fired",
-          firedAt: MoreThanOrEqual(since),
-        },
-        order: { firedAt: "DESC" },
-        take,
-      }),
-      AppDataSource.getRepository(RunLesson).find({
-        where: { companyId, employeeId: In(empIds), createdAt: MoreThanOrEqual(since) },
-        order: { createdAt: "DESC" },
-        take,
-      }),
-      sessions.length
-        ? AppDataSource.getRepository(RepositoryWorkSessionTurn).find({
-            where: { companyId, sessionId: In([...sessionById.keys()]) },
-            order: { createdAt: "DESC" },
-            take,
-          })
-        : Promise.resolve([] as RepositoryWorkSessionTurn[]),
-    ]);
+            {
+              conversationId: In([...convById.keys()]),
+              role: "assistant",
+              updatedAt: MoreThanOrEqual(since),
+            },
+          ],
+          order: { updatedAt: "DESC", createdAt: "DESC" },
+          take,
+        })
+      : Promise.resolve([] as ConversationMessage[]),
+    conversations.length
+      ? AppDataSource.getRepository(ConversationMessage).find({
+          where: {
+            conversationId: In([...convById.keys()]),
+            role: "assistant",
+            status: "working",
+          },
+          select: [
+            "id",
+            "conversationId",
+            "status",
+            "updatedAt",
+            "progressPercent",
+            "progressLabel",
+          ],
+          order: { updatedAt: "DESC" },
+        })
+      : Promise.resolve([] as ConversationMessage[]),
+    AppDataSource.getRepository(Approval).find({
+      where: { companyId, employeeId: In(empIds), requestedAt: MoreThanOrEqual(since) },
+      order: { requestedAt: "DESC" },
+      take,
+    }),
+    AppDataSource.getRepository(Approval).find({
+      where: { companyId, employeeId: In(empIds), status: "pending" },
+      select: [
+        "id",
+        "employeeId",
+        "kind",
+        "title",
+        "payloadJson",
+        "status",
+        "requestedAt",
+        "decidedAt",
+      ],
+      order: { requestedAt: "DESC" },
+      // `payloadJson` is opaque, so a Member's Vault-capture filter runs in
+      // memory just as it does on Home's Approval queue. Past this generous
+      // safety ceiling an unusually deep backlog may be summarized
+      // incompletely; it never leaks.
+      take,
+    }),
+    AppDataSource.getRepository(EmployeeWakeup).find({
+      where: {
+        companyId,
+        employeeId: In(empIds),
+        status: "fired",
+        firedAt: MoreThanOrEqual(since),
+      },
+      order: { firedAt: "DESC" },
+      take,
+    }),
+    AppDataSource.getRepository(RunLesson).find({
+      where: { companyId, employeeId: In(empIds), createdAt: MoreThanOrEqual(since) },
+      order: { createdAt: "DESC" },
+      take,
+    }),
+    sessions.length
+      ? AppDataSource.getRepository(RepositoryWorkSessionTurn).find({
+          where: { companyId, sessionId: In([...sessionById.keys()]) },
+          order: { createdAt: "DESC" },
+          take,
+        })
+      : Promise.resolve([] as RepositoryWorkSessionTurn[]),
+    sessions.length
+      ? AppDataSource.getRepository(RepositoryWorkSessionTurn).find({
+          where: {
+            companyId,
+            sessionId: In([...sessionById.keys()]),
+            status: "running",
+          },
+          select: ["id", "sessionId", "status", "createdAt"],
+          order: { createdAt: "DESC" },
+        })
+      : Promise.resolve([] as RepositoryWorkSessionTurn[]),
+  ]);
 
   const canSeeVaultRows = isAdminRole(role);
 
@@ -408,6 +511,26 @@ export async function getEmployeeWorkTimeline(params: {
 
   const entries: WorkEntry[] = [];
 
+  const describeChatTurn = (msg: ConversationMessage, conv: Conversation) => {
+    // A transcript is private to the Member who requested it — that is what
+    // stops a lower-privilege Member replaying context produced under somebody
+    // else's authority. The work is still reported; its subject is not.
+    const owned = conv.ownerUserId === userId;
+    const subject = owned && conv.title ? safe(conv.title) : "a private conversation";
+    const working = msg.status === "working";
+    const progress =
+      working && owned && msg.progressLabel
+        ? `${safe(msg.progressLabel)}${msg.progressPercent !== null ? ` · ${msg.progressPercent}%` : ""}`
+        : null;
+    return {
+      at: iso(msg.updatedAt),
+      endedAt: working ? null : iso(msg.updatedAt),
+      active: working,
+      title: working ? `Working on ${subject}` : `Replied in ${subject}`,
+      detail: progress ?? (working ? "Working on a reply" : ""),
+    };
+  };
+
   // ── Runs ─────────────────────────────────────────────────────────────────
   // Effects land on the entry that owns them, so the run index is built first.
   const runEntryById = new Map<string, WorkEntry>();
@@ -421,6 +544,7 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "run",
       at: iso(run.startedAt),
       endedAt: run.finishedAt ? iso(run.finishedAt) : null,
+      active: run.status === "running",
       employee,
       title: runTitle(routine.name),
       detail: runDetail(run),
@@ -455,20 +579,17 @@ export async function getEmployeeWorkTimeline(params: {
     if (!conv) continue;
     const employee = empById.get(conv.employeeId);
     if (!employee) continue;
-    // A transcript is private to the Member who requested it — that is what
-    // stops a lower-privilege Member replaying context produced under somebody
-    // else's authority. The work is still reported; its subject is not.
-    const owned = conv.ownerUserId === userId;
-    const title = owned && conv.title ? safe(conv.title) : "a private conversation";
+    const presentation = describeChatTurn(msg, conv);
     const entry: WorkEntry = {
-      // Newest turn first, so this is the conversation's most recent activity.
+      // Newest turn first, so this is the conversation's most recent work.
       id: `chat:${conv.id}`,
       kind: "chat",
-      at: iso(msg.createdAt),
-      endedAt: null,
+      at: presentation.at,
+      endedAt: presentation.endedAt,
+      active: presentation.active,
       employee,
-      title: `Replied in ${title}`,
-      detail: "",
+      title: presentation.title,
+      detail: presentation.detail,
       run: null,
       effects: [],
       effectCount: 0,
@@ -479,10 +600,12 @@ export async function getEmployeeWorkTimeline(params: {
   for (const [conversationId, entry] of chatEntryByConversation) {
     const conv = convById.get(conversationId);
     const replies = plural(chatTurnCounts.get(conversationId) ?? 0, "reply", "replies");
-    entry.detail =
-      conv && conv.source !== "web" && conv.source !== "help"
-        ? `${replies} · ${conv.source}`
-        : replies;
+    if (!entry.active) {
+      entry.detail =
+        conv && conv.source !== "web" && conv.source !== "help"
+          ? `${replies} · ${conv.source}`
+          : replies;
+    }
   }
 
   // ── Repository work sessions ─────────────────────────────────────────────
@@ -499,6 +622,7 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "work_session",
       at: iso(at),
       endedAt: turn.finishedAt ? iso(turn.finishedAt) : null,
+      active: turn.status === "running",
       employee,
       title: `Worked in ${safe(session.title) || "a repository"}`,
       detail: workSessionDetail(turn),
@@ -521,8 +645,9 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "approval",
       at: iso(approval.requestedAt),
       endedAt: approval.decidedAt ? iso(approval.decidedAt) : null,
+      active: false,
       employee,
-      title: `Asked for approval: ${title || approval.kind.replaceAll("_", " ")}`,
+      title: `Approval required: ${title || approval.kind.replaceAll("_", " ")}`,
       detail: approval.status,
       run: null,
       effects: [],
@@ -540,6 +665,7 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "wakeup",
       at: iso(wakeup.firedAt),
       endedAt: null,
+      active: false,
       employee,
       title: "Woke itself up to follow something through",
       detail: safe(wakeup.outcomeNote) || safe(wakeup.brief),
@@ -558,6 +684,7 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "lesson",
       at: iso(lesson.createdAt),
       endedAt: null,
+      active: false,
       employee,
       title: `Took a lesson from a run: ${safe(lesson.cause) || "unnamed"}`,
       detail: safe(lesson.advice),
@@ -597,6 +724,7 @@ export async function getEmployeeWorkTimeline(params: {
       kind: "effect",
       at: effect.at,
       endedAt: null,
+      active: false,
       employee,
       title: effect.targetLabel || row.targetId || row.action,
       detail: row.action,
@@ -613,11 +741,116 @@ export async function getEmployeeWorkTimeline(params: {
     return a.id < b.id ? 1 : -1;
   });
 
+  const summaryByEmployee = new Map<string, WorkEmployeeSummary>(
+    employees.map((employee) => [
+      employee.id,
+      {
+        employeeId: employee.id,
+        entryCount: 0,
+        latest: null,
+        current: null,
+        waiting: null,
+      },
+    ]),
+  );
+  const digest = (entry: WorkEntry): WorkEntryDigest => ({
+    id: entry.id,
+    kind: entry.kind,
+    at: entry.at,
+    title: entry.title,
+    detail: entry.detail,
+    active: entry.active,
+  });
+  const isNewer = (candidate: WorkEntryDigest, current: WorkEntryDigest | null): boolean =>
+    !current ||
+    candidate.at > current.at ||
+    (candidate.at === current.at && candidate.id > current.id);
+  const rememberCurrent = (employeeId: string, candidate: WorkEntryDigest): void => {
+    const summary = summaryByEmployee.get(employeeId);
+    if (summary && isNewer(candidate, summary.current)) summary.current = candidate;
+  };
+  const rememberWaiting = (employeeId: string, candidate: WorkEntryDigest): void => {
+    const summary = summaryByEmployee.get(employeeId);
+    if (summary && isNewer(candidate, summary.waiting)) summary.waiting = candidate;
+  };
+  for (const entry of entries) {
+    const summary = summaryByEmployee.get(entry.employee.id);
+    if (!summary) continue;
+    summary.entryCount += 1;
+    summary.latest ??= digest(entry);
+    if (!summary.current && entry.active) {
+      summary.current = digest(entry);
+    }
+    if (
+      !summary.waiting &&
+      entry.kind === "approval" &&
+      entry.detail === "pending" &&
+      !entry.endedAt
+    ) {
+      summary.waiting = digest(entry);
+    }
+  }
+
+  // Current work and unresolved human gates outlive the 24-hour history
+  // window. They do not change `entryCount` or `latest` — those still describe
+  // the window — but they must keep the roster from calling someone quiet
+  // while they are visibly still working or waiting for a Member.
+  for (const run of activeRuns) {
+    const routine = routineById.get(run.routineId);
+    if (!routine) continue;
+    rememberCurrent(routine.employeeId, {
+      id: `run:${run.id}`,
+      kind: "run",
+      at: iso(run.startedAt),
+      title: runTitle(routine.name),
+      detail: runDetail(run),
+      active: true,
+    });
+  }
+  for (const msg of activeChatTurns) {
+    const conv = convById.get(msg.conversationId);
+    if (!conv) continue;
+    const presentation = describeChatTurn(msg, conv);
+    rememberCurrent(conv.employeeId, {
+      id: `chat:${conv.id}`,
+      kind: "chat",
+      at: presentation.at,
+      title: presentation.title,
+      detail: presentation.detail,
+      active: true,
+    });
+  }
+  for (const turn of activeSessionTurns) {
+    const session = sessionById.get(turn.sessionId);
+    if (!session) continue;
+    rememberCurrent(session.employeeId, {
+      id: `work_session:${turn.id}`,
+      kind: "work_session",
+      at: iso(turn.createdAt),
+      title: `Worked in ${safe(session.title) || "a repository"}`,
+      detail: workSessionDetail(turn),
+      active: true,
+    });
+  }
+  for (const approval of pendingApprovals) {
+    if (approval.decidedAt || (!canSeeVaultRows && isVaultCaptureApproval(approval))) continue;
+    const title = redactApprovalSummary(approval.title);
+    rememberWaiting(approval.employeeId, {
+      id: `approval:${approval.id}`,
+      kind: "approval",
+      at: iso(approval.requestedAt),
+      title: `Approval required: ${title || approval.kind.replaceAll("_", " ")}`,
+      detail: approval.status,
+      active: false,
+    });
+  }
+
   return {
     since: iso(since),
     until: iso(until),
     employeeId,
     entries: entries.slice(0, limit),
     entryCount: entries.length,
+    employeeSummaries: [...summaryByEmployee.values()],
   };
 }

--- a/Home/client/docs/pages/Employees.tsx
+++ b/Home/client/docs/pages/Employees.tsx
@@ -193,8 +193,7 @@ export function Employees() {
       <H3 id="org-chart">Org chart</H3>
       <P>
         Set <Code>reportsTo</Code> on an employee to give them a manager. Genosyn renders this as an
-        org chart and surfaces it to the runner — useful when you want a <Strong>Handoff</Strong>
-        {" "}
+        org chart and surfaces it to the runner — useful when you want a <Strong>Handoff</Strong>{" "}
         from one employee to another to follow the reporting line.
       </P>
 
@@ -263,8 +262,7 @@ export function Employees() {
         </LI>
         <LI>
           <Strong>Settings → Skills / Routines.</Strong> These are company-wide sections, not
-          per-employee ones: they live at AI → <DocLink to="/docs/skills">Skills</DocLink> and AI →
-          {" "}
+          per-employee ones: they live at AI → <DocLink to="/docs/skills">Skills</DocLink> and AI →{" "}
           <DocLink to="/docs/routines">Routines</DocLink>. The two entries under Settings open those
           lists filtered to this employee, and are marked with a corner arrow to say so.
         </LI>
@@ -311,11 +309,14 @@ export function Employees() {
 
       <H2 id="work-timeline">The work timeline</H2>
       <P>
-        Your <DocLink to="/docs">Home page</DocLink> ends with the{" "}
-        <Strong>work timeline</Strong> — everything your AI Employees actually did in the last 24
-        hours, newest first, grouped under <Strong>Today</Strong> and <Strong>Yesterday</Strong>.
-        Pick a name from the dropdown in its header to narrow it to one employee; the heading
-        follows your choice, so you always know whose day you are looking at.
+        Your <DocLink to="/docs">Home page</DocLink> ends with the <Strong>work timeline</Strong> —
+        everything your AI Employees actually did in the last 24 hours, newest first, grouped under{" "}
+        <Strong>Today</Strong> and <Strong>Yesterday</Strong>. Every employee appears as a bubble
+        across the top. The status under their name distinguishes
+        <Strong> Working now</Strong>, <Strong>Waiting for input</Strong>, recent work, and a quiet
+        day. Choose a bubble to see that employee&apos;s current or latest work, then use
+        <Strong> Check in</Strong> to open their Chat or <Strong>Employee details</Strong> to
+        inspect their Settings. Choose <Strong>Everyone</Strong> to return to the company-wide view.
       </P>
       <P>Seven kinds of work land on it:</P>
       <UL>
@@ -326,16 +327,18 @@ export function Employees() {
         </LI>
         <LI>
           <Strong>Conversations.</Strong> One line per thread, saying how many times the employee
-          replied. A thread you did not start is reported without its subject — transcripts stay
-          private to the Member who asked for them.
+          replied. A reply still in flight is shown as current work, including its latest progress
+          label and percentage for the Member who started it. A thread you did not start is reported
+          without its subject or progress — transcripts stay private to the Member who asked for
+          them.
         </LI>
         <LI>
           <Strong>Repository work</Strong>, with the files, insertions and deletions each turn
           produced — see <DocLink to="/docs/repositories">Repositories</DocLink>.
         </LI>
         <LI>
-          <Strong>Approvals they asked for</Strong>, so a blocked employee is visible as work in
-          progress rather than only as a queue entry.
+          <Strong>Approvals required by actions they attempted</Strong>, so an employee waiting at a
+          system gate is visible rather than only as a queue entry.
         </LI>
         <LI>
           <Strong>Wakeups</Strong> that fired and <Strong>Lessons</Strong> taken from a graded run —
@@ -349,20 +352,26 @@ export function Employees() {
         </LI>
       </UL>
       <P>
-        The panel hides itself on a day when nothing happened, the same way every other Home panel
-        does. Choose an employee who has been idle, though, and it stays put and says so — a panel
-        that vanished after you picked a name would read as a fault rather than as quiet.
+        The roster stays visible even when the whole team is quiet, because it is also the quickest
+        way to reach an employee and check in. The recent-work side says plainly when the selected
+        employee has no recorded work in the window. A busy employee cannot crowd another
+        employee&apos;s status out of the list: the bubbles use a per-employee summary calculated
+        before the 40-row display limit is applied. Work still running — and an unresolved Approval
+        still waiting — remains in that summary even when it began before the 24-hour history
+        window; the recent-work list itself stays bounded to the window.
       </P>
-      <Callout kind="info" title="The timeline is what the server recorded. The Journal is what the employee wrote.">
+      <Callout
+        kind="info"
+        title="The timeline is what the server recorded. The Journal is what the employee wrote."
+      >
         Journal entries are the employee&apos;s own account of its work, written through the
         built-in MCP server. The work timeline is assembled at read time from the rows the server
         itself wrote at each write seam — run records, the effect ledger behind{" "}
         <DocLink to="/docs/verification">Checks and verdicts</DocLink>, approval rows — so an
         employee cannot narrate its way onto it. When the two disagree, the timeline is the one to
-        trust. It is also not the{" "}
-        <DocLink to="/docs/plans-billing">audit log</DocLink>: that is an admin tool covering every
-        actor and all of history and is a paid feature, while seeing what your own workforce did
-        today is available on every plan, to every Member.
+        trust. It is also not the <DocLink to="/docs/plans-billing">audit log</DocLink>: that is an
+        admin tool covering every actor and all of history and is a paid feature, while seeing what
+        your own workforce did today is available on every plan, to every Member.
       </Callout>
     </>
   );

--- a/Home/client/docs/pages/Introduction.tsx
+++ b/Home/client/docs/pages/Introduction.tsx
@@ -129,8 +129,9 @@ export function Introduction() {
         and DMs, todos assigned to you, reviews and approvals waiting on your decision, the latest
         unread <DocLink to="/docs/tldrs">TLDR</DocLink>, the{" "}
         <DocLink to="/docs/employees#work-timeline">work timeline</DocLink> of everything your AI
-        Employees did in the last 24 hours, and shortcuts to every section. When something needs you
-        — or a fresh recap is ready — it&apos;s the first thing you see.
+        Employees did in the last 24 hours, with employee bubbles that show who is working now and
+        open a direct check-in, plus shortcuts to every section. When something needs you — or a
+        fresh recap is ready — it&apos;s the first thing you see.
       </P>
       <P>
         Home only shows you what it actually has. Every queue — the{" "}
@@ -142,10 +143,9 @@ export function Introduction() {
         and colleagues keep seeing it until they dismiss it themselves. So the page is only ever as
         long as your day is busy, and on a quiet one it says{" "}
         <Strong>Nothing needs you right now</Strong> and leaves it at that. The one panel that is
-        not a queue is the{" "}
-        <DocLink to="/docs/employees#work-timeline">work timeline</DocLink> — it sits below that
-        message rather than inside it, because a quiet day for you can still be a busy one for your
-        AI Employees.
+        not a queue is the <DocLink to="/docs/employees#work-timeline">work timeline</DocLink> — it
+        sits below that message rather than inside it, because a quiet day for you can still be a
+        busy one for your AI Employees.
       </P>
       <P>
         <Strong>Clicking a row on Home keeps you on Home.</Strong> An unread channel opens the


### PR DESCRIPTION
## Summary

- replace Home's dense employee dropdown with an always-visible bubble roster for Everyone and every AI Employee
- show source-backed working, waiting, recent, and quiet states; selecting a bubble reveals current/latest work plus direct Check in and Employee details actions
- make work rows readable with relative time, humanized Effects, Run verdicts, privacy-safe Chat progress, responsive layouts, and explicit loading/error states
- add pre-limit employee rollups and targeted live refreshes so noisy timelines, long-running work, and rolling 24-hour boundaries stay truthful without polling the full union

## Roadmap

Advances **M61 — The work timeline** by turning the Home timeline into a human-consumable workforce view while preserving the server-recorded timeline, bounded window, and Member visibility rules.

## Testing

- 142 focused client, route, service, privacy, durable Chat, and interruption tests pass
- `npm run lint`, `npm run typecheck`, and `npm run build` pass in `App/`
- `npm run lint`, `npm run typecheck`, and `npm run build` pass in `Home/`
- production bundle checked in Chrome at 1440px and 390px; no page overflow, the bubble strip scrolls, and Check in reaches the employee Chat

## Manual test steps

1. Open Home in a company with several AI Employees and work from the last 24 hours.
2. Confirm Everyone and every employee appear as bubbles with written working, waiting, recent, or quiet status.
3. Select employees in each state and verify the spotlight and recent-work list change to the selected employee.
4. Confirm Current work remains visible for an in-flight Run, Chat turn, or Repository work session, and a pending Approval reads as Waiting for input.
5. Use Check in and Employee details; confirm they open the selected employee's Chat and Settings.
6. Resize to a phone width; confirm the roster scrolls horizontally and the page itself does not overflow.
7. Verify another Member's private conversation subject and progress are not disclosed.

No dependencies or migrations were added.
