### PR TITLE
Make preparing a signature request survive a long contract

### DIFF
--- a/App/client/components/signatures/PdfCanvasRenderer.tsx
+++ b/App/client/components/signatures/PdfCanvasRenderer.tsx
@@ -32,6 +32,8 @@ export type PdfCanvasRendererProps = {
   fieldLabel?: (field: SignatureField) => string;
   fieldClassName?: (field: SignatureField, selected: boolean) => string;
   fieldStyle?: (field: SignatureField) => React.CSSProperties;
+  /** Reported once the PDF is parsed, so callers can offer page navigation. */
+  onPageCountChange?: (pageCount: number) => void;
   readOnly?: boolean;
   className?: string;
 };
@@ -52,11 +54,18 @@ export function PdfCanvasRenderer({
   fieldLabel,
   fieldClassName,
   fieldStyle,
+  onPageCountChange,
   readOnly = false,
   className = "",
 }: PdfCanvasRendererProps) {
   const [document, setDocument] = React.useState<PDFDocumentProxy | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const reportPageCount = React.useRef(onPageCountChange);
+  reportPageCount.current = onPageCountChange;
+
+  React.useEffect(() => {
+    if (document) reportPageCount.current?.(document.numPages);
+  }, [document]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -267,11 +276,15 @@ function PdfPage({
   }
 
   return (
-    <div className="mx-auto max-w-[850px]">
+    <div
+      className="mx-auto max-w-[850px] scroll-mt-[var(--signature-page-offset,0px)]"
+      data-signature-page={pageNumber}
+    >
       <div
         ref={wrapperRef}
         role={!readOnly && onPageClick ? "button" : undefined}
         tabIndex={!readOnly && onPageClick ? 0 : undefined}
+        data-signature-page-surface={!readOnly && onPageClick ? pageNumber : undefined}
         aria-label={
           !readOnly && onPageClick
             ? `Page ${pageNumber}. Press Enter or Space to place the selected field in the center.`

--- a/App/client/lib/signing.test.ts
+++ b/App/client/lib/signing.test.ts
@@ -1,0 +1,522 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  clampSignaturePage,
+  duplicateSignatureFieldGeometry,
+  signatureCompletionProgress,
+  signatureDraftReadiness,
+  signatureEditorShortcut,
+  signatureFieldPageSummary,
+  signatureFieldPagesToFill,
+  signatureReadinessTarget,
+  signatureRecipientEmailProblem,
+  signatureScrollAncestorIndex,
+  signatureShortcutTargetIsTextEntry,
+  visibleSignaturePage,
+  type SignatureDraftReadinessIssue,
+  type SignatureField,
+  type SignatureRecipient,
+} from "./signing";
+
+function field(over: Partial<SignatureField> = {}): SignatureField {
+  return {
+    id: "fld",
+    recipientId: "rcp",
+    type: "signature",
+    label: "Signature",
+    placeholder: "",
+    required: true,
+    pageNumber: 1,
+    x: 0.1,
+    y: 0.1,
+    width: 0.3,
+    height: 0.08,
+    sortOrder: 0,
+    ...over,
+  };
+}
+
+function recipient(over: Partial<SignatureRecipient> = {}): SignatureRecipient {
+  return {
+    id: "rcp",
+    role: "signer",
+    name: "Dana Whitfield",
+    email: "dana@northwind-logistics.test",
+    routingOrder: 0,
+    status: "waiting",
+    lastDeliveryStatus: "pending",
+    lastDeliveryError: "",
+    lastDeliveredAt: null,
+    reminderCount: 0,
+    ...over,
+  };
+}
+
+describe("duplicateSignatureFieldGeometry", () => {
+  test("offsets the copy down and right so it does not hide the original", () => {
+    const copy = duplicateSignatureFieldGeometry(field({ x: 0.1, y: 0.2 }));
+    assert.ok(copy.x > 0.1);
+    assert.ok(copy.y > 0.2);
+  });
+
+  test("keeps the copy's size", () => {
+    const copy = duplicateSignatureFieldGeometry(field({ width: 0.3, height: 0.08 }));
+    assert.equal(copy.width, 0.3);
+    assert.equal(copy.height, 0.08);
+  });
+
+  test("offsets back up and left at the bottom-right corner", () => {
+    const copy = duplicateSignatureFieldGeometry(
+      field({ x: 0.7, y: 0.92, width: 0.3, height: 0.08 }),
+    );
+    assert.ok(copy.x < 0.7, `x moved to ${copy.x}`);
+    assert.ok(copy.y < 0.92, `y moved to ${copy.y}`);
+  });
+
+  test("keeps the copy inside the page", () => {
+    const copy = duplicateSignatureFieldGeometry(
+      field({ x: 0.68, y: 0.9, width: 0.3, height: 0.08 }),
+    );
+    assert.ok(copy.x >= 0 && copy.x + copy.width <= 1);
+    assert.ok(copy.y >= 0 && copy.y + copy.height <= 1);
+  });
+
+  test("a field filling the page stays put rather than escaping it", () => {
+    const copy = duplicateSignatureFieldGeometry({ x: 0, y: 0, width: 1, height: 1 });
+    assert.ok(copy.x >= 0 && copy.x + copy.width <= 1);
+    assert.ok(copy.y >= 0 && copy.y + copy.height <= 1);
+  });
+
+  test("honours a custom offset", () => {
+    const copy = duplicateSignatureFieldGeometry(field({ x: 0.1, y: 0.1 }), 0.1);
+    assert.ok(Math.abs(copy.x - 0.2) < 1e-9, `x=${copy.x}`);
+    assert.ok(Math.abs(copy.y - 0.2) < 1e-9, `y=${copy.y}`);
+  });
+
+  test("treats a non-finite offset as the default", () => {
+    const copy = duplicateSignatureFieldGeometry(field({ x: 0.1, y: 0.1 }), Number.NaN);
+    assert.ok(copy.x > 0.1 && copy.x < 0.15);
+  });
+});
+
+describe("signatureFieldPagesToFill", () => {
+  const source = field({ recipientId: "dana", type: "signature", pageNumber: 1 });
+
+  test("returns every page the signer does not already have", () => {
+    assert.deepEqual(signatureFieldPagesToFill(source, [source], 4), [2, 3, 4]);
+  });
+
+  test("returns nothing when the signer already has one on each page", () => {
+    const existing = [1, 2, 3].map((pageNumber) =>
+      field({ recipientId: "dana", type: "signature", pageNumber }),
+    );
+    assert.deepEqual(signatureFieldPagesToFill(source, existing, 3), []);
+  });
+
+  test("ignores another signer's fields on the same page", () => {
+    const other = field({ recipientId: "marcus", type: "signature", pageNumber: 2 });
+    assert.deepEqual(signatureFieldPagesToFill(source, [source, other], 3), [2, 3]);
+  });
+
+  test("ignores the same signer's other field types", () => {
+    const date = field({ recipientId: "dana", type: "date", pageNumber: 2 });
+    assert.deepEqual(signatureFieldPagesToFill(source, [source, date], 3), [2, 3]);
+  });
+
+  test("a single-page document leaves nothing to fill", () => {
+    assert.deepEqual(signatureFieldPagesToFill(source, [source], 1), []);
+  });
+
+  test("an unknown page count fills nothing rather than guessing", () => {
+    assert.deepEqual(signatureFieldPagesToFill(source, [source], 0), []);
+    assert.deepEqual(signatureFieldPagesToFill(source, [source], -3), []);
+    assert.deepEqual(signatureFieldPagesToFill(source, [source], 2.5), []);
+  });
+});
+
+describe("signatureFieldPageSummary", () => {
+  test("counts the fields on every page, including the empty ones", () => {
+    const fields = [
+      field({ id: "a", pageNumber: 1 }),
+      field({ id: "b", pageNumber: 3 }),
+      field({ id: "c", pageNumber: 3 }),
+    ];
+    assert.deepEqual(signatureFieldPageSummary(fields, 3), [
+      { pageNumber: 1, fieldCount: 1 },
+      { pageNumber: 2, fieldCount: 0 },
+      { pageNumber: 3, fieldCount: 2 },
+    ]);
+  });
+
+  test("ignores fields pointing past the end of the document", () => {
+    const fields = [field({ pageNumber: 9 })];
+    assert.deepEqual(signatureFieldPageSummary(fields, 2), [
+      { pageNumber: 1, fieldCount: 0 },
+      { pageNumber: 2, fieldCount: 0 },
+    ]);
+  });
+
+  test("an unknown page count summarizes nothing", () => {
+    assert.deepEqual(signatureFieldPageSummary([field()], 0), []);
+  });
+});
+
+describe("clampSignaturePage", () => {
+  test("keeps a page inside the document", () => {
+    assert.equal(clampSignaturePage(1, 5), 1);
+    assert.equal(clampSignaturePage(5, 5), 5);
+    assert.equal(clampSignaturePage(0, 5), 1);
+    assert.equal(clampSignaturePage(9, 5), 5);
+  });
+
+  test("rounds a fractional page", () => {
+    assert.equal(clampSignaturePage(2.4, 5), 2);
+    assert.equal(clampSignaturePage(2.6, 5), 3);
+  });
+
+  test("falls back to the first page for junk input", () => {
+    assert.equal(clampSignaturePage(Number.NaN, 5), 1);
+    assert.equal(clampSignaturePage(3, 0), 1);
+  });
+});
+
+describe("visibleSignaturePage", () => {
+  const pages = [
+    { pageNumber: 1, top: 0, bottom: 900 },
+    { pageNumber: 2, top: 900, bottom: 1800 },
+    { pageNumber: 3, top: 1800, bottom: 2700 },
+  ];
+
+  test("picks the page filling most of the viewport", () => {
+    assert.equal(visibleSignaturePage(pages, { top: 850, bottom: 1750 }), 2);
+  });
+
+  test("a viewport wholly inside one page reports that page", () => {
+    assert.equal(visibleSignaturePage(pages, { top: 1900, bottom: 2200 }), 3);
+  });
+
+  test("an exact tie prefers the earlier page, so scrolling never reads backwards", () => {
+    assert.equal(visibleSignaturePage(pages, { top: 450, bottom: 1350 }), 1);
+  });
+
+  test("a viewport above the document reports the first page", () => {
+    assert.equal(visibleSignaturePage(pages, { top: -500, bottom: -100 }), 1);
+  });
+
+  test("no pages reports the first page rather than throwing", () => {
+    assert.equal(visibleSignaturePage([], { top: 0, bottom: 100 }), 1);
+  });
+});
+
+describe("signatureScrollAncestorIndex", () => {
+  test("skips a column that may scroll but does not", () => {
+    const index = signatureScrollAncestorIndex([
+      { overflowY: "auto", scrollHeight: 2857, clientHeight: 2857 },
+      { overflowY: "visible", scrollHeight: 2857, clientHeight: 2857 },
+      { overflowY: "auto", scrollHeight: 2981, clientHeight: 844 },
+    ]);
+    assert.equal(index, 2);
+  });
+
+  test("takes the nearest ancestor that really scrolls", () => {
+    const index = signatureScrollAncestorIndex([
+      { overflowY: "scroll", scrollHeight: 2000, clientHeight: 600 },
+      { overflowY: "auto", scrollHeight: 4000, clientHeight: 600 },
+    ]);
+    assert.equal(index, 0);
+  });
+
+  test("ignores a non-scrolling overflow value", () => {
+    const index = signatureScrollAncestorIndex([
+      { overflowY: "hidden", scrollHeight: 4000, clientHeight: 600 },
+    ]);
+    assert.equal(index, -1);
+  });
+
+  test("reports none when nothing scrolls", () => {
+    assert.equal(signatureScrollAncestorIndex([]), -1);
+  });
+});
+
+describe("signatureReadinessTarget", () => {
+  test("routes a title issue to the title field", () => {
+    assert.deepEqual(signatureReadinessTarget({ code: "title", message: "" }), { kind: "title" });
+  });
+
+  test("routes an expiry issue to the expiry field", () => {
+    assert.deepEqual(signatureReadinessTarget({ code: "expiry", message: "" }), { kind: "expiry" });
+  });
+
+  test("routes 'no signers' to the add-recipient control", () => {
+    assert.deepEqual(signatureReadinessTarget({ code: "signer", message: "" }), {
+      kind: "add-recipient",
+    });
+  });
+
+  test("routes a recipient issue to the exact input it is about", () => {
+    assert.deepEqual(
+      signatureReadinessTarget({
+        code: "recipient",
+        message: "",
+        recipientId: "r1",
+        input: "name",
+      }),
+      { kind: "recipient", recipientId: "r1", input: "name" },
+    );
+  });
+
+  test("routes a duplicate address to that recipient's email", () => {
+    assert.deepEqual(
+      signatureReadinessTarget({
+        code: "duplicate_email",
+        message: "",
+        recipientId: "r2",
+        input: "email",
+      }),
+      { kind: "recipient", recipientId: "r2", input: "email" },
+    );
+  });
+
+  test("routes a missing signature to the document, for that signer", () => {
+    assert.deepEqual(
+      signatureReadinessTarget({ code: "signature", message: "", recipientId: "r1" }),
+      { kind: "signature", recipientId: "r1" },
+    );
+  });
+
+  test("falls back to the email input when an older issue names no input", () => {
+    assert.deepEqual(
+      signatureReadinessTarget({ code: "recipient", message: "", recipientId: "r1" }),
+      { kind: "recipient", recipientId: "r1", input: "email" },
+    );
+  });
+
+  test("a recipient issue with no recipient still leads somewhere useful", () => {
+    assert.deepEqual(signatureReadinessTarget({ code: "recipient", message: "" }), {
+      kind: "add-recipient",
+    });
+  });
+});
+
+describe("signatureDraftReadiness", () => {
+  const envelope = { title: "Mutual NDA", expiresAt: null };
+
+  test("names the input behind a missing name", () => {
+    const issues = signatureDraftReadiness(
+      envelope,
+      [recipient({ name: "  " })],
+      [field({ recipientId: "rcp" })],
+    );
+    const issue = issues.find((candidate) => /needs a name/.test(candidate.message));
+    assert.equal(issue?.input, "name");
+    assert.equal(issue?.recipientId, "rcp");
+  });
+
+  test("names the input behind an invalid address", () => {
+    const issues = signatureDraftReadiness(
+      envelope,
+      [recipient({ email: "not-an-address" })],
+      [field({ recipientId: "rcp" })],
+    );
+    const issue = issues.find((candidate) => /valid email/.test(candidate.message));
+    assert.equal(issue?.input, "email");
+  });
+
+  test("names the input behind a duplicate address", () => {
+    const issues = signatureDraftReadiness(
+      envelope,
+      [
+        recipient({ id: "a", name: "Dana", email: "dana@northwind-logistics.test" }),
+        recipient({ id: "b", name: "Dana again", email: "DANA@northwind-logistics.test" }),
+      ],
+      [field({ recipientId: "a" }), field({ recipientId: "b" })],
+    );
+    const issue = issues.find((candidate) => candidate.code === "duplicate_email");
+    assert.equal(issue?.input, "email");
+    assert.equal(issue?.recipientId, "b");
+  });
+
+  test("a complete draft has nothing left to answer", () => {
+    assert.deepEqual(
+      signatureDraftReadiness(envelope, [recipient()], [field({ recipientId: "rcp" })]),
+      [],
+    );
+  });
+});
+
+describe("signatureRecipientEmailProblem", () => {
+  test("stays quiet on an untouched row", () => {
+    const row = recipient({ email: "" });
+    assert.equal(signatureRecipientEmailProblem(row, [row]), null);
+  });
+
+  test("stays quiet on whitespace alone", () => {
+    const row = recipient({ email: "   " });
+    assert.equal(signatureRecipientEmailProblem(row, [row]), null);
+  });
+
+  test("flags a malformed address", () => {
+    const row = recipient({ email: "dana@@northwind" });
+    assert.equal(
+      signatureRecipientEmailProblem(row, [row]),
+      "This does not look like an email address.",
+    );
+  });
+
+  test("accepts a valid address", () => {
+    const row = recipient();
+    assert.equal(signatureRecipientEmailProblem(row, [row]), null);
+  });
+
+  test("flags an address an earlier recipient already used", () => {
+    const first = recipient({ id: "a", name: "Dana Whitfield" });
+    const second = recipient({ id: "b", name: "Dana again" });
+    assert.equal(
+      signatureRecipientEmailProblem(second, [first, second]),
+      "Already used by Dana Whitfield.",
+    );
+  });
+
+  test("blames the later row, never the first one", () => {
+    const first = recipient({ id: "a" });
+    const second = recipient({ id: "b" });
+    assert.equal(signatureRecipientEmailProblem(first, [first, second]), null);
+  });
+
+  test("matches addresses that differ only by case or padding", () => {
+    const first = recipient({ id: "a", name: "Dana Whitfield" });
+    const second = recipient({ id: "b", email: "  DANA@Northwind-Logistics.test " });
+    assert.equal(
+      signatureRecipientEmailProblem(second, [first, second]),
+      "Already used by Dana Whitfield.",
+    );
+  });
+
+  test("names an unnamed duplicate without printing an empty name", () => {
+    const first = recipient({ id: "a", name: "   " });
+    const second = recipient({ id: "b" });
+    assert.equal(
+      signatureRecipientEmailProblem(second, [first, second]),
+      "Already used by another recipient.",
+    );
+  });
+});
+
+describe("signatureEditorShortcut", () => {
+  test("recognises duplicate on both platforms", () => {
+    assert.equal(signatureEditorShortcut({ key: "d", metaKey: true }), "duplicate");
+    assert.equal(signatureEditorShortcut({ key: "d", ctrlKey: true }), "duplicate");
+    assert.equal(signatureEditorShortcut({ key: "D", metaKey: true }), "duplicate");
+  });
+
+  test("recognises delete from either key", () => {
+    assert.equal(signatureEditorShortcut({ key: "Delete" }), "delete");
+    assert.equal(signatureEditorShortcut({ key: "Backspace" }), "delete");
+  });
+
+  test("leaves a bare letter alone so typing is never swallowed", () => {
+    assert.equal(signatureEditorShortcut({ key: "d" }), null);
+  });
+
+  test("leaves the browser's own modifier shortcuts alone", () => {
+    assert.equal(signatureEditorShortcut({ key: "Backspace", metaKey: true }), null);
+    assert.equal(signatureEditorShortcut({ key: "r", metaKey: true }), null);
+  });
+});
+
+describe("signatureShortcutTargetIsTextEntry", () => {
+  test("recognises the controls where Backspace means a character", () => {
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "INPUT" }), true);
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "TEXTAREA" }), true);
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "SELECT" }), true);
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "input" }), true);
+    assert.equal(
+      signatureShortcutTargetIsTextEntry({ tagName: "DIV", isContentEditable: true }),
+      true,
+    );
+  });
+
+  test("lets the shortcut through elsewhere", () => {
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "DIV" }), false);
+    assert.equal(signatureShortcutTargetIsTextEntry({ tagName: "BUTTON" }), false);
+    assert.equal(signatureShortcutTargetIsTextEntry(null), false);
+    assert.equal(signatureShortcutTargetIsTextEntry(undefined), false);
+    assert.equal(signatureShortcutTargetIsTextEntry({}), false);
+  });
+});
+
+describe("signatureCompletionProgress", () => {
+  test("counts only the required fields", () => {
+    const fields = [
+      field({ id: "a", required: true }),
+      field({ id: "b", required: false }),
+      field({ id: "c", required: true }),
+    ];
+    assert.deepEqual(signatureCompletionProgress(fields, { a: "signed" }), {
+      done: 1,
+      total: 2,
+      percent: 50,
+    });
+  });
+
+  test("an untouched request reads as zero", () => {
+    assert.deepEqual(signatureCompletionProgress([field({ id: "a" })], {}), {
+      done: 0,
+      total: 1,
+      percent: 0,
+    });
+  });
+
+  test("a finished request reads as complete", () => {
+    assert.deepEqual(signatureCompletionProgress([field({ id: "a" })], { a: "Dana" }), {
+      done: 1,
+      total: 1,
+      percent: 100,
+    });
+  });
+
+  test("nothing required reads as complete, not as an empty bar", () => {
+    assert.deepEqual(signatureCompletionProgress([field({ required: false })], {}), {
+      done: 0,
+      total: 0,
+      percent: 100,
+    });
+  });
+
+  test("a checkbox counts only when it is ticked", () => {
+    const checkbox = field({ id: "a", type: "checkbox" });
+    assert.equal(signatureCompletionProgress([checkbox], { a: false }).done, 0);
+    assert.equal(signatureCompletionProgress([checkbox], { a: true }).done, 1);
+  });
+
+  test("whitespace alone does not complete a field", () => {
+    assert.equal(signatureCompletionProgress([field({ id: "a" })], { a: "   " }).done, 0);
+  });
+
+  test("rounds the percentage for display", () => {
+    const fields = [1, 2, 3].map((n) => field({ id: `f${n}` }));
+    assert.equal(signatureCompletionProgress(fields, { f1: "x" }).percent, 33);
+  });
+});
+
+describe("readiness issues are addressable end to end", () => {
+  test("every issue a broken draft raises leads to a control", () => {
+    const issues: SignatureDraftReadinessIssue[] = signatureDraftReadiness(
+      { title: "", expiresAt: "2000-01-01T00:00:00.000Z" },
+      [
+        recipient({ id: "a", name: "", email: "nope" }),
+        recipient({ id: "b", name: "Marcus", email: "marcus@acmefixture.test" }),
+      ],
+      [],
+    );
+    assert.ok(issues.length >= 5, `expected several issues, got ${issues.length}`);
+    for (const issue of issues) {
+      const target = signatureReadinessTarget(issue);
+      assert.ok(
+        ["title", "expiry", "add-recipient", "recipient", "signature"].includes(target.kind),
+        `unroutable issue: ${JSON.stringify(issue)}`,
+      );
+    }
+  });
+});

