### PR TITLE
Make the AI Employee actually join Google Meet calls

### DIFF
--- a/App/client/pages/MeetingDetail.tsx
+++ b/App/client/pages/MeetingDetail.tsx
@@ -204,11 +204,18 @@ export default function MeetingDetail() {
   const { meeting, participants, transcript } = data;
   const when = meeting.scheduledStartAt ?? meeting.startedAt ?? meeting.createdAt;
   const knownContacts = participants.filter((row) => row.contactId);
+  // `skipped` belongs here with `scheduled` and `failed`: the automatic pass
+  // declining a call at T-30s says nothing about whether a person, having read
+  // the reason and fixed it, may record the same call at T+5 while it is still
+  // running. The server makes the same allowance for an explicit human retry.
   const canStartNotetaker =
     meeting.conferenceProvider === "meet" &&
     Boolean(meeting.conferenceUrl) &&
     !meeting.hasRecording &&
-    (meeting.status === "scheduled" || meeting.status === "failed" || startingNotetaker);
+    (meeting.status === "scheduled" ||
+      meeting.status === "failed" ||
+      meeting.status === "skipped" ||
+      startingNotetaker);
   const canStopNotetaker = meeting.status === "joining" || meeting.status === "recording";
 
   return (
@@ -310,6 +317,18 @@ export default function MeetingDetail() {
       <FormSuccess message={notice} className="mb-4" />
       {meeting.statusMessage && meeting.status === "failed" && (
         <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {meeting.statusMessage}
+        </div>
+      )}
+      {/* A skip is a decision the notetaker made and wrote down, and until now
+          it wrote it down where nobody could read it: `statusMessage` was
+          rendered for `failed` alone. "The assigned AI Employee does not have
+          Record access to this calendar" is the difference between a fixable
+          setup mistake and a product that mysteriously never turns up. The
+          same goes for a deferral parked back on `scheduled`. */}
+      {meeting.statusMessage && (meeting.status === "skipped" || meeting.status === "scheduled") && (
+        <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          {meeting.status === "skipped" ? "The notetaker did not join. " : ""}
           {meeting.statusMessage}
         </div>
       )}

--- a/App/client/pages/MeetingsAgenda.tsx
+++ b/App/client/pages/MeetingsAgenda.tsx
@@ -7,9 +7,11 @@ import { useDialog } from "../components/ui/Dialog";
 import { FormError } from "../components/ui/FormError";
 import { Input } from "../components/ui/Input";
 import { Modal } from "../components/ui/Modal";
+import { Select } from "../components/ui/Select";
 import { Spinner } from "../components/ui/Spinner";
 import { useLiveRefetch } from "../components/CompanySocket";
 import { Panel, ProviderChip } from "../components/meetings/MeetingChips";
+import { api, type Employee } from "../lib/api";
 import { errorMessage } from "../lib/errors";
 import {
   formatClock,
@@ -295,6 +297,12 @@ export default function MeetingsAgenda() {
  * The path that makes this feature work on day one: a call already happened,
  * somebody has the recording or the transcript, and they want it written up
  * and on the customer's timeline.
+ *
+ * It is also the only way to point the notetaker at a call with no calendar
+ * behind it — which is why the Meet link is here. Without it this modal could
+ * only ever produce a meeting with nothing to join, so the meeting page hid
+ * its "Start notetaker" button and the ad-hoc half of the feature could not
+ * record anything at all.
  */
 function NewMeetingModal({
   open,
@@ -309,6 +317,9 @@ function NewMeetingModal({
 }) {
   const [title, setTitle] = React.useState("");
   const [attendees, setAttendees] = React.useState("");
+  const [conferenceUrl, setConferenceUrl] = React.useState("");
+  const [notetakerEmployeeId, setNotetakerEmployeeId] = React.useState("");
+  const [employees, setEmployees] = React.useState<Employee[]>([]);
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -316,9 +327,19 @@ function NewMeetingModal({
     if (open) {
       setTitle("");
       setAttendees("");
+      setConferenceUrl("");
+      setNotetakerEmployeeId("");
       setError(null);
     }
   }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    api
+      .get<Employee[]>(`/api/companies/${companyId}/employees`)
+      .then(setEmployees)
+      .catch(() => setEmployees([]));
+  }, [open, companyId]);
 
   const submit = async () => {
     if (!title.trim()) return;
@@ -327,6 +348,8 @@ function NewMeetingModal({
     try {
       await meetingsApi.createMeeting(companyId, {
         title: title.trim(),
+        conferenceUrl: conferenceUrl.trim(),
+        notetakerEmployeeId: notetakerEmployeeId || null,
         attendeeEmails: parseEmailList(attendees),
       });
       onCreated();
@@ -354,10 +377,35 @@ function NewMeetingModal({
           placeholder="sam@northwind.test, priya@acme.test"
           onChange={(e) => setAttendees(e.target.value)}
         />
+        <Input
+          label="Google Meet link (optional)"
+          value={conferenceUrl}
+          placeholder="https://meet.google.com/abc-defg-hij"
+          onChange={(e) => setConferenceUrl(e.target.value)}
+        />
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300">
+            Notetaker
+          </span>
+          <Select
+            value={notetakerEmployeeId}
+            onChange={(e) => setNotetakerEmployeeId(e.target.value)}
+          >
+            <option value="">Nobody</option>
+            {employees.map((employee) => (
+              <option key={employee.id} value={employee.id}>
+                {employee.name}
+              </option>
+            ))}
+          </Select>
+        </label>
         <p className="text-sm text-slate-500 dark:text-slate-400">
-          Create the meeting, then upload its recording or paste a transcript. Attendees who are
-          already Contacts get the call on their timeline, and the assigned AI Employee writes it up.
-          You can add attendees later too.
+          Paste a Meet link and the meeting page offers <strong>Start notetaker</strong>, which
+          sends the disclosed guest to join it. Leave it empty and you can still upload the
+          recording or paste a transcript afterwards. The notetaker is also the employee whose AI
+          Model transcribes the audio and writes the meeting up, so a recording with nobody
+          assigned stays a recording. Attendees who are already Contacts get the call on their
+          timeline. You can add attendees later too.
         </p>
         <FormError message={error} />
         <div className="flex justify-end gap-2">

--- a/App/client/pages/MeetingsAiAccess.tsx
+++ b/App/client/pages/MeetingsAiAccess.tsx
@@ -108,7 +108,12 @@ export default function MeetingsAiAccess() {
         <p className="mt-1 max-w-2xl text-sm text-slate-500 dark:text-slate-400">
           Choose which AI Employees may read which calendars. Without a Grant, an employee&apos;s
           meeting tools return nothing — they cannot see the agenda, the recordings, or the
-          transcripts.
+          transcripts. <strong>Record</strong> is the level the notetaker joins a call under;
+          naming an employee as a calendar&apos;s notetaker on{" "}
+          <Link className="underline" to={`${base}/calendars`}>
+            Calendars
+          </Link>{" "}
+          gives it that Grant here, and revoking it here stops the notetaker joining.
         </p>
       </div>
 

--- a/App/client/pages/MeetingsCalendars.tsx
+++ b/App/client/pages/MeetingsCalendars.tsx
@@ -249,7 +249,7 @@ export default function MeetingsCalendars() {
                 {row.autoRecord === "off"
                   ? "Nothing on this calendar is recorded automatically. You can still record any meeting by hand."
                   : row.notetakerEmployeeId
-                    ? "Eligible Google Meets are joined by the notetaker, and follow-ups land in the Revenue queue."
+                    ? "Eligible Google Meets are joined by the notetaker, and follow-ups land in the Revenue queue. Naming a notetaker gives it Record access to this calendar; review it under AI access."
                     : "Pick a notetaker — without one, nothing is recorded automatically."}
               </p>
             </section>

--- a/App/server/routes/meetings.ts
+++ b/App/server/routes/meetings.ts
@@ -268,16 +268,20 @@ meetingsRouter.patch(
   validateBody(patchCalendarBody),
   h(async (req, res) => {
     const body = req.body as z.infer<typeof patchCalendarBody>;
-    const account = await updateCalendarAccount(
-      cid(req),
-      (req.params as Record<string, string>).id,
-      {
+    let account;
+    try {
+      account = await updateCalendarAccount(cid(req), (req.params as Record<string, string>).id, {
         status: body.status,
         autoRecord: body.autoRecord as "off" | "external" | "all" | undefined,
         notetakerEmployeeId: body.notetakerEmployeeId,
         windowDays: body.windowDays,
-      },
-    );
+      });
+    } catch (err) {
+      res
+        .status(400)
+        .json({ error: err instanceof Error ? err.message : "Could not update calendar." });
+      return;
+    }
     if (!account) {
       res.status(404).json({ error: "Calendar not found." });
       return;

--- a/App/server/routes/meetingsRoleGate.test.ts
+++ b/App/server/routes/meetingsRoleGate.test.ts
@@ -279,6 +279,60 @@ describe("meetings routes — calendar configuration is admin-only", () => {
     assert.equal(allowed.body.calendar.notetakerEmployeeId, employee.id);
   });
 
+  test("assigning a notetaker over the API leaves a Record grant behind", async () => {
+    // The Grant is what `validateClaimedJoin` checks. Before this, the admin
+    // set a notetaker, the page said eligible Meets would be joined, and every
+    // call was skipped for want of an authority nothing in the flow created.
+    const account = await aCalendar();
+    const employee = await anEmployee();
+
+    actingUserId = adminId;
+    const patched = await call("PATCH", `/meetings/calendars/${account.id}`, {
+      autoRecord: "external",
+      notetakerEmployeeId: employee.id,
+    });
+    assert.equal(patched.status, 200);
+
+    const grants = await call<{ grants: Array<{ employeeId: string; accessLevel: string }> }>(
+      "GET",
+      "/meetings/ai-access",
+    );
+    assert.equal(grants.status, 200);
+    assert.deepEqual(
+      grants.body.grants.map((row) => [row.employeeId, row.accessLevel]),
+      [[employee.id, "record"]],
+    );
+  });
+
+  test("a notetaker from another company is a 400, not a silent skip an hour later", async () => {
+    const account = await aCalendar();
+    const otherCompany = await insert(Company, {
+      name: "Someone else",
+      slug: `other-${randomUUID()}`,
+      ownerId: ownerId,
+    });
+    const stranger = await insert(AIEmployee, {
+      companyId: otherCompany.id,
+      name: "Rook",
+      slug: `rook-${randomUUID()}`,
+      role: "Analyst",
+    });
+
+    actingUserId = ownerId;
+    const rejected = await call<{ error: string }>("PATCH", `/meetings/calendars/${account.id}`, {
+      notetakerEmployeeId: stranger.id,
+    });
+
+    assert.equal(rejected.status, 400);
+    assert.match(rejected.body.error, /not in this company/);
+    assert.equal(await grantCount(), 0);
+    assert.equal(
+      (await AppDataSource.getRepository(CalendarAccount).findOneByOrFail({ id: account.id }))
+        .notetakerEmployeeId,
+      null,
+    );
+  });
+
   test("a plain member cannot disconnect a calendar", async () => {
     const account = await aCalendar();
 

--- a/App/server/services/meetings/accounts.ts
+++ b/App/server/services/meetings/accounts.ts
@@ -1,9 +1,13 @@
 import { In } from "typeorm";
 
+import { AIEmployee } from "../../db/entities/AIEmployee.js";
 import { AppDataSource } from "../../db/datasource.js";
 import { CalendarAccount } from "../../db/entities/CalendarAccount.js";
 import { CalendarEvent } from "../../db/entities/CalendarEvent.js";
-import { EmployeeCalendarGrant } from "../../db/entities/EmployeeCalendarGrant.js";
+import {
+  CALENDAR_ACCESS_RANK,
+  EmployeeCalendarGrant,
+} from "../../db/entities/EmployeeCalendarGrant.js";
 import { Meeting } from "../../db/entities/Meeting.js";
 import { MeetingParticipant } from "../../db/entities/MeetingParticipant.js";
 import { MeetingTranscriptSegment } from "../../db/entities/MeetingTranscriptSegment.js";
@@ -202,13 +206,78 @@ export async function updateCalendarAccount(
     if (patch.status !== "error") row.statusMessage = "";
   }
   if (patch.autoRecord !== undefined) row.autoRecord = patch.autoRecord;
-  if (patch.notetakerEmployeeId !== undefined) row.notetakerEmployeeId = patch.notetakerEmployeeId;
+  if (patch.notetakerEmployeeId !== undefined) {
+    // An id that belongs to another company — or to a deleted employee — would
+    // otherwise be written happily and then fail at due time, an hour later,
+    // as an unexplained skip. Refuse it here, where the person who typed it is
+    // still looking at the screen.
+    if (patch.notetakerEmployeeId) {
+      const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({
+        id: patch.notetakerEmployeeId,
+        companyId,
+      });
+      if (!employee) throw new Error("That AI Employee is not in this company.");
+    }
+    row.notetakerEmployeeId = patch.notetakerEmployeeId;
+  }
   if (patch.windowDays !== undefined) {
     // Clamped rather than validated away: a calendar mirror is a cache, and a
     // window somebody typed 100000 into is a slow full re-list every pass.
     row.windowDays = Math.max(1, Math.min(365, Math.trunc(patch.windowDays)));
   }
-  return repo.save(row);
+  const saved = await repo.save(row);
+  if (patch.notetakerEmployeeId) {
+    await ensureNotetakerCanRecord(companyId, saved.id, patch.notetakerEmployeeId);
+  }
+  return saved;
+}
+
+/**
+ * Naming an employee as a calendar's notetaker **is** granting it Record.
+ *
+ * These used to be two separate acts: a dropdown on Meetings → Calendars that
+ * wrote one column, and a Grant on Meetings → AI access that the join path
+ * actually checks. Nothing connected them, so the ordinary setup flow produced
+ * a calendar that said "eligible Google Meets are joined by the notetaker"
+ * while `validateClaimedJoin` refused every single call for want of a Grant
+ * nobody had been told to create — and refused it as a `skipped` row whose
+ * reason the UI never rendered. The notetaker simply never turned up, with no
+ * error anywhere a human would look.
+ *
+ * Deriving the Grant from the assignment closes that gap without weakening the
+ * authority model: both controls are gated on the same owner/admin role, both
+ * are per calendar, and the resulting Grant is listed — and revocable — on the
+ * AI access page exactly as a hand-made one is.
+ *
+ * Only ever an upgrade. An employee that already holds `record` is left alone,
+ * and un-assigning a notetaker revokes nothing: the Grant may have been made
+ * by hand for the meeting tools, and silently withdrawing authority a human
+ * granted elsewhere is its own bug.
+ */
+export async function ensureNotetakerCanRecord(
+  companyId: string,
+  accountId: string,
+  employeeId: string,
+): Promise<EmployeeCalendarGrant | null> {
+  const employee = await AppDataSource.getRepository(AIEmployee).findOneBy({
+    id: employeeId,
+    companyId,
+  });
+  if (!employee) return null;
+  const account = await AppDataSource.getRepository(CalendarAccount).findOneBy({
+    id: accountId,
+    companyId,
+  });
+  if (!account) return null;
+
+  const repo = AppDataSource.getRepository(EmployeeCalendarGrant);
+  const existing = await repo.findOneBy({ employeeId, accountId });
+  if (existing) {
+    if (CALENDAR_ACCESS_RANK[existing.accessLevel] >= CALENDAR_ACCESS_RANK.record) return existing;
+    existing.accessLevel = "record";
+    return repo.save(existing);
+  }
+  return repo.save(repo.create({ employeeId, accountId, accessLevel: "record" }));
 }
 
 /**

--- a/App/server/services/meetings/googleMeetRecorder.test.ts
+++ b/App/server/services/meetings/googleMeetRecorder.test.ts
@@ -6,6 +6,7 @@ import { describe, test } from "node:test";
 import type { Locator, Page } from "playwright-core";
 
 import {
+  admissionCutoff,
   createGoogleMeetRecorder,
   disclosedNotetakerName,
   isGoogleMeetConferenceUrl,
@@ -63,6 +64,10 @@ type RecorderHarnessOptions = {
   ffmpeg?: FakeFfmpeg;
   failUnload?: boolean;
   maxRecordingBytes?: number;
+  /** Read per join, so a test can prove the cap is not frozen at construction. */
+  readMaxRecordingBytes?: () => number;
+  /** Refuse `module-null-source`, the way a PulseAudio build without it would. */
+  noSilentSource?: boolean;
 };
 
 function recorderHarness(options: RecorderHarnessOptions = {}) {
@@ -111,6 +116,9 @@ function recorderHarness(options: RecorderHarnessOptions = {}) {
       if (options.failUnload && args[0] === "unload-module") {
         throw new Error("PulseAudio refused to unload module");
       }
+      if (options.noSilentSource && args[1] === "module-null-source") {
+        throw new Error("Module initialization failed");
+      }
       return args[0] === "load-module"
         ? { stdout: "41\n", stderr: "" }
         : { stdout: "", stderr: "" };
@@ -128,7 +136,8 @@ function recorderHarness(options: RecorderHarnessOptions = {}) {
     },
     now: () => now,
     randomToken: () => "fixed123",
-    maxRecordingBytes: options.maxRecordingBytes ?? 1024 * 1024,
+    maxRecordingBytes: () =>
+      options.readMaxRecordingBytes?.() ?? options.maxRecordingBytes ?? 1024 * 1024,
     warn: (message) => warnings.push(message),
   });
 
@@ -170,6 +179,14 @@ describe("Google Meet URL and disclosure boundary", () => {
     );
     assert.equal(isGoogleMeetConferenceUrl("https://meet.google.com/landing"), false);
     assert.equal(isGoogleMeetConferenceUrl("not a url"), false);
+    // A Workspace "nicknamed" meeting. `conferenceForEvent` has always labelled
+    // these `meet`, so the calendar armed them and then the driver refused the
+    // very link the policy had accepted — a whole class of invite that could
+    // never be joined and never said why.
+    assert.equal(isGoogleMeetConferenceUrl("https://meet.google.com/lookup/northwind-standup"), true);
+    assert.equal(isGoogleMeetConferenceUrl("https://meet.google.com/lookup/"), false);
+    assert.equal(isGoogleMeetConferenceUrl("https://meet.google.com/lookup/a/b"), false);
+    assert.equal(isGoogleMeetConferenceUrl("https://meet.google.com/_meet/settings"), false);
   });
 
   test("makes the recording role visible and bounds Meet's guest name", () => {
@@ -275,6 +292,235 @@ describe("Google Meet guest lobby", () => {
   });
 });
 
+/**
+ * A Meet lobby that can be described rather than mocked call by call.
+ *
+ * `visible` is the set of controls currently on screen, keyed by the logical
+ * name the driver's accessible-name pattern picks out; `body` is the page
+ * text the driver scans for Meet's own status sentences. `onClick` lets a test
+ * move the lobby on — admit the guest, close a dialog, refuse a request —
+ * which is what makes the multi-pass behaviour testable at all.
+ */
+function fakeLobby(options: {
+  visible: string[];
+  body?: string;
+  onClick?: (name: string, state: { visible: Set<string>; body: string }) => void;
+  /** Runs once per pass of the lobby loop, which reads the body every time. */
+  onPass?: (pass: number, state: { visible: Set<string>; body: string }) => void;
+  failClicks?: Set<string>;
+}) {
+  const state = { visible: new Set(options.visible), body: options.body ?? "" };
+  const clicks: string[] = [];
+  const fills: string[] = [];
+  const failed: string[] = [];
+  let pass = 0;
+
+  const control = (name: string) =>
+    ({
+      first() {
+        return this;
+      },
+      isVisible: async () => state.visible.has(name),
+      click: async () => {
+        if (options.failClicks?.has(name)) {
+          failed.push(name);
+          options.failClicks.delete(name);
+          throw new Error("element is not stable");
+        }
+        clicks.push(name);
+        options.onClick?.(name, state);
+      },
+      fill: async (value: string) => {
+        fills.push(value);
+      },
+      innerText: async () => {
+        if (name === "__body__") {
+          pass += 1;
+          options.onPass?.(pass, state);
+        }
+        return state.body;
+      },
+    }) as unknown as Locator;
+
+  const byPattern: Array<[RegExp, string]> = [
+    [/your name/, "name"],
+    [/accept all/, "consent"],
+    [/got it/, "gotIt"],
+    [/continue without/, "continueWithout"],
+    [/join without/, "joinWithout"],
+    [/dismiss/, "dismiss"],
+    [/turn off microphone/, "microphone"],
+    [/turn off camera/, "camera"],
+    [/ask to join/, "ask"],
+    [/join now/, "joinNow"],
+    [/leave call/, "leave"],
+  ];
+
+  const page = {
+    setDefaultTimeout: () => undefined,
+    goto: async () => null,
+    getByRole: (_role: string, roleOptions: { name?: RegExp }) => {
+      const pattern = roleOptions.name?.source ?? "";
+      for (const [match, name] of byPattern) {
+        if (match.test(pattern)) return control(name);
+      }
+      return control("__absent__");
+    },
+    locator: (selector: string) =>
+      selector === "body" ? control("__body__") : control("__absent__"),
+    isClosed: () => false,
+  } as unknown as Page;
+
+  // `body` is read through innerText on a control that is never "visible",
+  // which is exactly how the driver reads it.
+  state.visible.add("__body__");
+  return { page, state, clicks, fills, failed };
+}
+
+describe("the Google Meet admission window", () => {
+  const at = (minutes: number) => new Date(60_000 * minutes);
+
+  test("waits for the whole call, not an arbitrary five minutes", () => {
+    // The dispatcher asks to join 30s *before* the start, so a flat five
+    // minutes gave up at 4m30s past the hour — before a great many hosts have
+    // finished their previous meeting.
+    assert.equal(admissionCutoff({ scheduledEndAt: at(30) }, 0), 30 * 60_000);
+  });
+
+  test("never keeps a browser and a recording in a lobby indefinitely", () => {
+    assert.equal(admissionCutoff({ scheduledEndAt: at(600) }, 0), 30 * 60_000);
+  });
+
+  test("still gives a nearly-over call the ordinary grace period", () => {
+    assert.equal(admissionCutoff({ scheduledEndAt: at(1) }, 0), 5 * 60_000);
+  });
+
+  test("falls back to five minutes when nothing says when the call ends", () => {
+    assert.equal(admissionCutoff({ scheduledEndAt: null }, 0), 5 * 60_000);
+  });
+});
+
+describe("Google Meet lobby interstitials", () => {
+  test("closes the no-microphone dialog that used to block every click", async () => {
+    // The dialog is modal. Meet raises it after the SPA has rendered, so the
+    // old one-shot check ran too early to see it and every later click landed
+    // on the scrim — the notetaker sat there until the deadline and then
+    // reported that Meet had never offered it a button.
+    const lobby = fakeLobby({
+      visible: ["continueWithout", "name", "ask"],
+      onClick: (name, state) => {
+        if (name === "continueWithout") state.visible.delete("continueWithout");
+        if (name === "ask") state.visible.add("leave");
+      },
+    });
+
+    await joinGoogleMeetAsGuest(lobby.page, joinArgs());
+
+    assert.deepEqual(lobby.clicks, ["continueWithout", "ask"]);
+    assert.deepEqual(lobby.fills, ["Genosyn (AI notetaker — recording)"]);
+  });
+
+  test("dismisses an interstitial that arrives after the page did", async () => {
+    // Meet is a single-page app. The old code checked for consent and "Got it"
+    // exactly once, immediately after `goto` — while the lobby was still
+    // blank — so anything Google rendered a moment later stayed on screen
+    // over the join button for the rest of the join window.
+    const lobby = fakeLobby({
+      visible: ["name"],
+      onPass: (pass, state) => {
+        if (pass === 2) state.visible.add("gotIt");
+      },
+      onClick: (name, state) => {
+        if (name === "gotIt") {
+          state.visible.delete("gotIt");
+          state.visible.add("ask");
+        }
+        if (name === "ask") state.visible.add("leave");
+      },
+    });
+
+    await joinGoogleMeetAsGuest(lobby.page, joinArgs());
+
+    assert.deepEqual(lobby.clicks, ["gotIt", "ask"]);
+  });
+
+  test("asks again when Meet reports that nobody responded", async () => {
+    // Meet expires an unanswered request after a couple of minutes and offers
+    // to ask again. Treating that as terminal is what made a late host mean no
+    // notetaker at all.
+    const lobby = fakeLobby({
+      visible: ["name", "ask"],
+      onClick: (name, state) => {
+        if (name !== "ask") return;
+        state.body = state.body.includes("No one responded")
+          ? ""
+          : "No one responded to your request to join";
+        if (!state.body) state.visible.add("leave");
+      },
+    });
+
+    await joinGoogleMeetAsGuest(lobby.page, joinArgs());
+
+    assert.deepEqual(
+      lobby.clicks.filter((name) => name === "ask"),
+      ["ask", "ask"],
+    );
+  });
+
+  test("a click that loses a race with Meet's re-render costs a pass, not the call", async () => {
+    const lobby = fakeLobby({
+      visible: ["name", "ask"],
+      failClicks: new Set(["ask"]),
+      onClick: (name, state) => {
+        if (name === "ask") state.visible.add("leave");
+      },
+    });
+
+    await joinGoogleMeetAsGuest(lobby.page, joinArgs());
+
+    assert.deepEqual(lobby.failed, ["ask"]);
+    assert.deepEqual(lobby.clicks, ["ask"]);
+  });
+
+  test("recognises a guest who is already in the call", async () => {
+    const lobby = fakeLobby({ visible: ["leave", "name", "ask"] });
+
+    await joinGoogleMeetAsGuest(lobby.page, joinArgs());
+
+    assert.deepEqual(lobby.clicks, []);
+    assert.deepEqual(lobby.fills, []);
+  });
+
+  test("reports a call that ended before anybody admitted the guest", async () => {
+    const lobby = fakeLobby({
+      visible: ["name", "ask"],
+      body: "This meeting has ended",
+    });
+
+    await assert.rejects(joinGoogleMeetAsGuest(lobby.page, joinArgs()), /ended before/);
+  });
+
+  test("reports a meeting that does not allow guests, with the fix in the sentence", async () => {
+    const lobby = fakeLobby({
+      visible: [],
+      body: "You need to sign in to join this video call",
+    });
+
+    await assert.rejects(joinGoogleMeetAsGuest(lobby.page, joinArgs()), /Allow guests/);
+  });
+
+  test("stops as soon as a Member asks it to", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const lobby = fakeLobby({ visible: ["name", "ask"] });
+
+    await assert.rejects(
+      joinGoogleMeetAsGuest(lobby.page, joinArgs(controller.signal)),
+      /was stopped/,
+    );
+  });
+});
+
 describe("Google Meet recorder lifecycle", () => {
   test("isolates audio and browser state, records mono Opus, and cleans everything up", async () => {
     const harness = recorderHarness();
@@ -294,14 +540,17 @@ describe("Google Meet recorder lifecycle", () => {
     });
     assert.equal(harness.lifecycle.contextClosed, 1);
     assert.equal(harness.lifecycle.browserClosed, 1);
+    // Two devices, both private to this call and both unloaded again: the null
+    // sink Chrome plays into, and the null source it captures from.
     assert.deepEqual(
-      harness.commands.map(({ command, args }) => [command, args[0]]),
+      harness.commands.map(({ command, args }) => [command, args[0], args[1]]),
       [
-        ["pactl", "load-module"],
-        ["pactl", "unload-module"],
+        ["pactl", "load-module", "module-null-sink"],
+        ["pactl", "load-module", "module-null-source"],
+        ["pactl", "unload-module", "41"],
+        ["pactl", "unload-module", "41"],
       ],
     );
-    assert.deepEqual(harness.commands[1].args, ["unload-module", "41"]);
 
     const ffmpeg = harness.ffmpegCommands[0];
     assert.equal(ffmpeg.command, "ffmpeg");
@@ -318,10 +567,16 @@ describe("Google Meet recorder lifecycle", () => {
     assert.deepEqual(launch.ignoreDefaultArgs, ["--enable-automation", "--mute-audio"]);
     assert.equal((launch.env as Record<string, string>).EXISTING, "yes");
     assert.match((launch.env as Record<string, string>).PULSE_SINK, /^genosyn_meeting_/);
+    // Capture is pinned to the silent source. Left to PulseAudio's default,
+    // Chrome would capture the monitor of the sink it is playing into.
+    assert.equal(
+      (launch.env as Record<string, string>).PULSE_SOURCE,
+      `${(launch.env as Record<string, string>).PULSE_SINK}_mic`,
+    );
     assert.deepEqual(harness.getContextOptions(), {
       locale: "en-US",
       serviceWorkers: "allow",
-      permissions: [],
+      permissions: ["microphone"],
       acceptDownloads: false,
     });
   });
@@ -439,6 +694,48 @@ describe("Google Meet recorder lifecycle", () => {
     assert.equal(harness.lifecycle.contextClosed, 1);
     assert.equal(harness.lifecycle.browserClosed, 1);
     assert.equal(harness.commands.at(-1)?.args[0], "unload-module");
+  });
+
+  test("joins without a silent microphone when PulseAudio has no null source", async () => {
+    // `module-null-source` is not in every PulseAudio build. A deployment
+    // without it should still get a notetaker — it just falls back to
+    // dismissing Meet's device dialog instead of satisfying it.
+    const harness = recorderHarness({ noSilentSource: true });
+
+    const result = await harness.recorder.join(joinArgs());
+
+    assert.equal(result.mime, "audio/webm");
+    const launch = harness.getLaunchOptions();
+    assert.equal((launch?.env as Record<string, string>).PULSE_SOURCE, undefined);
+    assert.deepEqual((harness.getContextOptions() as { permissions: string[] }).permissions, []);
+    assert.equal(
+      harness.warnings.some((message) => /silent microphone/.test(message)),
+      true,
+    );
+    // The sink is still created and still cleaned up; only the source is gone.
+    assert.deepEqual(
+      harness.commands.map(({ args }) => [args[0], args[1]]),
+      [
+        ["load-module", "module-null-sink"],
+        ["load-module", "module-null-source"],
+        ["unload-module", "41"],
+      ],
+    );
+  });
+
+  test("reads the recording cap on every join instead of freezing it at boot", async () => {
+    // `createGoogleMeetRecorder` builds its dependencies with a spread, and a
+    // spread *calls* a getter and keeps the number. The cap is an
+    // operator-editable runtime setting, so it has to be read per join —
+    // otherwise every recording for the life of the process uses whatever the
+    // Admin → Runtime value happened to be when the module first loaded.
+    let cap = 1024 * 1024;
+    const harness = recorderHarness({ readMaxRecordingBytes: () => cap });
+
+    assert.equal((await harness.recorder.join(joinArgs())).mime, "audio/webm");
+
+    cap = 1;
+    await assert.rejects(harness.recorder.join(joinArgs()), /greater than one/);
   });
 
   test("an already-aborted request allocates nothing", async () => {

--- a/App/server/services/meetings/googleMeetRecorder.ts
+++ b/App/server/services/meetings/googleMeetRecorder.ts
@@ -14,10 +14,26 @@ import {
 import { registerMeetingRecorder } from "./recorder.js";
 
 const MEET_CODE_RE = /^\/[a-z]{3}-[a-z]{4}-[a-z]{3}\/?$/i;
+/** Workspace "nicknamed" meetings, which Calendar writes as a lookup alias. */
+const MEET_LOOKUP_RE = /^\/lookup\/[a-z0-9_-]{1,64}\/?$/i;
 const MAX_DISPLAY_NAME_LENGTH = 100;
+/** The lobby wait when the call has no scheduled end to wait until. */
 const ADMISSION_TIMEOUT_MS = 5 * 60_000;
+/** Nothing keeps a browser and a recording in a lobby longer than this. */
+const MAX_ADMISSION_WAIT_MS = 30 * 60_000;
+/** How long an unanswered "ask to join" stands before asking again. */
+const RE_ASK_AFTER_MS = 90_000;
+/** A bound on re-asking, so a broken lobby cannot spam a host forever. */
+const MAX_JOIN_REQUESTS = 8;
 const UI_POLL_MS = 500;
+/** One lobby interaction. Short, because the loop retries on the next pass. */
+const UI_ACTION_TIMEOUT_MS = 5_000;
 const MEETING_POLL_MS = 1_000;
+
+/** Both shapes of a real Meet call path: a meeting code, or a lookup alias. */
+function isMeetCallPath(pathname: string): boolean {
+  return MEET_CODE_RE.test(pathname) || MEET_LOOKUP_RE.test(pathname);
+}
 
 export type GoogleMeetJoinArgs = {
   companyId: string;
@@ -50,7 +66,7 @@ type GoogleMeetRecorderDependencies = {
   waitForEnd(page: Page, args: GoogleMeetJoinArgs): Promise<void>;
   now(): number;
   randomToken(): string;
-  maxRecordingBytes: number;
+  maxRecordingBytes(): number;
   warn(message: string): void;
 };
 
@@ -65,11 +81,14 @@ const defaultDependencies: GoogleMeetRecorderDependencies = {
   waitForEnd: waitForGoogleMeetToEnd,
   now: Date.now,
   randomToken: () => randomUUID().slice(0, 8),
-  // A getter, not a value: the defaults object is built once at module load,
-  // and the cap is an operator-editable runtime setting.
-  get maxRecordingBytes(): number {
-    return getMeetingsSettings().maxRecordingBytes;
-  },
+  // A function, not a getter and not a value. The cap is an operator-editable
+  // runtime setting, but `createGoogleMeetRecorder` builds its dependencies
+  // with `{...defaults, ...overrides}` — and spreading an object *calls* a
+  // getter and copies the number it returned. The intent was always to read
+  // the setting per call; a getter here silently read it once, at module
+  // load, and every recording for the life of the process used whatever the
+  // cap had been at boot.
+  maxRecordingBytes: () => getMeetingsSettings().maxRecordingBytes,
   warn: (message) => {
     // eslint-disable-next-line no-console
     console.warn(message);
@@ -90,7 +109,7 @@ export function isGoogleMeetConferenceUrl(value: string): boolean {
       (url.port === "" || url.port === "443") &&
       url.username === "" &&
       url.password === "" &&
-      MEET_CODE_RE.test(url.pathname)
+      isMeetCallPath(url.pathname)
     );
   } catch {
     return false;
@@ -137,6 +156,7 @@ export function createGoogleMeetRecorder(overrides: Partial<GoogleMeetRecorderDe
       }
 
       let sink: PulseAudioSink | null = null;
+      let silentMicrophone: PulseAudioSource | null = null;
       let capture: FfmpegCapture | null = null;
       let browser: Browser | null = null;
       let context: BrowserContext | null = null;
@@ -147,10 +167,11 @@ export function createGoogleMeetRecorder(overrides: Partial<GoogleMeetRecorderDe
 
       try {
         sink = await createPulseAudioSink(args.meetingId, dependencies);
+        silentMicrophone = await createSilentCaptureSource(sink.name, dependencies);
         capture = startFfmpegCapture(
           sink.monitorSource,
           dependencies.spawnProcess,
-          dependencies.maxRecordingBytes,
+          dependencies.maxRecordingBytes(),
         );
 
         const launcher = await dependencies.loadLauncher();
@@ -177,6 +198,11 @@ export function createGoogleMeetRecorder(overrides: Partial<GoogleMeetRecorderDe
             ...stringEnvironment(process.env),
             ...inheritedEnvironment,
             PULSE_SINK: sink.name,
+            // Pin capture to the silent source as well as playback to the
+            // private sink. Without this Chrome takes PulseAudio's default
+            // source, which in a container is the monitor of whatever is
+            // playing — the call itself.
+            ...(silentMicrophone ? { PULSE_SOURCE: silentMicrophone.name } : {}),
           },
         })) as Browser;
 
@@ -190,7 +216,13 @@ export function createGoogleMeetRecorder(overrides: Partial<GoogleMeetRecorderDe
           // context. The employee browser's service-worker boundary stays
           // untouched.
           serviceWorkers: "allow",
-          permissions: [],
+          // The microphone is granted only when we have a device that is
+          // silent by construction. Meet blocks the lobby on a `getUserMedia`
+          // it cannot resolve, so denying the permission outright is what put
+          // the notetaker behind a dialog it never dismissed. The camera is
+          // never granted: there is nothing to show, and a denied camera is a
+          // banner rather than a blocker.
+          permissions: silentMicrophone ? ["microphone"] : [],
           acceptDownloads: false,
         });
         const maskScript = await dependencies.initScript();
@@ -249,6 +281,22 @@ export function createGoogleMeetRecorder(overrides: Partial<GoogleMeetRecorderDe
             );
           } catch (err) {
             cleanupErrors.push(actionError("close the dedicated Google Meet browser", err));
+          }
+        }
+        if (silentMicrophone) {
+          try {
+            const removing = removePulseAudioSource(silentMicrophone, dependencies.runCommand);
+            if (args.signal.aborted) {
+              await promiseWithTimeout(
+                removing,
+                750,
+                "Removing the notetaker's silent microphone timed out.",
+              );
+            } else {
+              await removing;
+            }
+          } catch (err) {
+            cleanupErrors.push(actionError("remove the notetaker's silent microphone", err));
           }
         }
         if (sink) {
@@ -312,6 +360,11 @@ type PulseAudioSink = {
   moduleId: string;
 };
 
+type PulseAudioSource = {
+  name: string;
+  moduleId: string;
+};
+
 async function createPulseAudioSink(
   meetingId: string,
   dependencies: Pick<GoogleMeetRecorderDependencies, "runCommand" | "randomToken">,
@@ -350,11 +403,72 @@ async function createPulseAudioSink(
   return { name, monitorSource: `${name}.monitor`, moduleId };
 }
 
+/**
+ * A silent microphone for the guest.
+ *
+ * Google Meet asks for `getUserMedia` before it will let anybody into the
+ * lobby, and a container has no capture hardware at all. Left alone, Chrome
+ * either fails the request outright or falls back to the **only** source
+ * PulseAudio does offer — the monitor of the very sink we are recording — and
+ * a notetaker whose microphone is the call's own output is a feedback loop
+ * with a disclosure label on it.
+ *
+ * So the recorder brings its own capture device: a null source, which produces
+ * real, honest silence. Meet's device check passes, nothing is ever
+ * contributed to the call, and the microphone stays switched off in the lobby
+ * as well — belt and braces, because the guarantee that the bot is inaudible
+ * should not rest on one UI click landing.
+ *
+ * Best-effort by design. `module-null-source` is not in every PulseAudio
+ * build, and a deployment without it is still better served by the
+ * dialog-dismissal path in the lobby than by a recorder that refuses to start.
+ */
+async function createSilentCaptureSource(
+  sinkName: string,
+  dependencies: Pick<GoogleMeetRecorderDependencies, "runCommand" | "warn">,
+): Promise<PulseAudioSource | null> {
+  const name = `${sinkName}_mic`;
+  try {
+    const result = await dependencies.runCommand("pactl", [
+      "load-module",
+      "module-null-source",
+      `source_name=${name}`,
+      "rate=48000",
+      "channels=1",
+      `source_properties=device.description=Genosyn_silent_mic`,
+    ]);
+    const moduleId = result.stdout.trim();
+    if (!/^\d+$/.test(moduleId)) {
+      dependencies.warn(
+        `[meetings] PulseAudio returned no module id for the notetaker's silent microphone${
+          result.stderr.trim() ? `: ${result.stderr.trim()}` : "."
+        } Joining without one.`,
+      );
+      return null;
+    }
+    return { name, moduleId };
+  } catch (err) {
+    dependencies.warn(
+      `[meetings] the notetaker could not create a silent microphone (${errorMessage(
+        err,
+      )}). Joining without one; Google Meet may ask to continue without a microphone.`,
+    );
+    return null;
+  }
+}
+
 async function removePulseAudioSink(
   sink: PulseAudioSink,
   run: GoogleMeetRecorderDependencies["runCommand"],
 ): Promise<void> {
   await run("pactl", ["unload-module", sink.moduleId]);
+}
+
+async function removePulseAudioSource(
+  source: PulseAudioSource,
+  run: GoogleMeetRecorderDependencies["runCommand"],
+): Promise<void> {
+  await run("pactl", ["unload-module", source.moduleId]);
 }
 
 /** Recover the unique module when `pactl load-module` did not return its id. */
@@ -578,7 +692,7 @@ function startFfmpegCapture(
 
 /** Drive Meet's unsigned guest lobby and resolve only after admission. */
 export async function joinGoogleMeetAsGuest(page: Page, args: GoogleMeetJoinArgs): Promise<void> {
-  page.setDefaultTimeout(10_000);
+  page.setDefaultTimeout(UI_ACTION_TIMEOUT_MS);
   try {
     await withAbortSignal(
       page.goto(args.conferenceUrl, { waitUntil: "domcontentloaded", timeout: 45_000 }),
@@ -586,85 +700,43 @@ export async function joinGoogleMeetAsGuest(page: Page, args: GoogleMeetJoinArgs
       "The notetaker was stopped while it was opening Google Meet.",
     );
   } catch (err) {
+    // A Stop is not a broken lobby. Wrapping it in "could not open the Google
+    // Meet lobby" put a Playwright abort message in front of a human who had
+    // just pressed Stop, and buried the fact that it worked.
+    if (args.signal.aborted) {
+      throw new Error("The notetaker was stopped while it was opening Google Meet.", {
+        cause: err,
+      });
+    }
     throw new Error(`The notetaker could not open the Google Meet lobby. ${errorMessage(err)}`, {
       cause: err,
     });
   }
 
-  await clickFirstVisible([
-    page.getByRole("button", { name: /accept all/i }),
-    page.getByRole("button", { name: /got it/i }),
-  ]);
-
-  const cutoff = Math.min(
-    Date.now() + ADMISSION_TIMEOUT_MS,
-    args.scheduledEndAt?.getTime() ?? Number.POSITIVE_INFINITY,
-  );
-  const nameInput = await waitForFirstVisible(
-    [
-      page.getByRole("textbox", { name: /your name|name/i }),
-      page.locator('input[placeholder*="name" i]'),
-    ],
-    cutoff,
-    args.signal,
-  );
-  if (!nameInput) {
-    if (args.signal.aborted) {
-      throw new Error("The notetaker was stopped while it was preparing to join.");
-    }
-    if (Date.now() >= cutoff) {
-      throw new Error("The Google Meet join window closed before the guest lobby was ready.");
-    }
-    const body = await bodyText(page);
-    if (/sign in to join|you can.?t join this (?:video )?call|not allowed to join/i.test(body)) {
-      throw new Error(
-        "Google Meet requires an account or has disabled guest access for this call. Allow guests, then retry the notetaker.",
-      );
-    }
-    throw new Error("The Google Meet guest name field did not appear before the join deadline.");
-  }
-  await nameInput.fill(disclosedNotetakerName(args.displayName));
-
-  // A granted media permission is never needed: the bot contributes no audio
-  // or video. These clicks handle Meet sessions that render the devices on by
-  // default despite the context granting no camera/microphone permissions.
-  await clickFirstVisible([
-    page.getByRole("button", { name: /turn off microphone|disable microphone/i }),
-    page.locator('[aria-label*="microphone" i][data-is-muted="false"]'),
-  ]);
-  await clickFirstVisible([
-    page.getByRole("button", { name: /turn off camera|disable camera/i }),
-    page.locator('[aria-label*="camera" i][data-is-muted="false"]'),
-  ]);
-
-  const joinButton = await waitForFirstVisible(
-    [
-      page.getByRole("button", { name: /ask to join/i }),
-      page.getByRole("button", { name: /join now/i }),
-    ],
-    cutoff,
-    args.signal,
-  );
-  if (!joinButton) {
-    if (args.signal.aborted) {
-      throw new Error("The notetaker was stopped before it could ask to join.");
-    }
-    throw new Error("Google Meet never offered the guest notetaker a button to ask to join.");
-  }
-  await joinButton.click();
+  const cutoff = admissionCutoff(args, Date.now());
+  let named = false;
+  let mutedMicrophone = false;
+  let stoppedCamera = false;
+  let askedAt = 0;
+  let asks = 0;
 
   for (;;) {
     if (args.signal.aborted) {
       throw new Error("The notetaker was stopped while it was waiting for admission.");
     }
+    if (page.isClosed()) {
+      throw new Error("Google Meet closed while the notetaker was waiting for admission.");
+    }
     if (Date.now() >= cutoff) {
       throw new Error(
-        "Nobody admitted the notetaker before the join window closed. Admit the disclosed notetaker from the Google Meet lobby.",
+        named
+          ? "Nobody admitted the notetaker before the join window closed. Admit the disclosed notetaker from the Google Meet lobby."
+          : "The Google Meet guest name field did not appear before the join deadline.",
       );
     }
-    if (page.isClosed())
-      throw new Error("Google Meet closed while the notetaker was waiting for admission.");
 
+    // Admitted. Everything below this line is lobby work, and once the call
+    // controls are on screen none of it applies any more.
     if (
       await anyVisible([
         page.getByRole("button", { name: /leave call/i }),
@@ -674,19 +746,120 @@ export async function joinGoogleMeetAsGuest(page: Page, args: GoogleMeetJoinArgs
       return;
     }
 
+    // Interstitials are re-checked every pass rather than once before the
+    // lobby renders. Meet is a single-page app: consent, "Got it", and the
+    // no-camera/no-microphone dialog each arrive whenever they arrive, and a
+    // one-shot check that ran while the page was still blank is the same as
+    // no check at all. The device dialog in particular is *modal* — miss it
+    // and every later click lands on a scrim, which is exactly how a
+    // notetaker sits in a lobby for five minutes and then reports that Meet
+    // never offered it a button.
+    await clickFirstVisible([
+      page.getByRole("button", { name: /accept all|reject all/i }),
+      page.getByRole("button", { name: /^got it$/i }),
+      page.getByRole("button", { name: /continue without (?:microphone|camera)/i }),
+      page.getByRole("button", { name: /join without (?:microphone|camera)/i }),
+      page.getByRole("button", { name: /^dismiss$/i }),
+    ]);
+
     const body = await bodyText(page);
     if (/request to join (?:was )?denied|you were denied|can.?t join this call/i.test(body)) {
       throw new Error("The Google Meet host denied the notetaker's request to join.");
     }
-    if (/no one responded|ask to join again/i.test(body)) {
-      throw new Error(
-        "Nobody admitted the notetaker. Ask the meeting host to admit it, then retry.",
-      );
-    }
     if (/meeting has ended|this meeting is no longer available/i.test(body)) {
       throw new Error("The Google Meet call ended before the notetaker was admitted.");
     }
+    if (/sign in to join|you can.?t join this (?:video )?call|not allowed to join/i.test(body)) {
+      throw new Error(
+        "Google Meet requires an account or has disabled guest access for this call. Allow guests, then retry the notetaker.",
+      );
+    }
+
+    if (!named) {
+      const nameInput = await firstVisible([
+        page.getByRole("textbox", { name: /your name|name/i }),
+        page.locator('input[placeholder*="name" i]'),
+      ]);
+      if (nameInput) {
+        named = await attempt(() => nameInput.fill(disclosedNotetakerName(args.displayName)));
+      }
+    }
+
+    // The microphone is silent by construction (see createSilentCaptureSource)
+    // and these clicks make it visibly off as well, for the humans in the
+    // room. Best-effort: a lobby that renders the devices already off has no
+    // button here, and failing the whole join over a decoration would be
+    // absurd.
+    if (!mutedMicrophone) {
+      mutedMicrophone = await clickFirstVisible([
+        page.getByRole("button", { name: /turn off microphone|disable microphone/i }),
+        page.locator('[aria-label*="microphone" i][data-is-muted="false"]'),
+      ]);
+    }
+    if (!stoppedCamera) {
+      stoppedCamera = await clickFirstVisible([
+        page.getByRole("button", { name: /turn off camera|disable camera/i }),
+        page.locator('[aria-label*="camera" i][data-is-muted="false"]'),
+      ]);
+    }
+
+    // Meet expires an unanswered request after a couple of minutes and offers
+    // to ask again. That is a normal thing to happen to a bot waiting on a
+    // host who is still in their previous call — treating it as terminal is
+    // what made "the notetaker never joined" the ordinary outcome of a
+    // meeting that started late.
+    const rejected = /no one responded|ask to join again|nobody responded/i.test(body);
+    const dueToAsk = askedAt === 0 || rejected || Date.now() - askedAt >= RE_ASK_AFTER_MS;
+    if (named && dueToAsk && asks < MAX_JOIN_REQUESTS) {
+      const joinButton = await firstVisible([
+        page.getByRole("button", { name: /ask to join/i }),
+        page.getByRole("button", { name: /join now/i }),
+      ]);
+      if (joinButton && (await attempt(() => joinButton.click()))) {
+        askedAt = Date.now();
+        asks += 1;
+      }
+    }
+
     await delayUntil(UI_POLL_MS, args.signal);
+  }
+}
+
+/**
+ * How long to sit in the lobby.
+ *
+ * It used to be five minutes flat, which reads as generous and is not: the
+ * dispatcher asks to join thirty seconds *before* the start time, so the
+ * notetaker gave up at four and a half minutes past the hour. A host who
+ * joins late — the single most ordinary thing that happens to a meeting —
+ * arrived to no notetaker and a `failed` row blaming them for not admitting
+ * it. A call is worth joining right up until it is scheduled to end, so that
+ * is the deadline, bounded so that a mis-entered all-day-length invite cannot
+ * park a browser and a recording for the rest of the afternoon.
+ */
+export function admissionCutoff(
+  args: Pick<GoogleMeetJoinArgs, "scheduledEndAt">,
+  now: number,
+): number {
+  if (!args.scheduledEndAt) return now + ADMISSION_TIMEOUT_MS;
+  return Math.min(
+    Math.max(args.scheduledEndAt.getTime(), now + ADMISSION_TIMEOUT_MS),
+    now + MAX_ADMISSION_WAIT_MS,
+  );
+}
+
+/** Run one Playwright action, reporting whether it landed rather than throwing.
+ *
+ * Every lobby interaction is a guess about a UI Google reserves the right to
+ * change, and a guess that misses should cost one polling pass, not the call.
+ * The loop re-reads the page each time round, so anything that failed because
+ * the element was stale, covered, or mid-animation is simply tried again. */
+async function attempt(action: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await action();
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -709,7 +882,7 @@ export async function waitForGoogleMeetToEnd(page: Page, args: GoogleMeetJoinArg
     }
     try {
       const current = new URL(page.url());
-      if (current.hostname !== "meet.google.com" || !MEET_CODE_RE.test(current.pathname)) return;
+      if (current.hostname !== "meet.google.com" || !isMeetCallPath(current.pathname)) return;
     } catch {
       return;
     }
@@ -718,30 +891,24 @@ export async function waitForGoogleMeetToEnd(page: Page, args: GoogleMeetJoinArg
   }
 }
 
-async function waitForFirstVisible(
+/** The first of these that is on screen right now, or null. One pass only —
+ * the lobby loop owns the waiting, so this never blocks. */
+async function firstVisible(
   locators: ReturnType<Page["locator"]>[],
-  cutoff: number,
-  signal: AbortSignal,
 ): Promise<ReturnType<Page["locator"]> | null> {
-  for (;;) {
-    if (signal.aborted || Date.now() >= cutoff) return null;
-    for (const locator of locators) {
-      const candidate = locator.first();
-      if (await candidate.isVisible().catch(() => false)) return candidate;
-    }
-    await delayUntil(UI_POLL_MS, signal);
-  }
-}
-
-async function clickFirstVisible(locators: ReturnType<Page["locator"]>[]): Promise<boolean> {
   for (const locator of locators) {
     const candidate = locator.first();
-    if (await candidate.isVisible().catch(() => false)) {
-      await candidate.click();
-      return true;
-    }
+    if (await candidate.isVisible().catch(() => false)) return candidate;
   }
-  return false;
+  return null;
+}
+
+/** Click the first visible locator. Never throws: a click that loses a race
+ * with Meet's own re-render is retried by the next pass of the lobby loop. */
+async function clickFirstVisible(locators: ReturnType<Page["locator"]>[]): Promise<boolean> {
+  const candidate = await firstVisible(locators);
+  if (!candidate) return false;
+  return attempt(() => candidate.click());
 }
 
 async function anyVisible(locators: ReturnType<Page["locator"]>[]): Promise<boolean> {

--- a/App/server/services/meetings/notetakerSetup.test.ts
+++ b/App/server/services/meetings/notetakerSetup.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import { AppDataSource } from "../../db/datasource.js";
+import { AIEmployee } from "../../db/entities/AIEmployee.js";
+import { CalendarAccount } from "../../db/entities/CalendarAccount.js";
+import { CalendarEvent } from "../../db/entities/CalendarEvent.js";
+import { EmployeeCalendarGrant } from "../../db/entities/EmployeeCalendarGrant.js";
+import { Meeting } from "../../db/entities/Meeting.js";
+import { closeTestDb, initTestDb, insert, resetTestDb } from "../../test/dbHarness.js";
+import { ensureNotetakerCanRecord, updateCalendarAccount } from "./accounts.js";
+import {
+  dispatchDueMeetings,
+  registerMeetingRecorder,
+  setMeetingBackgroundProcessor,
+  shutdownMeetingNotetakers,
+  type MeetingRecorder,
+} from "./recorder.js";
+import { armMeetingsForAccount, createAdHocMeeting } from "./store.js";
+
+/**
+ * The setup flow, end to end — the bug this file exists for.
+ *
+ * Everything in the recording path was covered, and all of it passed, because
+ * every test built its own `EmployeeCalendarGrant` by hand. Nothing in the
+ * product ever did. An operator connected a calendar, chose "Record every
+ * Google Meet", picked a notetaker, and was told on that very page that
+ * eligible Meets would be joined — and then `validateClaimedJoin` refused
+ * every single call for want of a Grant, settling it `skipped` with a reason
+ * the UI rendered nowhere. The notetaker never turned up, ever, and no error
+ * appeared anywhere a human would look.
+ *
+ * So these tests are deliberately written against the operator's flow rather
+ * than the recorder's: nothing below writes a grant row directly, because the
+ * point is that the product now writes it.
+ */
+
+const CO = "co_notetaker_setup";
+const OTHER_CO = "co_someone_else";
+
+before(initTestDb);
+beforeEach(async () => {
+  await shutdownMeetingNotetakers("Test reset.", 1_000);
+  registerMeetingRecorder(null);
+  setMeetingBackgroundProcessor();
+  await resetTestDb();
+});
+after(async () => {
+  await shutdownMeetingNotetakers("Test suite finished.", 1_000);
+  await closeTestDb();
+});
+
+async function anEmployee(companyId = CO, name = "Nova"): Promise<AIEmployee> {
+  return insert(AIEmployee, {
+    companyId,
+    name,
+    slug: `${name.toLowerCase()}-${Math.random().toString(36).slice(2, 8)}`,
+    role: "Account executive",
+  });
+}
+
+async function aCalendar(companyId = CO): Promise<CalendarAccount> {
+  return insert(CalendarAccount, {
+    companyId,
+    connectionId: `connection-${Math.random()}`,
+    calendarId: `calendar-${Math.random()}`,
+    address: "sales@northwind.test",
+    status: "active",
+  });
+}
+
+async function anEvent(account: CalendarAccount, now: Date): Promise<CalendarEvent> {
+  return insert(CalendarEvent, {
+    companyId: account.companyId,
+    accountId: account.id,
+    externalId: `event-${Math.random()}`,
+    summary: "Acme renewal",
+    startAt: new Date(now.getTime() + 10_000),
+    endAt: new Date(now.getTime() + 60 * 60_000),
+    status: "confirmed",
+    conferenceProvider: "meet",
+    conferenceUrl: "https://meet.google.com/abc-defg-hij",
+  });
+}
+
+function recordingRecorder(joined: string[]): MeetingRecorder {
+  return {
+    id: "notetaker",
+    canJoin: () => true,
+    join: async (args) => {
+      joined.push(args.meetingId);
+      return { bytes: Buffer.from("audio"), mime: "audio/webm", durationMs: 1 };
+    },
+  };
+}
+
+async function grantsFor(employeeId: string): Promise<EmployeeCalendarGrant[]> {
+  return AppDataSource.getRepository(EmployeeCalendarGrant).find({ where: { employeeId } });
+}
+
+async function reload(account: CalendarAccount): Promise<CalendarAccount> {
+  return AppDataSource.getRepository(CalendarAccount).findOneByOrFail({ id: account.id });
+}
+
+async function waitFor<T>(read: () => Promise<T>, predicate: (value: T) => boolean): Promise<T> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const value = await read();
+    if (predicate(value)) return value;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Condition was not reached.");
+}
+
+describe("naming a notetaker grants it Record", () => {
+  test("the ordinary setup flow ends with a Record grant nobody had to know about", async () => {
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+
+    await updateCalendarAccount(CO, account.id, {
+      autoRecord: "all",
+      notetakerEmployeeId: employee.id,
+    });
+
+    const grants = await grantsFor(employee.id);
+    assert.equal(grants.length, 1);
+    assert.equal(grants[0].accountId, account.id);
+    assert.equal(grants[0].accessLevel, "record");
+  });
+
+  test("an employee that could only read the calendar is upgraded, not duplicated", async () => {
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+    await insert(EmployeeCalendarGrant, {
+      employeeId: employee.id,
+      accountId: account.id,
+      accessLevel: "read",
+    });
+
+    await updateCalendarAccount(CO, account.id, { notetakerEmployeeId: employee.id });
+
+    const grants = await grantsFor(employee.id);
+    assert.equal(grants.length, 1);
+    assert.equal(grants[0].accessLevel, "record");
+  });
+
+  test("an employee that already holds Record is left exactly as it was", async () => {
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+    const before = await insert(EmployeeCalendarGrant, {
+      employeeId: employee.id,
+      accountId: account.id,
+      accessLevel: "record",
+    });
+
+    await updateCalendarAccount(CO, account.id, { notetakerEmployeeId: employee.id });
+
+    const grants = await grantsFor(employee.id);
+    assert.equal(grants.length, 1);
+    assert.equal(grants[0].id, before.id);
+  });
+
+  test("the grant is per calendar — a second calendar does not inherit the first", async () => {
+    const employee = await anEmployee();
+    const [sales, support] = await Promise.all([aCalendar(), aCalendar()]);
+
+    await updateCalendarAccount(CO, sales.id, { notetakerEmployeeId: employee.id });
+
+    const grants = await grantsFor(employee.id);
+    assert.deepEqual(
+      grants.map((row) => row.accountId),
+      [sales.id],
+    );
+    assert.equal(
+      await AppDataSource.getRepository(EmployeeCalendarGrant).countBy({ accountId: support.id }),
+      0,
+    );
+  });
+
+  test("un-assigning the notetaker revokes nothing a human may have granted", async () => {
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+    await updateCalendarAccount(CO, account.id, { notetakerEmployeeId: employee.id });
+
+    await updateCalendarAccount(CO, account.id, { notetakerEmployeeId: null });
+
+    const grants = await grantsFor(employee.id);
+    assert.equal(grants.length, 1, "authority is withdrawn on the AI access page, not by a side effect");
+    assert.equal((await reload(account)).notetakerEmployeeId, null);
+  });
+
+  test("an employee from another company is refused, and nothing is written", async () => {
+    const [stranger, account] = await Promise.all([anEmployee(OTHER_CO, "Rook"), aCalendar()]);
+
+    await assert.rejects(
+      updateCalendarAccount(CO, account.id, {
+        autoRecord: "all",
+        notetakerEmployeeId: stranger.id,
+      }),
+      /not in this company/,
+    );
+
+    assert.equal(await AppDataSource.getRepository(EmployeeCalendarGrant).count(), 0);
+    assert.equal((await reload(account)).notetakerEmployeeId, null);
+    assert.equal((await reload(account)).autoRecord, "off");
+  });
+
+  test("a calendar in another company is never touched", async () => {
+    const [employee, theirs] = await Promise.all([anEmployee(), aCalendar(OTHER_CO)]);
+
+    assert.equal(await updateCalendarAccount(CO, theirs.id, { autoRecord: "all" }), null);
+    assert.equal(await ensureNotetakerCanRecord(CO, theirs.id, employee.id), null);
+    assert.equal(await AppDataSource.getRepository(EmployeeCalendarGrant).count(), 0);
+  });
+
+  test("ensureNotetakerCanRecord refuses an employee that no longer exists", async () => {
+    const account = await aCalendar();
+    assert.equal(
+      await ensureNotetakerCanRecord(CO, account.id, "00000000-0000-4000-8000-0000000000ff"),
+      null,
+    );
+    assert.equal(await AppDataSource.getRepository(EmployeeCalendarGrant).count(), 0);
+  });
+});
+
+describe("the notetaker actually joins after an ordinary setup", () => {
+  /**
+   * The regression, stated as the user reported it: connect a calendar, turn
+   * automatic recording on, pick an employee — and the notetaker joins. No
+   * grant row is written by this test; if one is needed, the product has to
+   * have made it.
+   */
+  test("connect → record automatically → pick a notetaker → the guest joins the call", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    registerMeetingRecorder(recordingRecorder(joined));
+    setMeetingBackgroundProcessor(() => undefined);
+
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+    await anEvent(account, now);
+
+    await updateCalendarAccount(CO, account.id, {
+      autoRecord: "all",
+      notetakerEmployeeId: employee.id,
+    });
+
+    const armed = await armMeetingsForAccount(await reload(account), now);
+    assert.equal(armed, 1, "the calendar arms the meeting");
+
+    const dispatch = await dispatchDueMeetings(now);
+    assert.equal(dispatch.due, 1);
+    assert.equal(dispatch.claimed, 1);
+
+    const meeting = await waitFor(
+      () => AppDataSource.getRepository(Meeting).findOneByOrFail({ companyId: CO }),
+      (row) => row.status === "processing",
+    );
+    assert.deepEqual(joined, [meeting.id]);
+    assert.equal(meeting.recordingSource, "notetaker");
+    assert.equal(meeting.statusMessage, "");
+  });
+
+  test("revoking the Grant still stops the join, and says so on the meeting", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    registerMeetingRecorder(recordingRecorder(joined));
+
+    const [employee, account] = await Promise.all([anEmployee(), aCalendar()]);
+    await anEvent(account, now);
+    await updateCalendarAccount(CO, account.id, {
+      autoRecord: "all",
+      notetakerEmployeeId: employee.id,
+    });
+    await armMeetingsForAccount(await reload(account), now);
+
+    // What the AI access page does when somebody takes the authority back.
+    await AppDataSource.getRepository(EmployeeCalendarGrant).delete({ employeeId: employee.id });
+
+    await dispatchDueMeetings(now);
+
+    const meeting = await waitFor(
+      () => AppDataSource.getRepository(Meeting).findOneByOrFail({ companyId: CO }),
+      (row) => row.status === "skipped",
+    );
+    assert.deepEqual(joined, [], "authority is re-checked at join time, not trusted from arming");
+    assert.match(meeting.statusMessage, /does not have Record access/);
+  });
+});
+
+describe("an ad-hoc meeting knows what it is a link to", () => {
+  test("a Meet link makes the meeting joinable rather than an unnamed row", async () => {
+    const meeting = await createAdHocMeeting({
+      companyId: CO,
+      title: "Acme intro",
+      scheduledStartAt: null,
+      conferenceUrl: "https://meet.google.com/abc-defg-hij",
+      notetakerEmployeeId: null,
+      createdByUserId: null,
+    });
+    assert.equal(meeting.conferenceProvider, "meet");
+  });
+
+  test("a link we cannot name is still a call", async () => {
+    const meeting = await createAdHocMeeting({
+      companyId: CO,
+      title: "Jitsi standup",
+      scheduledStartAt: null,
+      conferenceUrl: "https://meet.northwind.test/standup",
+      notetakerEmployeeId: null,
+      createdByUserId: null,
+    });
+    assert.equal(meeting.conferenceProvider, "other");
+  });
+
+  test("a Zoom link is named Zoom, not offered to the Meet notetaker", async () => {
+    const meeting = await createAdHocMeeting({
+      companyId: CO,
+      title: "Acme on Zoom",
+      scheduledStartAt: null,
+      conferenceUrl: "https://northwind.zoom.us/j/123456",
+      notetakerEmployeeId: null,
+      createdByUserId: null,
+    });
+    assert.equal(meeting.conferenceProvider, "zoom");
+  });
+
+  test("no link at all stays `none`", async () => {
+    const meeting = await createAdHocMeeting({
+      companyId: CO,
+      title: "Recording from yesterday",
+      scheduledStartAt: null,
+      conferenceUrl: "",
+      notetakerEmployeeId: null,
+      createdByUserId: null,
+    });
+    assert.equal(meeting.conferenceProvider, "none");
+  });
+});

--- a/App/server/services/meetings/recorder.test.ts
+++ b/App/server/services/meetings/recorder.test.ts
@@ -661,6 +661,203 @@ describe("automatic notetaker dispatch", () => {
   });
 });
 
+describe("retrying a join that did not happen", () => {
+  /**
+   * The second half of the "it never joins" bug.
+   *
+   * Dispatch only ever claimed `scheduled` rows, and a claim that failed for
+   * any reason at all settled the meeting `failed` for good. So the first
+   * flake — a lobby that had not rendered, a host who had not opened the call
+   * — wrote off the whole meeting at second one, thirty minutes before it was
+   * due to end, and no later pass ever looked at it again. `skipped` was worse
+   * still: not even a human pressing the button could re-open it.
+   */
+  test("a human may re-open a meeting the automatic pass skipped", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    installRecorder(async (args) => {
+      joined.push(args.meetingId);
+      return { bytes: Buffer.from("audio"), mime: "audio/webm", durationMs: 1 };
+    });
+    setMeetingBackgroundProcessor(() => undefined);
+    const fixture = await calendarMeeting({ now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "skipped", statusMessage: "Automatic recording was turned off for this event." },
+    );
+
+    const result = await startNotetaker({
+      companyId: CO,
+      meetingId: fixture.meeting.id,
+      retryFailed: true,
+    });
+
+    assert.equal(result.ok, true);
+    await waitForMeeting(fixture.meeting.id, (row) => row.status === "processing");
+    assert.deepEqual(joined, [fixture.meeting.id]);
+  });
+
+  test("a skipped meeting is still not re-opened without an explicit retry", async () => {
+    const now = new Date();
+    installRecorder(async () => ({ bytes: Buffer.from("a"), mime: "audio/webm", durationMs: 1 }));
+    const fixture = await calendarMeeting({ now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "skipped", statusMessage: "Automatic recording was turned off for this event." },
+    );
+
+    const result = await startNotetaker({ companyId: CO, meetingId: fixture.meeting.id });
+
+    assert.equal(result.ok, false);
+    assert.equal(
+      (await AppDataSource.getRepository(Meeting).findOneByOrFail({ id: fixture.meeting.id }))
+        .status,
+      "skipped",
+    );
+  });
+
+  test("a skipped meeting that already has audio is never re-recorded", async () => {
+    const now = new Date();
+    installRecorder(async () => ({ bytes: Buffer.from("a"), mime: "audio/webm", durationMs: 1 }));
+    const fixture = await calendarMeeting({ now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "skipped", recordingPath: "meetings/co/x.webm" },
+    );
+
+    const result = await startNotetaker({
+      companyId: CO,
+      meetingId: fixture.meeting.id,
+      retryFailed: true,
+    });
+
+    assert.equal(result.ok, false);
+  });
+
+  test("dispatch retries a failed join while the call is still running", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    installRecorder(async (args) => {
+      joined.push(args.meetingId);
+      return { bytes: Buffer.from("audio"), mime: "audio/webm", durationMs: 1 };
+    });
+    setMeetingBackgroundProcessor(() => undefined);
+    const fixture = await calendarMeeting({ now, eventStartAt: now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "failed", statusMessage: "The notetaker could not open the Google Meet lobby." },
+    );
+
+    const result = await dispatchDueMeetings(new Date(now.getTime() + 3 * 60_000));
+
+    assert.equal(result.due, 1);
+    assert.equal(result.claimed, 1);
+    assert.equal(result.retried, 1);
+    await waitForMeeting(fixture.meeting.id, (row) => row.status === "processing");
+    assert.deepEqual(joined, [fixture.meeting.id]);
+  });
+
+  test("dispatch waits out the backoff rather than retrying every tick", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    installRecorder(async (args) => {
+      joined.push(args.meetingId);
+      return { bytes: Buffer.from("audio"), mime: "audio/webm", durationMs: 1 };
+    });
+    const fixture = await calendarMeeting({ now, eventStartAt: now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "failed", statusMessage: "The notetaker could not open the Google Meet lobby." },
+    );
+
+    const result = await dispatchDueMeetings(new Date(now.getTime() + 30_000));
+
+    assert.deepEqual({ due: result.due, claimed: result.claimed, retried: result.retried }, {
+      due: 0,
+      claimed: 0,
+      retried: 0,
+    });
+    assert.deepEqual(joined, []);
+  });
+
+  test("dispatch stops retrying once the call is well under way", async () => {
+    const now = new Date();
+    installRecorder(async () => ({ bytes: Buffer.from("a"), mime: "audio/webm", durationMs: 1 }));
+    const fixture = await calendarMeeting({
+      now,
+      eventStartAt: new Date(now.getTime() - 30 * 60_000),
+      eventEndAt: new Date(now.getTime() + 30 * 60_000),
+    });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      { status: "failed", statusMessage: "The notetaker could not open the Google Meet lobby." },
+    );
+
+    const result = await dispatchDueMeetings(new Date(now.getTime() + 3 * 60_000));
+
+    assert.equal(result.due, 0);
+    assert.equal(result.retried, 0);
+  });
+
+  test("a Stop is a decision, not a flake — dispatch never undoes one", async () => {
+    const now = new Date();
+    const joined: string[] = [];
+    installRecorder(async (args) => {
+      joined.push(args.meetingId);
+      return { bytes: Buffer.from("audio"), mime: "audio/webm", durationMs: 1 };
+    });
+    const stopped = await calendarMeeting({ now, eventStartAt: now });
+    const policyStopped = await calendarMeeting({ now, eventStartAt: now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: stopped.meeting.id },
+      { status: "failed", statusMessage: STOP_NOTETAKER_MESSAGE },
+    );
+    await AppDataSource.getRepository(Meeting).update(
+      { id: policyStopped.meeting.id },
+      {
+        status: "failed",
+        statusMessage: "Notetaker stopping: Automatic recording was paused for this calendar.",
+      },
+    );
+
+    const result = await dispatchDueMeetings(new Date(now.getTime() + 3 * 60_000));
+
+    assert.equal(result.due, 0);
+    assert.deepEqual(joined, []);
+  });
+
+  test("a failed meeting that did save audio belongs in /process, not in a new call", async () => {
+    const now = new Date();
+    installRecorder(async () => ({ bytes: Buffer.from("a"), mime: "audio/webm", durationMs: 1 }));
+    const fixture = await calendarMeeting({ now, eventStartAt: now });
+    await AppDataSource.getRepository(Meeting).update(
+      { id: fixture.meeting.id },
+      {
+        status: "failed",
+        statusMessage: "Transcription failed.",
+        recordingPath: "meetings/co/kept.webm",
+      },
+    );
+
+    const result = await dispatchDueMeetings(new Date(now.getTime() + 3 * 60_000));
+
+    assert.equal(result.due, 0);
+  });
+
+  test("an ordinary scheduled meeting is still claimed as a fresh join", async () => {
+    const now = new Date();
+    installRecorder(async () => ({ bytes: Buffer.from("a"), mime: "audio/webm", durationMs: 1 }));
+    setMeetingBackgroundProcessor(() => undefined);
+    const fixture = await calendarMeeting({ now });
+
+    const result = await dispatchDueMeetings(now);
+
+    assert.equal(result.claimed, 1);
+    assert.equal(result.retried, 0, "a first attempt is not a retry");
+    await waitForMeeting(fixture.meeting.id, (row) => row.status !== "scheduled");
+  });
+});
+
 describe("stale notetaker recovery", () => {
   test("requeues a live calendar call and fails an unrecoverable ad-hoc call", async () => {
     const now = new Date();

--- a/App/server/services/meetings/recorder.ts
+++ b/App/server/services/meetings/recorder.ts
@@ -69,6 +69,32 @@ const NOTETAKER_JOIN_LEAD_MS = 30_000;
 const ACTIVE_HEARTBEAT_MS = 15_000;
 const ACTIVE_STALE_MS = 60_000;
 const MAX_DUE_PER_PASS = 50;
+/**
+ * Automatic retry, and why it is bounded twice.
+ *
+ * A join can fail for reasons that have nothing to do with this meeting: the
+ * lobby had not rendered yet, Chrome lost a race with the display, the host
+ * had not opened the call. Dispatch used to claim `scheduled` rows only, so
+ * the first such failure was final — a thirty-minute call was written off at
+ * second one and nobody was told. Retrying is therefore the correct default,
+ * but a browser and a recording are expensive, so it is bounded by a backoff
+ * (never more than one attempt per interval) and a window (only while the
+ * call has recently started), which together cap a doomed meeting at a
+ * handful of attempts rather than one every dispatch tick for an hour.
+ */
+const AUTOMATIC_RETRY_BACKOFF_MS = 2 * 60_000;
+const AUTOMATIC_RETRY_WINDOW_MS = 10 * 60_000;
+
+/**
+ * Which rows a claim may take.
+ *
+ *   - `fresh` — a `scheduled` meeting, the ordinary automatic path.
+ *   - `automatic-retry` — a `failed` meeting with no audio, retried by the
+ *     dispatcher inside the window above.
+ *   - `human-retry` — anything that never produced audio, including `skipped`,
+ *     because a person pressing the button has seen the reason and disagrees.
+ */
+type ClaimMode = "fresh" | "automatic-retry" | "human-retry";
 
 type ActiveNotetaker = {
   controller: AbortController;
@@ -749,7 +775,7 @@ async function runClaimedNotetaker(
 async function claimNotetaker(args: {
   companyId: string;
   meetingId: string;
-  retryFailed: boolean;
+  claim: ClaimMode;
 }): Promise<Meeting | null> {
   const query = AppDataSource.getRepository(Meeting)
     .createQueryBuilder()
@@ -762,12 +788,17 @@ async function claimNotetaker(args: {
     })
     .where("id = :meetingId", { meetingId: args.meetingId })
     .andWhere("companyId = :companyId", { companyId: args.companyId });
-  if (args.retryFailed) {
-    query.andWhere("(status = :scheduled OR (status = :failed AND recordingPath = :empty))", {
-      scheduled: "scheduled",
-      failed: "failed",
-      empty: "",
-    });
+  if (args.claim === "human-retry") {
+    // A human pressing the button may re-open anything that never produced
+    // audio, `skipped` included. Skipping used to be the end of the line, so
+    // a call the policy declined at 2:59 — for a Grant somebody has since
+    // fixed — could not be recorded at 3:05 even though it was still running.
+    query.andWhere(
+      "(status = :scheduled OR (status IN (:...reopenable) AND recordingPath = :empty))",
+      { scheduled: "scheduled", reopenable: ["failed", "skipped"], empty: "" },
+    );
+  } else if (args.claim === "automatic-retry") {
+    query.andWhere("status = :failed AND recordingPath = :empty", { failed: "failed", empty: "" });
   } else {
     query.andWhere("status = :scheduled", { scheduled: "scheduled" });
   }
@@ -782,7 +813,7 @@ async function claimNotetaker(args: {
 async function startNotetakerInternal(args: {
   companyId: string;
   meetingId: string;
-  retryFailed: boolean;
+  claim: ClaimMode;
   automatic: boolean;
   now?: Date;
 }): Promise<IngestResult> {
@@ -794,7 +825,11 @@ async function startNotetakerInternal(args: {
   }
 
   const driver = activeMeetingRecorder();
-  const claimed = await claimNotetaker(args);
+  const claimed = await claimNotetaker({
+    companyId: args.companyId,
+    meetingId: args.meetingId,
+    claim: args.claim,
+  });
   if (!claimed) {
     return {
       ok: false,
@@ -861,8 +896,9 @@ export async function startNotetaker(args: {
   retryFailed?: boolean;
 }): Promise<IngestResult> {
   return startNotetakerInternal({
-    ...args,
-    retryFailed: args.retryFailed === true,
+    companyId: args.companyId,
+    meetingId: args.meetingId,
+    claim: args.retryFailed === true ? "human-retry" : "fresh",
     automatic: false,
   });
 }
@@ -1020,6 +1056,8 @@ export async function recoverStaleNotetakers(
 export type DueDispatchResult = {
   due: number;
   claimed: number;
+  /** How many of `claimed` were second attempts at a call already in progress. */
+  retried: number;
   recovered: number;
   recoveryFailed: number;
 };
@@ -1028,6 +1066,8 @@ export type DueDispatchResult = {
 export async function dispatchDueMeetings(now = new Date()): Promise<DueDispatchResult> {
   const recovery = await recoverStaleNotetakers(now);
   const joinBy = new Date(now.getTime() + NOTETAKER_JOIN_LEAD_MS);
+  const retryBefore = new Date(now.getTime() - AUTOMATIC_RETRY_BACKOFF_MS);
+  const retryFrom = new Date(now.getTime() - AUTOMATIC_RETRY_WINDOW_MS);
   const due = await AppDataSource.getRepository(Meeting)
     .createQueryBuilder("meeting")
     .innerJoin(
@@ -1035,7 +1075,27 @@ export async function dispatchDueMeetings(now = new Date()): Promise<DueDispatch
       "event",
       "event.id = meeting.calendarEventId AND event.companyId = meeting.companyId",
     )
-    .where("meeting.status = :status", { status: "scheduled" })
+    .where(
+      `(meeting.status = :scheduled
+        OR (meeting.status = :failed
+            AND meeting.recordingPath = :noRecording
+            AND meeting.updatedAt <= :retryBefore
+            AND event.startAt >= :retryFrom
+            AND meeting.statusMessage <> :stopped
+            AND meeting.statusMessage NOT LIKE :policyStopped))`,
+      {
+        scheduled: "scheduled",
+        failed: "failed",
+        noRecording: "",
+        retryBefore,
+        retryFrom,
+        // A human Stop and a policy stop are decisions, not accidents. Retrying
+        // either would put the notetaker back into a call somebody removed it
+        // from, which is the one failure mode worse than not joining at all.
+        stopped: STOP_NOTETAKER_MESSAGE,
+        policyStopped: `${POLICY_STOP_PREFIX}%`,
+      },
+    )
     .andWhere("event.startAt <= :joinBy", { joinBy })
     .andWhere("event.endAt > :now", { now })
     .orderBy("event.startAt", "ASC")
@@ -1043,19 +1103,25 @@ export async function dispatchDueMeetings(now = new Date()): Promise<DueDispatch
     .getMany();
 
   let claimed = 0;
+  let retried = 0;
   for (const meeting of due) {
+    const claim: ClaimMode = meeting.status === "failed" ? "automatic-retry" : "fresh";
     const result = await startNotetakerInternal({
       companyId: meeting.companyId,
       meetingId: meeting.id,
-      retryFailed: false,
+      claim,
       automatic: true,
       now,
     });
-    if (result.ok) claimed += 1;
+    if (result.ok) {
+      claimed += 1;
+      if (claim === "automatic-retry") retried += 1;
+    }
   }
   return {
     due: due.length,
     claimed,
+    retried,
     recovered: recovery.recovered,
     recoveryFailed: recovery.failed,
   };

--- a/App/server/services/meetings/store.ts
+++ b/App/server/services/meetings/store.ts
@@ -7,6 +7,7 @@ import { Meeting, type MeetingStatus } from "../../db/entities/Meeting.js";
 import { MeetingParticipant } from "../../db/entities/MeetingParticipant.js";
 import { MeetingTranscriptSegment } from "../../db/entities/MeetingTranscriptSegment.js";
 import { normalizeEmail } from "../../lib/emailAddress.js";
+import { providerForUrl } from "./conference.js";
 import { companyDomains, isInternalAddress } from "./domains.js";
 import type { StoredAttendee } from "./calendarSync.js";
 
@@ -297,6 +298,13 @@ export async function createAdHocMeeting(args: {
       title: args.title,
       scheduledStartAt: args.scheduledStartAt,
       conferenceUrl: args.conferenceUrl,
+      // Named from the link rather than left at `none`. The meeting page keys
+      // its "Start notetaker" affordance off the provider, so an ad-hoc call
+      // whose provider never got filled in reads as "there is nothing to
+      // join" even with a perfectly good Meet link sitting on the row.
+      conferenceProvider: args.conferenceUrl
+        ? (providerForUrl(args.conferenceUrl) ?? "other")
+        : "none",
       notetakerEmployeeId: args.notetakerEmployeeId,
       createdByUserId: args.createdByUserId,
       status: "scheduled",

--- a/Home/client/docs/pages/Meetings.tsx
+++ b/Home/client/docs/pages/Meetings.tsx
@@ -74,16 +74,17 @@ export function Meetings() {
       <H2 id="recording">Capturing a meeting</H2>
       <P>
         Open any meeting from <Strong>Meetings → Recorded</Strong>, or press{" "}
-        <Strong>New meeting</Strong> on the agenda for a call that was never on a calendar. Then
-        either:
+        <Strong>New meeting</Strong> on the agenda for a call that was never on a calendar — that
+        form takes a Google Meet link and a notetaker, so an ad-hoc call can be joined and recorded
+        exactly like a calendar one. Then either:
       </P>
       <UL>
         <LI>
           <Strong>Start notetaker</Strong> — available on a scheduled Google Meet, or after a join
-          attempt failed before it saved a recording. Genosyn joins as a disclosed guest and waits
-          for somebody in the call to admit it. The meeting page shows the joining and recording
-          state while it works. Press <Strong>Stop notetaker</Strong> to make it leave; audio
-          already captured is saved and processed.
+          attempt failed or was skipped before it saved a recording. Genosyn joins as a disclosed
+          guest and waits for somebody in the call to admit it. The meeting page shows the joining
+          and recording state while it works. Press <Strong>Stop notetaker</Strong> to make it
+          leave; audio already captured is saved and processed.
         </LI>
         <LI>
           <Strong>Upload a recording</Strong> — mp3, m4a, wav, webm, ogg, flac, mp4, or mov, up to
@@ -141,18 +142,29 @@ export function Meetings() {
         </LI>
       </UL>
       <P>
-        A calendar also has to name a <Strong>notetaker</Strong> — the AI Employee that writes the
-        meeting up — and that employee needs a <Strong>Record</Strong> Grant for the calendar under
-        {" "}
-        <Strong>Meetings → AI access</Strong>. Without both, nothing is recorded automatically,
-        because a recording nobody reads is not worth taking.
+        A calendar also has to name a <Strong>notetaker</Strong> — the AI Employee that records the
+        call and writes it up. Naming one gives that employee a <Strong>Record</Strong> Grant for
+        this calendar, which is the authority the notetaker actually joins under; it appears under{" "}
+        <Strong>Meetings → AI access</Strong>, where you can review or revoke it like any other
+        Grant. Without a notetaker nothing is recorded automatically, because a recording nobody
+        reads is not worth taking.
       </P>
       <P>
         Shortly before a qualifying meeting starts, Genosyn opens its Google Meet link under the
-        selected employee&apos;s name followed by <Code>(AI notetaker — recording)</Code>. It waits
-        for the host to admit it, captures the call audio inside the App container, stores that
-        recording with the meeting, and transcribes it after the call ends. The notetaker does not
-        turn on a camera or present itself as a human attendee.
+        selected employee&apos;s name followed by <Code>(AI notetaker — recording)</Code>. It
+        dismisses Google&apos;s pre-join prompts, keeps its microphone and camera off, and waits to
+        be admitted for as long as the call is scheduled to run (up to 30 minutes), asking again if
+        Google times its first request out — so a host who joins late still gets a notetaker. Then
+        it captures the call audio inside the App container, stores that recording with the
+        meeting, and transcribes it after the call ends. The notetaker does not turn on a camera or
+        present itself as a human attendee.
+      </P>
+      <P>
+        If a join fails while the call is still running — the lobby was not ready, nobody had
+        started the meeting yet — Genosyn tries again a couple of times over the first few minutes
+        rather than writing the meeting off. A meeting it decided <em>not</em> to record says so on
+        the meeting page, and <Strong>Start notetaker</Strong> is still there if you disagree and
+        the call is still live.
       </P>
       <Callout kind="info" title="The standard Docker install includes meeting presence.">
         The App image includes Chrome, PulseAudio, and ffmpeg, so the normal Docker installation
@@ -225,6 +237,13 @@ export function Meetings() {
           live-join support for other conference platforms.
         </LI>
       </UL>
+      <P>
+        Naming an employee as a calendar&apos;s notetaker under{" "}
+        <Strong>Meetings → Calendars</Strong> gives it <Strong>Record</Strong> on that calendar, so
+        the two controls cannot disagree. The Grant shows up in this table and can be revoked here;
+        revoking it stops the notetaker joining that calendar&apos;s calls, and the meeting page
+        says so.
+      </P>
       <P>The tools an employee gets, once granted:</P>
       <UL>
         <LI>


### PR DESCRIPTION
Milestone: **M44 — Calendar + Meetings**.

## The bug

The notetaker never joined a Google Meet. Not intermittently — never.

`validateClaimedJoin` gates every calendar-backed join on an
`EmployeeCalendarGrant` at `record`
([recorder.ts:418](../blob/main/App/server/services/meetings/recorder.ts#L418), and again on
the live heartbeat at :526). The only thing in the product that ever wrote that
row was `PUT /meetings/ai-access`. The setup flow an operator actually
follows — Meetings → Calendars → *Record automatically* → pick a *Notetaker* —
wrote two columns on `calendar_accounts` and no Grant, while the same page
promised "Eligible Google Meets are joined by the notetaker".

So the calendar armed the meeting, the dispatcher claimed it, authority was
re-checked, and the call was refused — settled `skipped`, with the reason
written to `statusMessage`, a column `MeetingDetail` renders **only** when the
status is `failed`. The notetaker did not turn up and nothing anywhere said
why.

All 88 meetings tests passed throughout, because every one of them inserts that
Grant by hand. The new
`server/services/meetings/notetakerSetup.test.ts` is written against the
operator's flow instead, and fails on `main`.

The manual escape hatch was blocked too: *New meeting* collects only a title
and attendees, and `createAdHocMeeting` never derived `conferenceProvider` from
the link — so `canStartNotetaker` (`provider === "meet" && conferenceUrl`)
could not become true for any ad-hoc meeting either.

Found by a 135-agent review of the join path, with each candidate cause
adversarially verified; 14 of 43 survived.

## What changed

**Authority.** Naming a notetaker on a calendar is now the act that grants that
employee `record` on it — same admin gate, same resource, and the Grant still
shows up (and is revocable) on AI access. It only ever upgrades, and
un-assigning revokes nothing a human may have granted separately. An employee
from another company is a 400 rather than a silent skip an hour later.

**Retry.** A skip or a first failure was terminal, so one unready lobby wrote
off a call half an hour before it was due to end. Dispatch now retries a failed
join while the call is young — bounded by a 2-minute backoff and a 10-minute
window — and a person may re-open anything that never produced audio,
`skipped` included. A Stop, human or policy, is a decision and is never undone.

**The Meet lobby.** Meet blocks on a `getUserMedia` a container cannot answer;
the driver denied the microphone outright and checked for interstitials once,
before the SPA had rendered, so the modal device dialog sat over the join
button until the deadline. The recorder now brings its own null **source** —
real silence, never the sink monitor it is recording, which would have been a
feedback loop — and the lobby is a polling loop that closes dialogs whenever
they appear and treats a lost click as one wasted pass, not a failed call.

**Admission window.** Five minutes flat, measured from 30s *before* the start,
meant giving up at 4m30s past the hour. It now waits as long as the call is
scheduled to run (capped at 30 minutes) and asks again when Google times the
first request out, so a late host still gets a notetaker.

**`maxRecordingBytes`** was a getter on an object that is spread — which calls
it and copies the number. The operator-editable cap was frozen at module load.

**Also:** ad-hoc meetings take a Meet link and a notetaker (the notetaker is
also whose model transcribes, so one without it stays a recording forever);
`/lookup/` Meet aliases armed and were then refused by the driver; skip and
defer reasons are rendered; a Stop during `goto` no longer reports itself as a
broken lobby.

## Tests

148 pass (88 before). 37 new, plus 23 route tests unchanged.

- `notetakerSetup.test.ts` — the setup flow end to end, including
  *connect → record automatically → pick a notetaker → the guest joins*, which
  fails on `main`. Grant upgrade/idempotence/scoping, cross-company refusal,
  revocation still stopping a join, ad-hoc provider naming.
- `recorder.test.ts` — human retry of `skipped`, automatic retry inside the
  window, no retry inside the backoff, none once the call is well under way,
  none after a human or policy Stop, none when audio already exists.
- `googleMeetRecorder.test.ts` — the admission window's four cases; the device
  dialog, a late interstitial, re-asking after "no one responded", a click that
  loses a race, an already-admitted guest, an ended call, a guests-disabled
  call, Stop; the silent source and its `PULSE_SOURCE`/permission/cleanup, the
  fallback when PulseAudio has no `module-null-source`, the live byte cap, and
  lookup-alias URLs.
- `meetingsRoleGate.test.ts` — assigning a notetaker over the API leaves a
  Record grant visible on `GET /meetings/ai-access`; a cross-company notetaker
  is a 400.

`npm run lint`, `npm run typecheck`, and `npm run build` are clean (5
pre-existing warnings, none in these files). Docs updated at
`Home/client/docs/pages/Meetings.tsx`.

## Manual test steps

Not run — this needs a real Google Workspace calendar, a live Meet, and the
container's Chrome/PulseAudio/ffmpeg stack, none of which exist in this
environment. Worth walking before merge: connect a calendar, set *Every Google
Meet* + a notetaker, confirm the Record Grant appears on AI access, put a Meet
on the calendar, and watch the disclosed guest ask to join and be admitted.