--- a/App/client/lib/signing.ts
+++ b/App/client/lib/signing.ts
@@ -146,6 +146,8 @@ export type SignatureDraftReadinessIssue = {
   code: "title" | "signer" | "recipient" | "duplicate_email" | "signature" | "expiry";
   message: string;
   recipientId?: string;
+  /** Which recipient input the issue is about, so the checklist can focus it. */
+  input?: "name" | "email";
 };
 
 export type SignatureDraftSaveResult = {
@@ -426,6 +428,28 @@ export function firstIncompleteRequiredSignatureField(
   );
 }
 
+export type SignatureCompletionProgress = { done: number; total: number; percent: number };
+
+/**
+ * How far through the required fields a signer is. A request with no required
+ * fields reads as complete rather than as an empty bar, because there is
+ * genuinely nothing left for the signer to fill in.
+ */
+export function signatureCompletionProgress(
+  fields: SignatureField[],
+  values: Record<string, unknown>,
+): SignatureCompletionProgress {
+  const required = fields.filter((field) => field.required);
+  const done = required.filter((field) =>
+    signatureFieldValueIsComplete(field, values[field.id]),
+  ).length;
+  return {
+    done,
+    total: required.length,
+    percent: required.length ? Math.round((done / required.length) * 100) : 100,
+  };
+}
+
 export function recipientProgress(envelope: SignatureEnvelope): { done: number; total: number } {
   return {
     done: Number(envelope.completedRecipientCount ?? 0),
@@ -455,6 +479,7 @@ export function signatureDraftReadiness(
       issues.push({
         code: "recipient",
         recipientId: recipient.id,
+        input: "name",
         message: `${label} needs a name`,
       });
     }
@@ -463,12 +488,14 @@ export function signatureDraftReadiness(
       issues.push({
         code: "recipient",
         recipientId: recipient.id,
+        input: "email",
         message: `${label} needs a valid email`,
       });
     } else if (emails.has(email)) {
       issues.push({
         code: "duplicate_email",
         recipientId: recipient.id,
+        input: "email",
         message: `${label} has the same email as ${emails.get(email)}`,
       });
     } else {
@@ -616,6 +643,192 @@ export function defaultFieldSize(type: SignatureFieldType): { width: number; hei
   if (type === "date" || type === "initials") return { width: 0.18, height: 0.055 };
   if (type === "signature") return { width: 0.3, height: 0.08 };
   return { width: 0.28, height: 0.055 };
+}
+
+/**
+ * Offset a copied field so it lands beside its original instead of hiding it.
+ * The copy moves down and right, or back up and left when the page edge is in
+ * the way, so a field placed at the very bottom of a page still yields a
+ * visibly separate duplicate.
+ */
+export function duplicateSignatureFieldGeometry(
+  geometry: SignatureFieldGeometry,
+  offset = 0.02,
+): SignatureFieldGeometry {
+  const current = clampFieldGeometry(geometry);
+  const step = Math.abs(finiteNumber(offset, 0.02));
+  const shift = (position: number, size: number): number => {
+    if (position + size + step <= 1) return position + step;
+    if (position - step >= 0) return position - step;
+    return position;
+  };
+  return clampFieldGeometry({
+    ...current,
+    x: shift(current.x, current.width),
+    y: shift(current.y, current.height),
+  });
+}
+
+/**
+ * Pages that still need a copy of this field. A page counts as covered when it
+ * already carries a field of the same type for the same recipient, so asking
+ * for "initials on every page" twice does not stack two fields on each page.
+ */
+export function signatureFieldPagesToFill(
+  field: Pick<SignatureField, "recipientId" | "type">,
+  fields: Pick<SignatureField, "recipientId" | "type" | "pageNumber">[],
+  pageCount: number,
+): number[] {
+  if (!Number.isInteger(pageCount) || pageCount < 1) return [];
+  const covered = new Set(
+    fields
+      .filter(
+        (candidate) =>
+          candidate.recipientId === field.recipientId && candidate.type === field.type,
+      )
+      .map((candidate) => candidate.pageNumber),
+  );
+  const pages: number[] = [];
+  for (let page = 1; page <= pageCount; page += 1) {
+    if (!covered.has(page)) pages.push(page);
+  }
+  return pages;
+}
+
+export type SignaturePageSummary = { pageNumber: number; fieldCount: number };
+
+/** Per-page field counts backing the editor's page navigator. */
+export function signatureFieldPageSummary(
+  fields: Pick<SignatureField, "pageNumber">[],
+  pageCount: number,
+): SignaturePageSummary[] {
+  if (!Number.isInteger(pageCount) || pageCount < 1) return [];
+  return Array.from({ length: pageCount }, (_, index) => ({
+    pageNumber: index + 1,
+    fieldCount: fields.filter((field) => field.pageNumber === index + 1).length,
+  }));
+}
+
+export function clampSignaturePage(page: number, pageCount: number): number {
+  if (!Number.isInteger(pageCount) || pageCount < 1) return 1;
+  if (!Number.isFinite(page)) return 1;
+  return Math.min(pageCount, Math.max(1, Math.round(page)));
+}
+
+export type SignaturePageBox = { pageNumber: number; top: number; bottom: number };
+
+/**
+ * The page a reader is actually looking at: the one sharing the most height
+ * with the viewport. Ties go to the lower page number so scrolling through a
+ * long document never reads backwards.
+ */
+export function visibleSignaturePage(
+  pages: SignaturePageBox[],
+  viewport: { top: number; bottom: number },
+): number {
+  let best: { pageNumber: number; overlap: number } | null = null;
+  for (const page of pages) {
+    const overlap =
+      Math.min(page.bottom, viewport.bottom) - Math.max(page.top, viewport.top);
+    if (!best || overlap > best.overlap) best = { pageNumber: page.pageNumber, overlap };
+  }
+  return best?.pageNumber ?? 1;
+}
+
+/** Marks a rendered PDF page so a caller can measure it or scroll to it. */
+export const SIGNATURE_PAGE_SELECTOR = "[data-signature-page]";
+export type SignatureScrollCandidate = {
+  overflowY: string;
+  scrollHeight: number;
+  clientHeight: number;
+};
+
+/**
+ * Which ancestor actually scrolls the document column. The editor column
+ * carries `overflow-y: auto` but is sized by its content, so the real scroller
+ * is further up the tree; an element that merely *may* scroll is not one that
+ * does, and scrolling the wrong one silently does nothing.
+ */
+export function signatureScrollAncestorIndex(
+  candidates: SignatureScrollCandidate[],
+): number {
+  return candidates.findIndex(
+    (candidate) =>
+      /auto|scroll|overlay/.test(candidate.overflowY) &&
+      candidate.scrollHeight > candidate.clientHeight + 1,
+  );
+}
+
+export type SignatureReadinessTarget =
+  | { kind: "title" }
+  | { kind: "expiry" }
+  | { kind: "add-recipient" }
+  | { kind: "recipient"; recipientId: string; input: "name" | "email" }
+  | { kind: "signature"; recipientId: string };
+
+/** What a readiness item should put the Member in front of when they click it. */
+export function signatureReadinessTarget(
+  issue: SignatureDraftReadinessIssue,
+): SignatureReadinessTarget {
+  if (issue.code === "title") return { kind: "title" };
+  if (issue.code === "expiry") return { kind: "expiry" };
+  if (issue.code === "signer" || !issue.recipientId) return { kind: "add-recipient" };
+  if (issue.code === "signature") {
+    return { kind: "signature", recipientId: issue.recipientId };
+  }
+  return {
+    kind: "recipient",
+    recipientId: issue.recipientId,
+    input: issue.input ?? "email",
+  };
+}
+
+/**
+ * Inline, per-input recipient feedback. A blank row stays quiet — the send
+ * checklist already says a recipient is incomplete, and marking a row someone
+ * has not finished typing as wrong is noise, not help.
+ */
+export function signatureRecipientEmailProblem(
+  recipient: Pick<SignatureRecipient, "id" | "email">,
+  recipients: Pick<SignatureRecipient, "id" | "name" | "email">[],
+): string | null {
+  if (!recipient.email.trim()) return null;
+  const email = normalizeSignatureEmail(recipient.email);
+  if (!email) return "This does not look like an email address.";
+  for (const candidate of recipients) {
+    if (candidate.id === recipient.id) break;
+    if (normalizeSignatureEmail(candidate.email) === email) {
+      return `Already used by ${candidate.name.trim() || "another recipient"}.`;
+    }
+  }
+  return null;
+}
+
+export type SignatureEditorShortcut = "duplicate" | "delete";
+
+/** Keyboard shortcuts the field editor answers when a field is selected. */
+export function signatureEditorShortcut(event: {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}): SignatureEditorShortcut | null {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "d") return "duplicate";
+  if (event.metaKey || event.ctrlKey) return null;
+  if (event.key === "Delete" || event.key === "Backspace") return "delete";
+  return null;
+}
+
+/**
+ * Shortcuts must not fire while someone is typing a label or a recipient name,
+ * where Backspace means "delete a character".
+ */
+export function signatureShortcutTargetIsTextEntry(
+  target: { tagName?: string; isContentEditable?: boolean } | null | undefined,
+): boolean {
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  const tagName = (target.tagName ?? "").toUpperCase();
+  return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT";
 }
 
 /** Accept both the canonical detail DTO and a legacy flat envelope response. */

--- a/App/client/pages/PublicSigning.tsx
+++ b/App/client/pages/PublicSigning.tsx
@@ -28,6 +28,7 @@ import {
   formatSignatureDate,
   publicSignatureRecipientIsComplete,
   signatureCalendarDateForOffset,
+  signatureCompletionProgress,
   signatureFieldValueIsComplete,
   type PublicSigningEnvelope,
   type SignatureField,
@@ -467,8 +468,9 @@ export default function PublicSigning() {
     );
   }
 
-  const requiredCount = data.fields.filter((field) => field.required).length;
-  const requiredDone = data.fields.filter((field) => field.required && fieldComplete(field)).length;
+  const progress = signatureCompletionProgress(data.fields, values);
+  const requiredCount = progress.total;
+  const requiredDone = progress.done;
   const nextRequiredField = firstIncompleteRequiredSignatureField(data.fields, values);
   const editorDisabled = submitting || editorFrozen;
   const documentDescription = [
@@ -515,7 +517,7 @@ export default function PublicSigning() {
             <div
               role="status"
               aria-live="polite"
-              className="rounded-lg bg-slate-100 px-3 py-2 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+              className="rounded-lg bg-slate-100 px-3 py-2 text-xs font-medium text-slate-600 sm:min-w-56 dark:bg-slate-800 dark:text-slate-300"
             >
               {requiredCount
                 ? `${requiredDone} of ${requiredCount} required fields complete`
@@ -583,6 +585,42 @@ export default function PublicSigning() {
               <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">
                 Complete every required field highlighted on the document, then agree and finish.
               </p>
+
+              {requiredCount > 0 && (
+                <div className="mt-4">
+                  <div className="flex items-baseline justify-between text-xs font-medium text-slate-600 dark:text-slate-300">
+                    <span>
+                      {requiredDone} of {requiredCount} required
+                    </span>
+                    <span className="tabular-nums text-slate-400">{progress.percent}%</span>
+                  </div>
+                  <div
+                    className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
+                    role="progressbar"
+                    aria-valuemin={0}
+                    aria-valuemax={requiredCount}
+                    aria-valuenow={requiredDone}
+                    aria-label="Required fields complete"
+                  >
+                    <div
+                      className="h-full rounded-full bg-indigo-600 transition-[width] duration-300 dark:bg-indigo-400"
+                      style={{ width: `${progress.percent}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {nextRequiredField && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-4 w-full"
+                  disabled={editorDisabled}
+                  onClick={() => navigateToField(nextRequiredField)}
+                >
+                  <ArrowDown size={15} /> Go to next required field
+                </Button>
+              )}
 
               <div className="mt-5 space-y-2">
                 {data.fields.map((field) => (

--- a/App/client/pages/SignatureDetail.tsx
+++ b/App/client/pages/SignatureDetail.tsx
@@ -8,12 +8,15 @@ import {
   CheckSquare,
   CheckCircle2,
   ChevronLeft,
+  ChevronRight,
   CircleUser,
   Clock3,
   Copy,
+  CopyPlus,
   Download,
   FileSignature,
   GripVertical,
+  Layers,
   Mail,
   Save,
   Send,
@@ -38,9 +41,12 @@ import { api, type Customer, type Employee } from "@/lib/api";
 import { errorMessage } from "@/lib/errors";
 import {
   SIGNATURE_FIELD_LABELS,
+  SIGNATURE_PAGE_SELECTOR,
   SIGNATURE_STATUS_LABELS,
   clampFieldGeometry,
+  clampSignaturePage,
   defaultFieldSize,
+  duplicateSignatureFieldGeometry,
   envelopeFilename,
   formatSignatureDate,
   formatSignatureDateTime,
@@ -50,16 +56,25 @@ import {
   recipientStatusClasses,
   signatureAiHandoffPrompt,
   signatureDateInputToEndOfDayIso,
+  signatureEditorShortcut,
+  signatureFieldPageSummary,
+  signatureFieldPagesToFill,
   signatureRecipientColor,
   signatureRecipientColorKey,
+  signatureRecipientEmailProblem,
+  signatureReadinessTarget,
+  signatureScrollAncestorIndex,
+  signatureShortcutTargetIsTextEntry,
   signatureIsoToDateInput,
   signatureDraftReadiness,
   signatureSendReviewIsCurrent,
   signatureStatusClasses,
+  visibleSignaturePage,
   type SignatureEnvelopeDetail,
   type SignatureAccessLevel,
   type SignatureField,
   type SignatureFieldType,
+  type SignaturePageSummary,
   type SignatureRecipient,
   type SignatureDraftReadinessIssue,
   type SignatureDraftSaveResult,
@@ -122,6 +137,7 @@ export default function SignatureDetail() {
   const [selectedAiEmployeeId, setSelectedAiEmployeeId] = React.useState("");
   const [error, setError] = React.useState<string | null>(null);
   const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [pageCount, setPageCount] = React.useState(0);
   const [dirty, setDirty] = React.useState(false);
   const [sendDispatching, setSendDispatching] = React.useState(false);
   const [autosaveError, setAutosaveError] = React.useState<string | null>(null);
@@ -195,6 +211,7 @@ export default function SignatureDetail() {
     setFields([]);
     setSelectedRecipientId("");
     setSelectedFieldId(null);
+    setPageCount(0);
     expectedUpdatedAtRef.current = null;
     latestSavedDetailRef.current = null;
     dirtyRef.current = false;
@@ -213,6 +230,9 @@ export default function SignatureDetail() {
 
   const selectedField = fields.find((field) => field.id === selectedFieldId) ?? null;
   const isDraft = detail?.envelope.status === "draft";
+  // The parsed PDF is authoritative once it loads; the stored count keeps page
+  // navigation available while it is still being fetched.
+  const documentPageCount = pageCount || Number(detail?.envelope.originalPageCount ?? 0);
   const readinessIssues = React.useMemo(
     () => (detail ? signatureDraftReadiness(detail.envelope, recipients, fields) : []),
     [detail, fields, recipients],
@@ -315,6 +335,73 @@ export default function SignatureDetail() {
       setSelectedFieldId(id);
     });
   }
+
+  function removeField(id: string) {
+    mutateDraft(() => {
+      setFields((current) => current.filter((field) => field.id !== id));
+      setSelectedFieldId(null);
+    });
+  }
+
+  /** Place a copy beside the original, so a second signature block is one action. */
+  function duplicateField(id: string) {
+    if (sendDispatchingRef.current) return;
+    const source = fields.find((field) => field.id === id);
+    if (!source) return;
+    const copyId = `tmp_field_${crypto.randomUUID()}`;
+    mutateDraft(() => {
+      setFields((current) => [
+        ...current,
+        {
+          ...source,
+          id: copyId,
+          ...duplicateSignatureFieldGeometry(source),
+          sortOrder: current.length,
+        },
+      ]);
+      setSelectedFieldId(copyId);
+    });
+  }
+
+  /** "Initial every page" in one action, skipping pages the signer already has. */
+  function addFieldToEveryPage(id: string) {
+    if (sendDispatchingRef.current) return;
+    const source = fields.find((field) => field.id === id);
+    if (!source) return;
+    const pages = signatureFieldPagesToFill(source, fields, documentPageCount);
+    if (!pages.length) return;
+    mutateDraft(() => {
+      setFields((current) => [
+        ...current,
+        ...pages.map((pageNumber, index) => ({
+          ...source,
+          id: `tmp_field_${crypto.randomUUID()}`,
+          pageNumber,
+          sortOrder: current.length + index,
+        })),
+      ]);
+    });
+  }
+
+  const runFieldShortcutRef = React.useRef<(shortcut: "duplicate" | "delete") => void>(() => {});
+  runFieldShortcutRef.current = (shortcut) => {
+    if (!selectedFieldId) return;
+    if (shortcut === "duplicate") duplicateField(selectedFieldId);
+    else removeField(selectedFieldId);
+  };
+
+  React.useEffect(() => {
+    if (!isDraft || !selectedFieldId || sendDispatching) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (signatureShortcutTargetIsTextEntry(event.target as HTMLElement | null)) return;
+      const shortcut = signatureEditorShortcut(event);
+      if (!shortcut) return;
+      event.preventDefault();
+      runFieldShortcutRef.current(shortcut);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isDraft, selectedFieldId, sendDispatching]);
 
   function draftPayload() {
     if (!detail) return null;
@@ -823,8 +910,8 @@ export default function SignatureDetail() {
   const sourceUrl = `${base}/source`;
 
   return (
-    <div className="flex min-h-full flex-col">
-      <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 px-4 py-3 backdrop-blur sm:px-6 dark:border-slate-700 dark:bg-slate-950/95">
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="z-30 shrink-0 border-b border-slate-200 bg-white/95 px-4 py-3 backdrop-blur sm:px-6 dark:border-slate-700 dark:bg-slate-950/95">
         <div className="flex flex-wrap items-center gap-3">
           <button
             type="button"
@@ -834,7 +921,9 @@ export default function SignatureDetail() {
           >
             <ChevronLeft size={19} />
           </button>
-          <div className="min-w-0 flex-1">
+          {/* Full width on a phone so the title keeps its line and the
+              actions wrap beneath it instead of squeezing it to an ellipsis. */}
+          <div className="min-w-0 basis-[calc(100%-3rem)] sm:flex-1 sm:basis-auto">
             <div className="flex items-center gap-2">
               <h1 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
                 {envelope.title}
@@ -966,6 +1055,10 @@ export default function SignatureDetail() {
           error={error}
           readinessIssues={readinessIssues}
           editingLocked={sendDispatching}
+          pageCount={documentPageCount}
+          onPageCountChange={setPageCount}
+          onDuplicateField={duplicateField}
+          onAddFieldToEveryPage={addFieldToEveryPage}
           onEnvelopeChange={updateEnvelope}
           onRecipientChange={updateRecipient}
           onRecipientsChange={(next) => {
@@ -999,12 +1092,7 @@ export default function SignatureDetail() {
           onSelectField={setSelectedFieldId}
           onMoveField={(id, position) => updateField(id, position)}
           onFieldChange={updateField}
-          onRemoveField={(id) => {
-            mutateDraft(() => {
-              setFields((current) => current.filter((field) => field.id !== id));
-              setSelectedFieldId(null);
-            });
-          }}
+          onRemoveField={removeField}
         />
       ) : (
         <SentEnvelope
@@ -1032,7 +1120,7 @@ export default function SignatureDetail() {
       )}
 
       {isDraft && (
-        <div className="border-t border-slate-200 bg-white px-4 py-3 sm:px-6 dark:border-slate-700 dark:bg-slate-950">
+        <div className="shrink-0 border-t border-slate-200 bg-white px-4 py-3 sm:px-6 dark:border-slate-700 dark:bg-slate-950">
           <div className="flex flex-wrap justify-between gap-2">
             <Button
               variant="ghost"
@@ -1105,6 +1193,10 @@ type DraftEditorProps = {
   error: string | null;
   readinessIssues: SignatureDraftReadinessIssue[];
   editingLocked: boolean;
+  pageCount: number;
+  onPageCountChange: (pageCount: number) => void;
+  onDuplicateField: (id: string) => void;
+  onAddFieldToEveryPage: (id: string) => void;
   onEnvelopeChange: (patch: Partial<SignatureEnvelopeDetail["envelope"]>) => void;
   onRecipientChange: (id: string, patch: Partial<DraftRecipient>) => void;
   onRecipientsChange: (recipients: DraftRecipient[]) => void;
@@ -1121,8 +1213,164 @@ type DraftEditorProps = {
 function DraftEditor(props: DraftEditorProps) {
   const { envelope } = props.detail;
   const editorRootRef = React.useRef<HTMLDivElement>(null);
+  const documentRef = React.useRef<HTMLElement>(null);
+  const toolbarRef = React.useRef<HTMLDivElement>(null);
   const [mobilePanel, setMobilePanel] = React.useState<"people" | "document" | "field">("people");
+  const [visiblePage, setVisiblePage] = React.useState(1);
+  const [toolbarHeight, setToolbarHeight] = React.useState(0);
+  const controlPrefix = React.useId();
   const signers = props.recipients.filter((recipient) => recipient.role === "signer");
+  const pageSummary = signatureFieldPageSummary(props.fields, props.pageCount);
+  const everyPagePages = props.selectedField
+    ? signatureFieldPagesToFill(props.selectedField, props.fields, props.pageCount)
+    : [];
+
+  function controlId(suffix: string): string {
+    return `${controlPrefix}${suffix}`;
+  }
+  function recipientInputId(recipientId: string, input: "name" | "email"): string {
+    return controlId(`recipient-${recipientId}-${input}`);
+  }
+  function smoothScroll(): ScrollBehavior {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+  }
+
+  function documentScroller(): HTMLElement | null {
+    const ancestors: HTMLElement[] = [];
+    for (
+      let node: HTMLElement | null = documentRef.current;
+      node;
+      node = node.parentElement
+    ) {
+      ancestors.push(node);
+    }
+    const index = signatureScrollAncestorIndex(
+      ancestors.map((node) => ({
+        overflowY: window.getComputedStyle(node).overflowY,
+        scrollHeight: node.scrollHeight,
+        clientHeight: node.clientHeight,
+      })),
+    );
+    return index >= 0 ? ancestors[index] : null;
+  }
+
+  /** Visible document area: below the sticky toolbar, above the scroller's floor. */
+  function documentViewport(scroller: HTMLElement): { top: number; bottom: number } {
+    const box = scroller.getBoundingClientRect();
+    const toolbar = toolbarRef.current?.getBoundingClientRect();
+    return {
+      top: toolbar ? Math.max(box.top, toolbar.bottom) : box.top,
+      bottom: box.bottom,
+    };
+  }
+  function focusControl(id: string) {
+    window.requestAnimationFrame(() => {
+      const element = window.document.getElementById(id);
+      if (!(element instanceof HTMLElement)) return;
+      element.focus({ preventScroll: true });
+      element.scrollIntoView({ behavior: smoothScroll(), block: "center" });
+    });
+  }
+
+  // The field toolbar sticks over the document, so a page scrolled to the top
+  // of the scrollport must clear it. Its height changes as the toolbar wraps.
+  React.useLayoutEffect(() => {
+    const toolbar = toolbarRef.current;
+    if (!toolbar) return;
+    const measure = () => setToolbarHeight(toolbar.offsetHeight);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(toolbar);
+    return () => observer.disconnect();
+  }, []);
+
+  // Track the page under the reader so the navigator says where they are, not
+  // just how many pages exist.
+  React.useEffect(() => {
+    const scroller = documentScroller();
+    const column = documentRef.current;
+    if (!scroller || !column || props.pageCount < 1) return;
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
+      const pages = Array.from(
+        column.querySelectorAll<HTMLElement>(SIGNATURE_PAGE_SELECTOR),
+      ).map((element) => {
+        const box = element.getBoundingClientRect();
+        return {
+          pageNumber: Number(element.dataset.signaturePage ?? 1),
+          top: box.top,
+          bottom: box.bottom,
+        };
+      });
+      if (!pages.length) return;
+      setVisiblePage(visibleSignaturePage(pages, documentViewport(scroller)));
+    };
+    const onScroll = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(measure);
+    };
+    measure();
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener("scroll", onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+    // documentScroller and documentViewport are re-created every render and
+    // read only refs, so listing them here would rebind the listener on each
+    // keystroke. Re-resolve the scroller when the page count or the visible
+    // mobile panel changes, which is when it can actually differ.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.pageCount, mobilePanel]);
+
+  function goToPage(page: number) {
+    const target = clampSignaturePage(page, props.pageCount);
+    const element = documentRef.current?.querySelector<HTMLElement>(
+      `[data-signature-page="${target}"]`,
+    );
+    if (!element) return;
+    // scrollIntoView resolves the real scrollport itself, and the column's
+    // scroll-margin keeps the page clear of the sticky field toolbar.
+    element.scrollIntoView({ behavior: smoothScroll(), block: "start" });
+    setVisiblePage(target);
+  }
+
+  function showField(field: SignatureField) {
+    setMobilePanel("document");
+    props.onSelectField(field.id);
+    window.requestAnimationFrame(() => goToPage(field.pageNumber));
+  }
+
+  /** Park the caret on a page so Enter drops the selected field type onto it. */
+  function focusDocumentPage(page: number) {
+    goToPage(page);
+    window.requestAnimationFrame(() => {
+      documentRef.current
+        ?.querySelector<HTMLElement>(
+          `[data-signature-page-surface="${clampSignaturePage(page, props.pageCount)}"]`,
+        )
+        ?.focus({ preventScroll: true });
+    });
+  }
+
+  /** Put the Member in front of the control that answers the checklist item. */
+  function resolveReadinessIssue(issue: SignatureDraftReadinessIssue) {
+    const target = signatureReadinessTarget(issue);
+    if (target.kind === "signature") {
+      props.onSelectedRecipientChange(target.recipientId);
+      props.onFieldToolChange("signature");
+      setMobilePanel("document");
+      focusDocumentPage(visiblePage);
+      return;
+    }
+    setMobilePanel("people");
+    if (target.kind === "title") focusControl(controlId("title"));
+    else if (target.kind === "expiry") focusControl(controlId("expires"));
+    else if (target.kind === "add-recipient") focusControl(controlId("add-recipient"));
+    else focusControl(recipientInputId(target.recipientId, target.input));
+  }
+
   function colorForSigner(recipientId: string) {
     const recipient = props.recipients.find((candidate) => candidate.id === recipientId);
     return signatureRecipientColor(recipient ? colorKeyForRecipient(recipient) : recipientId);
@@ -1137,14 +1385,14 @@ function DraftEditor(props: DraftEditorProps) {
   return (
     <div
       ref={editorRootRef}
-      className={`flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden ${
+      className={`flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${
         props.editingLocked ? "pointer-events-none opacity-70" : ""
       }`}
       aria-busy={props.editingLocked}
       aria-disabled={props.editingLocked}
     >
       <div
-        className="grid grid-cols-3 border-b border-slate-200 bg-white p-2 xl:hidden dark:border-slate-700 dark:bg-slate-950"
+        className="grid shrink-0 grid-cols-3 border-b border-slate-200 bg-white p-2 xl:hidden dark:border-slate-700 dark:bg-slate-950"
         role="tablist"
         aria-label="Request editor"
       >
@@ -1171,9 +1419,9 @@ function DraftEditor(props: DraftEditorProps) {
           </button>
         ))}
       </div>
-      <div className="grid min-h-0 min-w-0 flex-1 xl:grid-cols-[15rem_minmax(24rem,1fr)_15rem]">
+      <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[minmax(0,1fr)] xl:grid-cols-[15rem_minmax(24rem,1fr)_15rem]">
         <aside
-          className={`${mobilePanel === "people" ? "block" : "hidden"} border-b border-slate-200 bg-white p-4 xl:block xl:border-b-0 xl:border-r dark:border-slate-700 dark:bg-slate-950`}
+          className={`${mobilePanel === "people" ? "block" : "hidden"} min-h-0 overflow-y-auto border-b border-slate-200 bg-white p-4 xl:block xl:border-b-0 xl:border-r dark:border-slate-700 dark:bg-slate-950`}
         >
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
             Recipients
@@ -1181,6 +1429,7 @@ function DraftEditor(props: DraftEditorProps) {
           <div className="mt-3 space-y-3">
             {props.recipients.map((recipient) => {
               const signerIndex = signers.findIndex((signer) => signer.id === recipient.id);
+              const emailProblem = signatureRecipientEmailProblem(recipient, props.recipients);
               return (
                 <div
                   key={recipient.id}
@@ -1247,6 +1496,7 @@ function DraftEditor(props: DraftEditorProps) {
                   </div>
                   <div className="space-y-2">
                     <Input
+                      id={recipientInputId(recipient.id, "name")}
                       value={recipient.name}
                       onFocus={() => {
                         if (recipient.role === "signer")
@@ -1259,20 +1509,37 @@ function DraftEditor(props: DraftEditorProps) {
                       aria-label="Recipient name"
                       className="h-9"
                     />
-                    <Input
-                      value={recipient.email}
-                      type="email"
-                      onFocus={() => {
-                        if (recipient.role === "signer")
-                          props.onSelectedRecipientChange(recipient.id);
-                      }}
-                      onChange={(event) =>
-                        props.onRecipientChange(recipient.id, { email: event.target.value })
-                      }
-                      placeholder="name@company.com"
-                      aria-label="Recipient email"
-                      className="h-9"
-                    />
+                    <div>
+                      <Input
+                        id={recipientInputId(recipient.id, "email")}
+                        value={recipient.email}
+                        type="email"
+                        invalid={Boolean(emailProblem)}
+                        aria-describedby={
+                          emailProblem
+                            ? `${recipientInputId(recipient.id, "email")}-problem`
+                            : undefined
+                        }
+                        onFocus={() => {
+                          if (recipient.role === "signer")
+                            props.onSelectedRecipientChange(recipient.id);
+                        }}
+                        onChange={(event) =>
+                          props.onRecipientChange(recipient.id, { email: event.target.value })
+                        }
+                        placeholder="name@company.com"
+                        aria-label="Recipient email"
+                        className="h-9"
+                      />
+                      {emailProblem && (
+                        <p
+                          id={`${recipientInputId(recipient.id, "email")}-problem`}
+                          className="mt-1 text-[11px] leading-4 text-rose-600 dark:text-rose-300"
+                        >
+                          {emailProblem}
+                        </p>
+                      )}
+                    </div>
                     <div className="flex gap-2">
                       <Select
                         value={recipient.role}
@@ -1315,15 +1582,15 @@ function DraftEditor(props: DraftEditorProps) {
               );
             })}
             <Button
+              id={controlId("add-recipient")}
               variant="secondary"
               size="sm"
               className="w-full"
-              onClick={() =>
-                props.onRecipientsChange([
-                  ...props.recipients,
-                  freshRecipient(props.recipients.length),
-                ])
-              }
+              onClick={() => {
+                const next = freshRecipient(props.recipients.length);
+                props.onRecipientsChange([...props.recipients, next]);
+                focusControl(recipientInputId(next.id, "name"));
+              }}
             >
               <UserPlus size={14} /> Add recipient
             </Button>
@@ -1335,6 +1602,7 @@ function DraftEditor(props: DraftEditorProps) {
             </h2>
             <div className="mt-3 space-y-3">
               <Input
+                id={controlId("title")}
                 label="Title"
                 value={envelope.title}
                 onChange={(event) => props.onEnvelopeChange({ title: event.target.value })}
@@ -1366,6 +1634,7 @@ function DraftEditor(props: DraftEditorProps) {
                 <option value="ordered">In a set order</option>
               </Select>
               <Input
+                id={controlId("expires")}
                 label="Expires"
                 type="date"
                 value={signatureIsoToDateInput(envelope.expiresAt)}
@@ -1388,9 +1657,16 @@ function DraftEditor(props: DraftEditorProps) {
         </aside>
 
         <main
-          className={`${mobilePanel === "document" ? "block" : "hidden"} min-h-[70vh] min-w-0 overflow-y-auto bg-slate-200/60 xl:block dark:bg-slate-900`}
+          ref={documentRef}
+          style={
+            { "--signature-page-offset": `${toolbarHeight + 12}px` } as React.CSSProperties
+          }
+          className={`${mobilePanel === "document" ? "block" : "hidden"} min-h-0 min-w-0 overflow-y-auto bg-slate-200/60 xl:block dark:bg-slate-900`}
         >
-          <div className="sticky top-0 z-20 flex flex-wrap items-center gap-2 border-b border-slate-200 bg-white/95 p-3 backdrop-blur dark:border-slate-700 dark:bg-slate-950/95">
+          <div
+            ref={toolbarRef}
+            className="sticky top-0 z-20 flex flex-wrap items-center gap-2 border-b border-slate-200 bg-white/95 p-3 backdrop-blur dark:border-slate-700 dark:bg-slate-950/95"
+          >
             <Select
               aria-label="Assign new fields to"
               value={props.selectedRecipientId}
@@ -1427,9 +1703,20 @@ function DraftEditor(props: DraftEditorProps) {
                 </button>
               ))}
             </div>
-            <span className="ml-auto text-xs text-slate-400">
-              Click to place · drag fields to move · drag the corner to resize
-            </span>
+            {props.fields.length === 0 && (
+              <span className="ml-auto text-xs text-slate-400">
+                Click to place · drag fields to move · drag the corner to resize
+              </span>
+            )}
+            {props.pageCount > 1 && (
+              <PageNavigator
+                pageCount={props.pageCount}
+                visiblePage={visiblePage}
+                summary={pageSummary}
+                inputId={controlId("page")}
+                onGoToPage={goToPage}
+              />
+            )}
             {signers.length > 0 && (
               <div className="flex w-full flex-wrap gap-x-3 gap-y-1 border-t border-slate-100 pt-2 text-[11px] text-slate-500 dark:border-slate-800 dark:text-slate-400">
                 {signers.map((recipient, index) => (
@@ -1451,6 +1738,7 @@ function DraftEditor(props: DraftEditorProps) {
             sourceUrl={props.sourceUrl}
             fields={props.fields}
             selectedFieldId={props.selectedField?.id}
+            onPageCountChange={props.onPageCountChange}
             onPageClick={props.onAddField}
             onFieldSelect={(id) => {
               props.onSelectField(id);
@@ -1475,18 +1763,22 @@ function DraftEditor(props: DraftEditorProps) {
         </main>
 
         <aside
-          className={`${mobilePanel === "field" ? "block" : "hidden"} border-t border-slate-200 bg-white p-4 xl:block xl:border-l xl:border-t-0 dark:border-slate-700 dark:bg-slate-950`}
+          className={`${mobilePanel === "field" ? "block" : "hidden"} min-h-0 overflow-y-auto border-t border-slate-200 bg-white p-4 xl:block xl:border-l xl:border-t-0 dark:border-slate-700 dark:bg-slate-950`}
         >
-          <SendReadiness issues={props.readinessIssues} />
+          <SendReadiness issues={props.readinessIssues} onResolve={resolveReadinessIssue} />
           <div className="mt-5 border-t border-slate-100 pt-5 dark:border-slate-800">
             <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
-              Field settings
+              {props.selectedField ? "Field settings" : "Placed fields"}
             </h2>
             {!props.selectedField ? (
-              <p className="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-400">
-                Select a field on the document to edit it. Drag the field to move it, or drag its
-                bottom-right handle to resize it.
-              </p>
+              <PlacedFields
+                fields={props.fields}
+                recipients={props.recipients}
+                signers={signers}
+                colorFor={colorForSigner}
+                colorStyleFor={colorStyleForSigner}
+                onShowField={showField}
+              />
             ) : (
               <div className="mt-4 space-y-4">
                 <div
@@ -1572,14 +1864,49 @@ function DraftEditor(props: DraftEditorProps) {
                     }
                   />
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full text-rose-600 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/30"
-                  onClick={() => props.onRemoveField(props.selectedField!.id)}
-                >
-                  <Trash2 size={14} /> Remove field
-                </Button>
+                <div className="space-y-2 border-t border-slate-100 pt-4 dark:border-slate-800">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => props.onDuplicateField(props.selectedField!.id)}
+                  >
+                    <CopyPlus size={14} /> Duplicate field
+                    <kbd className="ml-1 rounded border border-slate-200 px-1 text-[10px] font-normal text-slate-400 dark:border-slate-700">
+                      {shortcutModifier()}D
+                    </kbd>
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="w-full"
+                    disabled={everyPagePages.length === 0}
+                    title={
+                      everyPagePages.length === 0
+                        ? "Every page already has this field for this signer."
+                        : undefined
+                    }
+                    onClick={() => props.onAddFieldToEveryPage(props.selectedField!.id)}
+                  >
+                    <Layers size={14} />
+                    {everyPagePages.length === 0
+                      ? "On every page already"
+                      : `Add to ${everyPagePages.length} other ${
+                          everyPagePages.length === 1 ? "page" : "pages"
+                        }`}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full text-rose-600 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/30"
+                    onClick={() => props.onRemoveField(props.selectedField!.id)}
+                  >
+                    <Trash2 size={14} /> Remove field
+                    <kbd className="ml-1 rounded border border-rose-200 px-1 text-[10px] font-normal text-rose-400 dark:border-rose-900">
+                      Del
+                    </kbd>
+                  </Button>
+                </div>
               </div>
             )}
           </div>
@@ -1589,7 +1916,157 @@ function DraftEditor(props: DraftEditorProps) {
   );
 }
 
-function SendReadiness({ issues }: { issues: SignatureDraftReadinessIssue[] }) {
+/** ⌘ on Apple keyboards, Ctrl elsewhere, for the shortcut hints. */
+function shortcutModifier(): string {
+  if (typeof navigator === "undefined") return "Ctrl+";
+  return /mac|iphone|ipad/i.test(navigator.platform || navigator.userAgent) ? "⌘" : "Ctrl+";
+}
+
+function PageNavigator({
+  pageCount,
+  visiblePage,
+  summary,
+  inputId,
+  onGoToPage,
+}: {
+  pageCount: number;
+  visiblePage: number;
+  summary: SignaturePageSummary[];
+  inputId: string;
+  onGoToPage: (page: number) => void;
+}) {
+  const fieldsOnPage = summary.find((page) => page.pageNumber === visiblePage)?.fieldCount ?? 0;
+  return (
+    <div className="flex w-full items-center gap-2 border-t border-slate-100 pt-2 dark:border-slate-800">
+      <button
+        type="button"
+        aria-label="Previous page"
+        disabled={visiblePage <= 1}
+        onClick={() => onGoToPage(visiblePage - 1)}
+        className="rounded-md p-1 text-slate-500 hover:bg-slate-100 disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:bg-slate-800"
+      >
+        <ChevronLeft size={15} />
+      </button>
+      <label htmlFor={inputId} className="text-[11px] font-medium text-slate-500">
+        Page
+      </label>
+      <input
+        id={inputId}
+        type="number"
+        min={1}
+        max={pageCount}
+        value={visiblePage}
+        onChange={(event) => onGoToPage(Number(event.target.value))}
+        className="h-7 w-14 rounded-md border border-slate-200 bg-white px-2 text-center text-xs tabular-nums text-slate-800 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+      />
+      <span className="text-[11px] tabular-nums text-slate-400">of {pageCount}</span>
+      <button
+        type="button"
+        aria-label="Next page"
+        disabled={visiblePage >= pageCount}
+        onClick={() => onGoToPage(visiblePage + 1)}
+        className="rounded-md p-1 text-slate-500 hover:bg-slate-100 disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:bg-slate-800"
+      >
+        <ChevronRight size={15} />
+      </button>
+      <span className="text-[11px] text-slate-400" aria-live="polite">
+        {fieldsOnPage
+          ? `${fieldsOnPage} ${fieldsOnPage === 1 ? "field" : "fields"} on this page`
+          : "No fields on this page"}
+      </span>
+      <div className="ml-auto hidden items-center gap-1 sm:flex">
+        {summary
+          .filter((page) => page.fieldCount > 0)
+          .slice(0, 12)
+          .map((page) => (
+            <button
+              key={page.pageNumber}
+              type="button"
+              onClick={() => onGoToPage(page.pageNumber)}
+              title={`Page ${page.pageNumber} · ${page.fieldCount} ${
+                page.fieldCount === 1 ? "field" : "fields"
+              }`}
+              className={`h-6 min-w-6 rounded px-1.5 text-[11px] font-medium tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                page.pageNumber === visiblePage
+                  ? "bg-indigo-600 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
+              }`}
+            >
+              {page.pageNumber}
+            </button>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function PlacedFields({
+  fields,
+  recipients,
+  signers,
+  colorFor,
+  colorStyleFor,
+  onShowField,
+}: {
+  fields: SignatureField[];
+  recipients: DraftRecipient[];
+  signers: DraftRecipient[];
+  colorFor: (recipientId: string) => ReturnType<typeof signatureRecipientColor>;
+  colorStyleFor: (recipientId: string) => React.CSSProperties;
+  onShowField: (field: SignatureField) => void;
+}) {
+  if (fields.length === 0) {
+    return (
+      <p className="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-400">
+        Pick a signer and a field type above, then click the document to place a field. Drag it to
+        move it, or drag its bottom-right handle to resize it.
+      </p>
+    );
+  }
+  return (
+    <>
+      <p className="mt-3 text-xs leading-5 text-slate-500 dark:text-slate-400">
+        Select a field to edit it, or choose one here to jump to it on the document.
+      </p>
+      <div className="mt-3 space-y-1">
+        {fields.map((field) => {
+          const owner = recipients.find((recipient) => recipient.id === field.recipientId);
+          const signerIndex = signers.findIndex(
+            (recipient) => recipient.id === field.recipientId,
+          );
+          return (
+            <button
+              key={field.id}
+              type="button"
+              onClick={() => onShowField(field)}
+              style={colorStyleFor(field.recipientId)}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-slate-600 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-slate-300 dark:hover:bg-slate-900"
+            >
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: colorFor(field.recipientId).dotColor }}
+              />
+              <span className="min-w-0 flex-1 truncate">
+                {owner?.name || `Signer ${signerIndex + 1}`} ·{" "}
+                {field.label || SIGNATURE_FIELD_LABELS[field.type]}
+              </span>
+              <span className="shrink-0 tabular-nums text-slate-400">p. {field.pageNumber}</span>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function SendReadiness({
+  issues,
+  onResolve,
+}: {
+  issues: SignatureDraftReadinessIssue[];
+  onResolve: (issue: SignatureDraftReadinessIssue) => void;
+}) {
   return (
     <div id="signature-readiness" aria-live="polite">
       <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
@@ -1601,15 +2078,18 @@ function SendReadiness({ issues }: { issues: SignatureDraftReadinessIssue[] }) {
         Ready to send
       </div>
       {issues.length ? (
-        <div className="mt-3 space-y-2">
+        <div className="mt-3 space-y-1">
           {issues.map((issue, index) => (
-            <div
+            <button
+              type="button"
               key={`${issue.code}-${issue.recipientId ?? "request"}-${index}`}
-              className="flex gap-2 text-xs leading-5 text-slate-600 dark:text-slate-300"
+              onClick={() => onResolve(issue)}
+              className="flex w-full gap-2 rounded-lg px-2 py-1.5 text-left text-xs leading-5 text-slate-600 hover:bg-amber-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-slate-300 dark:hover:bg-amber-950/30"
             >
               <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
-              {issue.message}
-            </div>
+              <span className="min-w-0 flex-1">{issue.message}</span>
+              <ChevronRight size={13} className="mt-0.5 shrink-0 text-slate-300" />
+            </button>
           ))}
         </div>
       ) : (
@@ -1646,8 +2126,8 @@ function SentEnvelope({
     return recipientColorStyle(recipient ? colorKeyForRecipient(recipient) : recipientId);
   }
   return (
-    <div className="grid min-w-0 flex-1 overflow-x-hidden 2xl:grid-cols-[minmax(0,1fr)_22rem]">
-      <main className="min-h-[70vh] min-w-0 overflow-y-auto bg-slate-200/60 dark:bg-slate-900">
+    <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-x-hidden 2xl:grid-cols-[minmax(0,1fr)_22rem]">
+      <main className="min-h-0 min-w-0 overflow-y-auto bg-slate-200/60 dark:bg-slate-900">
         <PdfCanvasRenderer
           sourceUrl={sourceUrl}
           fields={detail.fields}
@@ -1660,7 +2140,7 @@ function SentEnvelope({
           fieldStyle={(field) => signerColorStyle(field.recipientId)}
         />
       </main>
-      <aside className="border-t border-slate-200 bg-white p-5 2xl:border-l 2xl:border-t-0 dark:border-slate-700 dark:bg-slate-950">
+      <aside className="min-h-0 overflow-y-auto border-t border-slate-200 bg-white p-5 2xl:border-l 2xl:border-t-0 dark:border-slate-700 dark:bg-slate-950">
         <div className="flex items-center justify-between">
           <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Recipients</h2>
           {detail.envelope.status === "completed" && (

--- a/Home/client/docs/pages/Signatures.tsx
+++ b/Home/client/docs/pages/Signatures.tsx
@@ -47,8 +47,26 @@ export function Signatures() {
           <Strong> Shift</Strong> for larger steps.
         </LI>
         <LI>
-          Review the request and click <Strong>Send</Strong>. Genosyn freezes the source,
-          recipients, fields, and routing so the agreement cannot change under a signer.
+          Repeat a field without placing it again. With a field selected,{" "}
+          <Strong>Duplicate field</Strong> (or <Strong>⌘D</Strong> / <Strong>Ctrl+D</Strong>) drops
+          a copy beside it, and <Strong>Add to N other pages</Strong> puts the same field on every
+          page that signer does not already have one on — the way to ask for initials throughout a
+          long contract. <Strong>Delete</Strong> or <Strong>Backspace</Strong> removes the selected
+          field. Neither shortcut fires while you are typing in a field.
+        </LI>
+        <LI>
+          Move around a long document with the page navigator above the PDF: step through pages,
+          type a page number, or click one of the numbered chips, which mark the pages that already
+          carry fields. The panel on the right lists every placed field with its page; choose one to
+          jump straight to it.
+        </LI>
+        <LI>
+          Review the request and click <Strong>Send</Strong>. <Strong>Ready to send</Strong> lists
+          anything still missing, and each item is a link to the control that fixes it — a
+          recipient&apos;s name or address, the title, the expiry date, or the document itself when
+          a signer has no signature field yet. A malformed or repeated address is also marked on the
+          recipient row as you type. Genosyn freezes the source, recipients, fields, and routing so
+          the agreement cannot change under a signer.
         </LI>
       </OL>
       <Callout kind="info" title="Configure the public URL and transactional email first">
@@ -73,6 +91,13 @@ export function Signatures() {
         submits. They can also decline and give a reason. Signers do not need a Genosyn account.
         Date-signed fields use the signer&apos;s local calendar date; Genosyn binds the reported
         timezone and offset into the tamper-evident completion evidence.
+      </P>
+      <P>
+        The signing panel stays beside the document and tracks how far along the signer is: a
+        progress bar counts the required fields, a checklist marks off each one with its page
+        number, and <Strong>Go to next required field</Strong> jumps to whatever is still
+        outstanding — so nothing on page 40 of a contract is missed. On a phone the same control
+        sits in a bar at the bottom of the screen.
       </P>
       <Callout kind="warn" title="Treat the link like a password">
         A signer&apos;s private link remains their read-only receipt after completion, including

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2331,6 +2331,17 @@ Employee workflow in one company-scoped system.
       multi-signer field ownership obvious with recipient-specific colors and
       names, support direct pointer, touch and keyboard field resizing, and send
       clear company-branded invitation, reminder and completion emails.
+- [x] **A preparation surface that survives a long contract.** The editor's
+      three panes each scroll on their own, so recipients, the field toolbar and
+      the send checklist stay put instead of scrolling away with page 40. A page
+      navigator reports and jumps to any page and marks the ones already
+      carrying fields; the right pane lists every placed field and jumps to it.
+      Repeat a field with Duplicate (⌘/Ctrl+D) or place it on every page a
+      signer is still missing, and remove one with Delete — never while typing.
+      Every send-checklist item is a link to the control that answers it, a
+      malformed or repeated recipient address is marked on the row as it is
+      typed, and the signer's own panel carries a progress bar plus a jump to
+      the next required field.
 
 ### M37 — AI-native Vault ✅
 


### PR DESCRIPTION
**M36 — AI-native document signing.** Polish only: no schema change, no new
endpoint, no change to what is sent, signed, or recorded as evidence.

## Why

The signing editor was built for a one-page NDA, and everything past that
fought the person using it. The root cause was the three-pane layout: the
panes never scrolled on their own, so the whole editor scrolled as one long
page. Scrolling to the signature block on page 3 took the recipients panel,
the field-type toolbar and the send checklist off the top of the window — the
tools you need in order to place a field were gone at exactly the moment you
wanted to place one.

On top of that, on a long agreement there was no way to reach page 87 except
to scroll to it, no way to find a field you had already placed, and no way to
put the same field on every page except to place it 200 times.

## What changed

**The editor holds still.** Each pane scrolls inside its own column, so
recipients, the toolbar and the checklist stay put while the document moves.

**Page navigation.** A navigator above the PDF: step, type a page number, or
click a numbered chip for the pages that already carry fields. The right pane
lists every placed field with its page and jumps to it.

**Repeating a field.** With a field selected, `Duplicate field` (⌘/Ctrl+D)
drops a copy beside it, and `Add to N other pages` fills every page that
signer is still missing — what "initial every page" actually means. `Delete`
removes the selected field. Neither shortcut fires while you are typing.

**The send checklist answers itself.** Every item is now a link to the control
that fixes it: the recipient's name or address, the title, the expiry, or the
document itself when a signer has no signature field yet. A malformed or
repeated address is also marked on the recipient row as it is typed, rather
than only in the far-right panel — which on a phone is a different tab.

**For the signer**, the panel beside the document gained a progress bar over
the required fields and a `Go to next required field` jump. The mobile bar has
had that jump since M36; on a desktop the only way to find the one unfilled
checkbox on page 40 was to hunt the checklist for it.

**On a phone**, the header no longer squeezes the title to `Mu…` — the actions
wrap beneath it.

## Screenshots

**The editor, nothing selected — page navigator and the placed-field list**

![Editor overview](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/01-editor-page-1.png)

**Jumped to a field on page 3 — panels stay put, field actions on the right**

![Field selected](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/02-field-selected-page-3.png)

**Add to every page, and the button once there is nothing left to fill**

![Add to every page](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/03-add-to-every-page.png)

**A bad address, marked on the row and linked from the checklist**

![Actionable checklist](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/05-checklist-actionable.png)

**The signer's panel: progress bar and the jump to the next required field**

![Signer start](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/07-signer-start.png)
![Signer progress](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/08-signer-progress.png)

**On a phone**

![Mobile people](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/10-mobile-people.png)
![Mobile document](https://raw.githubusercontent.com/Genosyn/genosyn/claude/signature-polish-screenshots/11-mobile-document.png)

## Tests

`App/client/lib/signing.test.ts` — 62 new unit tests over the extracted pure
helpers: duplicate geometry (including the bottom-right corner and a
page-filling field), which pages still need a copy, the page summary and clamp,
which page is visibly in the scrollport (including the tie), which ancestor
actually scrolls, readiness→control routing for every issue code, inline
address problems (case, padding, unnamed duplicate, quiet while empty),
shortcut and text-entry guards, and signer progress.

```bash
cd App && npx tsx --test client/lib/signing.test.ts
```

## Manual test steps

Driven in a real headless Chromium against a local install; every step
asserted, not just eyeballed. **34 checks, all passing.**

- **Editor (1600×1000, 20 checks):** page navigator reports `of 3`; clicking a
  placed field scrolls to its page and the navigator follows; both side panels
  stay on screen and the field toolbar stays pinned to the column top while the
  document is scrolled; the page itself does not scroll; Duplicate adds one
  field; `Delete` removes it; `⌘D` duplicates; `Add to 2 other pages` takes
  4 fields to 6 and the button then reads `On every page already`; a malformed
  address is flagged inline and marked `aria-invalid`; the checklist lists it
  and clicking it focuses that recipient's email input.
- **Signer (1440×950, 8 checks):** progress starts at 1/4 (the date field is
  prefilled) and advances to 2/4 then 4/4 as the checkbox, job title and
  signature are completed; `Go to next required field` focuses the first
  incomplete field and disappears once nothing is left.
- **Phone (390×844, 6 checks):** no horizontal overflow; the People panel fills
  the screen and scrolls; the header title keeps its own line; the Document
  panel scrolls inside the viewport with its toolbar visible; the checklist tab
  renders.
- **Sent request (3 checks):** created, configured and sent through the real
  endpoints; the recipients list and audit trail stay beside a scrolled
  document.

`npm run lint`, `npm run typecheck` clean in both `App/` and `Home/` (the 5
remaining lint warnings are pre-existing, in `vendorCredits.ts` and
`writeOffs.test.ts`).

## Notes

- Scrolling deliberately goes through `scrollIntoView` plus a `scroll-margin`
  rather than a computed `scrollTo`: the column carrying `overflow-y` is not
  the one that actually scrolls, and scrolling the wrong element fails
  silently. `signatureScrollAncestorIndex` encodes that rule and is tested.
- Screenshots are hosted on a separate `claude/signature-polish-screenshots`
  branch so no image bytes land in `main`; delete it once this is merged.
