### PR TITLE
Make the Repository Overview about AI work (M65)

### DIFF
--- a/App/client/components/repositories/AiWorkOverview.test.ts
+++ b/App/client/components/repositories/AiWorkOverview.test.ts
@@ -1,0 +1,440 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StaticRouter } from "react-router-dom";
+
+import type {
+  RepositoryAiActivity,
+  RepositoryAiEmployeeWork,
+  RepositoryAiOverview,
+  RepositoryGrant,
+  RepositoryWorkSession,
+} from "../../lib/api.js";
+import type { RepositoryAiGlance } from "./aiOverview.js";
+import { AiEmployeeRow, AiSessionRow, AiWorkOverview } from "./AiWorkOverview.js";
+
+/**
+ * The Repository Overview's AI section, rendered.
+ *
+ * The App has no browser-like DOM, so these render to a static markup string —
+ * which is enough for the contracts that actually decide whether the page is
+ * worth looking at. A running session has to say what the employee is doing
+ * this second, not print "Working" beside a spinner; every listed session has
+ * to be a link to the place it can be acted on; a band with nothing in it must
+ * not be drawn; and a read that has not landed yet must never be reported as a
+ * quiet repository. The wording itself is pinned next door in
+ * `aiOverview.test.ts` — what is pinned here is which wording the components
+ * choose, and what they leave out.
+ */
+
+const AT = "2024-05-01T12:00:00.000Z";
+const COMPANY = "company-1";
+const AI_BASE = "/companies/company-1/repositories/api/ai";
+const ACCESS_HREF = "/companies/company-1/repositories/api/access";
+
+function session(overrides: Partial<RepositoryWorkSession> = {}): RepositoryWorkSession {
+  return {
+    id: "sess-1",
+    companyId: COMPANY,
+    repositoryId: "repo-1",
+    employeeId: "emp-1",
+    requestedByUserId: null,
+    title: "Add a health check endpoint",
+    instruction: "Add a health check endpoint",
+    status: "ready",
+    branch: "genosyn/sess-1",
+    baseCommit: null,
+    headCommit: null,
+    reply: "",
+    error: "",
+    turnCount: 1,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    publishedBranch: null,
+    pullRequestUrl: null,
+    pullRequestNumber: null,
+    finishedAt: null,
+    archivedAt: null,
+    createdAt: AT,
+    updatedAt: AT,
+    employee: { id: "emp-1", name: "Rey", slug: "rey", avatarKey: null },
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<RepositoryAiActivity> = {}): RepositoryAiActivity {
+  return {
+    sessionId: "sess-1",
+    summary: "Ran npm test → Exit 1",
+    at: AT,
+    steps: { done: 2, total: 7, current: "Fix the failing test" },
+    toolCalls: 24,
+    ...overrides,
+  };
+}
+
+function work(overrides: Partial<RepositoryAiEmployeeWork> = {}): RepositoryAiEmployeeWork {
+  return {
+    employeeId: "emp-1",
+    sessions: 8,
+    landed: 5,
+    filesChanged: 12,
+    insertions: 900,
+    deletions: 120,
+    lastActiveAt: AT,
+    ...overrides,
+  };
+}
+
+function overview(overrides: Partial<RepositoryAiOverview> = {}): RepositoryAiOverview {
+  return {
+    counts: { total: 1, running: 0, attention: 1, completed: 0, archived: 0 },
+    landed: { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0 },
+    totals: { turns: 1, discarded: 0 },
+    lastActiveAt: AT,
+    employees: [],
+    capped: false,
+    sessions: [session()],
+    activity: [],
+    ...overrides,
+  };
+}
+
+function glance(overrides: Partial<RepositoryAiGlance> = {}): RepositoryAiGlance {
+  return {
+    counts: { total: 1, running: 0, attention: 1, completed: 0, archived: 0 },
+    landed: { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0 },
+    granted: 1,
+    workingNames: [],
+    ...overrides,
+  };
+}
+
+function grant(overrides: Partial<RepositoryGrant> = {}): RepositoryGrant {
+  return {
+    id: "grant-1",
+    employeeId: "emp-1",
+    repositoryId: "repo-1",
+    accessLevel: "write",
+    createdAt: AT,
+    employee: {
+      id: "emp-1",
+      name: "Rey",
+      slug: "rey",
+      role: "Backend engineer",
+      avatarKey: null,
+      pullRequestReady: false,
+    },
+    ...overrides,
+  };
+}
+
+/** Every component here renders a react-router `Link` somewhere below it. */
+function render(element: React.ReactElement): string {
+  return renderToStaticMarkup(React.createElement(StaticRouter, null, element));
+}
+
+function renderRow(props: Partial<React.ComponentProps<typeof AiSessionRow>> = {}): string {
+  return render(
+    React.createElement(AiSessionRow, {
+      companyId: COMPANY,
+      session: session(),
+      activity: null,
+      href: `${AI_BASE}/sess-1`,
+      ...props,
+    }),
+  );
+}
+
+function renderOverview(props: Partial<React.ComponentProps<typeof AiWorkOverview>> = {}): string {
+  return render(
+    React.createElement(AiWorkOverview, {
+      companyId: COMPANY,
+      overview: overview(),
+      error: null,
+      glance: glance(),
+      grants: null,
+      aiBase: AI_BASE,
+      accessHref: ACCESS_HREF,
+      onRetry: async () => undefined,
+      ...props,
+    }),
+  );
+}
+
+describe("a session row", () => {
+  test("tells a reader what a running employee is doing right now", () => {
+    const html = renderRow({
+      session: session({ status: "running" }),
+      activity: activity(),
+    });
+    assert.match(html, /Ran npm test → Exit 1/);
+    assert.match(html, /Step 3 of 7/);
+    assert.match(html, /24 tool calls/);
+    // The row must not fall back to the status phrase — "Working now" is what
+    // a spinner already said.
+    assert.doesNotMatch(html, /Working now/);
+  });
+
+  test("says a turn is starting rather than nothing when no event has landed", () => {
+    const html = renderRow({ session: session({ status: "running" }), activity: null });
+    assert.match(html, /Starting…/);
+    assert.doesNotMatch(html, /Step \d+ of \d+/);
+    assert.doesNotMatch(html, /tool call/);
+  });
+
+  test("asks a finished session's reader for a decision, not for progress", () => {
+    const html = renderRow({ session: session({ status: "ready" }), activity: activity() });
+    assert.match(html, /Read the diff and decide/);
+    // Step and tool-call counts belong to a turn in flight. A session that
+    // ended an hour ago is not on step 3 of anything.
+    assert.doesNotMatch(html, /Step 3 of 7/);
+    assert.doesNotMatch(html, /tool call/);
+  });
+
+  test("is an anchor to the session's own page under the AI work base", () => {
+    const html = renderRow({
+      session: session({ id: "sess-9" }),
+      href: `${AI_BASE}/sess-9`,
+    });
+    assert.match(html, /^<li><a /);
+    assert.match(html, /href="\/companies\/company-1\/repositories\/api\/ai\/sess-9"/);
+  });
+
+  test("still renders a session whose employee was removed", () => {
+    const html = renderRow({ session: session({ employee: null }) });
+    assert.match(html, /<span class="truncate">Removed employee<\/span>/);
+    assert.match(html, /Add a health check endpoint/);
+  });
+
+  test("prints a diffstat only when the session changed something", () => {
+    assert.doesNotMatch(renderRow(), /files? · \+/);
+    const changed = renderRow({
+      session: session({ filesChanged: 4, insertions: 120, deletions: 8 }),
+    });
+    assert.match(changed, /4 files · \+120 · −8/);
+  });
+});
+
+describe("the AI work bands", () => {
+  test("does not draw a band with nothing in it", () => {
+    const html = renderOverview({
+      overview: overview({
+        counts: { total: 2, running: 0, attention: 1, completed: 1, archived: 0 },
+        sessions: [session(), session({ id: "sess-2", status: "published" })],
+      }),
+      glance: glance({ counts: { total: 2, running: 0, attention: 1, completed: 1, archived: 0 } }),
+    });
+    assert.match(html, /<h3[^>]*>Needs you<\/h3>/);
+    assert.match(html, /<h3[^>]*>Recently decided<\/h3>/);
+    assert.doesNotMatch(html, /<h3[^>]*>Working now<\/h3>/);
+  });
+
+  test("heads a band it does draw with its name and its count", () => {
+    const html = renderOverview({
+      overview: overview({
+        counts: { total: 2, running: 0, attention: 2, completed: 0, archived: 0 },
+        sessions: [session(), session({ id: "sess-2" })],
+      }),
+      glance: glance({ counts: { total: 2, running: 0, attention: 2, completed: 0, archived: 0 } }),
+    });
+    assert.match(html, /<h3[^>]*>Needs you<\/h3><span[^>]*>2<\/span>/);
+  });
+});
+
+describe("the stat strip", () => {
+  test("is absent on a repository that has never had a session", () => {
+    const html = renderOverview({
+      overview: overview({
+        counts: { total: 0, running: 0, attention: 0, completed: 0, archived: 0 },
+        sessions: [],
+      }),
+      glance: glance({ counts: { total: 0, running: 0, attention: 0, completed: 0, archived: 0 } }),
+    });
+    assert.doesNotMatch(html, /Lines accepted/);
+    assert.doesNotMatch(html, /Waiting for you<\/div>/);
+  });
+
+  test("is present as soon as one session exists", () => {
+    const html = renderOverview();
+    assert.match(html, /Lines accepted/);
+    assert.match(html, /None of 1 session has been accepted\./);
+  });
+});
+
+describe("the AI work section as a whole", () => {
+  test("says it is still reading rather than reporting a quiet repository", () => {
+    const html = renderOverview({
+      overview: null,
+      error: null,
+      glance: glance({
+        counts: { total: 5, running: 0, attention: 0, completed: 5, archived: 0 },
+        landed: { sessions: 2, filesChanged: 9, insertions: 400, deletions: 30 },
+      }),
+    });
+    assert.match(html, /Reading back the AI work…/);
+    assert.doesNotMatch(html, /Nothing is running/);
+    // No bands, no strip, no "0 sessions" — nothing that would read as an answer.
+    assert.doesNotMatch(html, /<h3[^>]*>Recently decided<\/h3>/);
+    assert.doesNotMatch(html, /Lines accepted/);
+  });
+
+  test("puts a failed read on the page with a retry and leaves the page usable", () => {
+    const html = renderOverview({
+      overview: null,
+      error: "Could not read the AI work.",
+      glance: glance(),
+    });
+    assert.match(html, /role="alert"/);
+    assert.match(html, /Could not read the AI work\./);
+    assert.match(html, /Retry/);
+    // A failure is not a loading state, and it does not take the way out with it.
+    assert.doesNotMatch(html, /Reading back the AI work/);
+    assert.match(html, /Start a work session/);
+    assert.match(html, /href="\/companies\/company-1\/repositories\/api\/ai"/);
+  });
+
+  test("never states the repository's state from a read that failed", () => {
+    // The old guard only covered loading, so a 500 printed "No AI employee can
+    // work in this repository yet." immediately above the alert saying the work
+    // could not be read.
+    const closed = renderOverview({
+      overview: null,
+      error: "Could not read the AI work.",
+      glance: glance(),
+    });
+    assert.match(closed, /The AI work here could not be read\./);
+    assert.doesNotMatch(closed, /No AI employee can work in this repository yet/);
+
+    const granted = renderOverview({
+      overview: null,
+      error: "Could not read the AI work.",
+      glance: glance({ granted: 1 }),
+      grants: [grant()],
+    });
+    assert.doesNotMatch(granted, /can work here\. None has yet/);
+  });
+
+  test("says nothing about an employee's tally before the digest has landed", () => {
+    // The grants read and the work read are independent, and grants usually win
+    // the race — so "No work here yet" under a busy employee would be a lie the
+    // page tells for as long as the other request takes.
+    const pending = renderOverview({ overview: null, error: null, grants: [grant()] });
+    assert.match(pending, /Rey/);
+    assert.doesNotMatch(pending, /No work here yet/);
+
+    const failed = renderOverview({
+      overview: null,
+      error: "Could not read the AI work.",
+      grants: [grant()],
+    });
+    assert.doesNotMatch(failed, /No work here yet/);
+  });
+
+  test("links onward only when the digest listed fewer sessions than it counted", () => {
+    const listed = [session(), session({ id: "sess-2" }), session({ id: "sess-3" })];
+    const counted = { total: 12, running: 0, attention: 3, completed: 7, archived: 2 };
+    assert.match(
+      renderOverview({
+        overview: overview({ counts: counted, sessions: listed }),
+        glance: glance({ counts: counted }),
+      }),
+      /7 more in AI work/,
+    );
+    const all = { total: 5, running: 0, attention: 3, completed: 0, archived: 2 };
+    assert.doesNotMatch(
+      renderOverview({
+        overview: overview({ counts: all, sessions: listed }),
+        glance: glance({ counts: all }),
+      }),
+      /more in AI work/,
+    );
+  });
+});
+
+describe("who works here", () => {
+  test("says nothing at all until the grants read lands", () => {
+    const html = renderOverview({ grants: null });
+    assert.doesNotMatch(html, /Who works here/);
+    assert.doesNotMatch(html, /No AI employee has access yet/);
+  });
+
+  test("asks for a grant once it knows there is none", () => {
+    const html = renderOverview({ grants: [] });
+    assert.match(html, /No AI employee has access yet/);
+    assert.match(html, /href="\/companies\/company-1\/repositories\/api\/access"/);
+    assert.doesNotMatch(html, /Who works here/);
+  });
+
+  test("lists one row per grant, each with what that employee has actually done", () => {
+    const html = renderOverview({
+      overview: overview({ employees: [work()] }),
+      grants: [
+        grant(),
+        grant({
+          id: "grant-2",
+          employeeId: "emp-2",
+          employee: {
+            id: "emp-2",
+            name: "Kaya",
+            slug: "kaya",
+            role: "Reviewer",
+            avatarKey: null,
+            pullRequestReady: false,
+          },
+        }),
+      ],
+    });
+    assert.match(html, /Who works here/);
+    assert.match(html, /8 sessions · 5 accepted · \+900 \/ −120/);
+    // The grant says an employee may work here; the tally says whether it has.
+    assert.match(html, /No work here yet/);
+    assert.match(html, /Manage AI access/);
+  });
+});
+
+describe("an employee row", () => {
+  function renderEmployee(props: Partial<React.ComponentProps<typeof AiEmployeeRow>> = {}): string {
+    return renderToStaticMarkup(
+      React.createElement(AiEmployeeRow, {
+        companyId: COMPANY,
+        grant: grant(),
+        work: null,
+        workKnown: true,
+        ...props,
+      }),
+    );
+  }
+
+  test("claims a pull request only for an employee that can open one", () => {
+    assert.doesNotMatch(renderEmployee(), /Can open pull requests/);
+    const ready = renderEmployee({
+      grant: grant({
+        employee: {
+          id: "emp-1",
+          name: "Rey",
+          slug: "rey",
+          role: "Backend engineer",
+          avatarKey: null,
+          pullRequestReady: true,
+        },
+      }),
+    });
+    assert.match(ready, /Can open pull requests/);
+  });
+
+  test("states the access level as what it lets the employee do", () => {
+    assert.match(renderEmployee({ grant: grant({ accessLevel: "write" }) }), /Can prepare work/);
+    const read = renderEmployee({ grant: grant({ accessLevel: "read" }) });
+    assert.match(read, /Read only/);
+    assert.doesNotMatch(read, /Can prepare work/);
+  });
+
+  test("names an employee that was removed instead of dropping the row", () => {
+    const html = renderEmployee({ grant: grant({ employee: null }) });
+    assert.match(html, /Removed employee/);
+    assert.doesNotMatch(html, /Can open pull requests/);
+  });
+});

--- a/App/client/components/repositories/AiWorkOverview.tsx
+++ b/App/client/components/repositories/AiWorkOverview.tsx
@@ -1,0 +1,434 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ArrowRight, Bot, GitPullRequest, Sparkles, Users } from "lucide-react";
+import { Avatar, employeeAvatarUrl } from "../ui/Avatar";
+import { Spinner } from "../ui/Spinner";
+import { buttonClassName } from "../ui/Button";
+import { formatRelative } from "../decisions/relative";
+import { DOT_CLASS, InlineRetry, TONE_CLASS } from "./sessionChrome";
+import { SESSION_STATUS_LABEL, SESSION_STATUS_TONE, sessionTitle } from "./sessionState";
+import {
+  AI_OVERVIEW_GROUP_LABEL,
+  AI_OVERVIEW_GROUP_ORDER,
+  activityBySession,
+  activityLine,
+  cappedNote,
+  diffstatLabel,
+  employeeWorkById,
+  employeeWorkLabel,
+  groupAiOverviewSessions,
+  landedSentence,
+  overviewSessionHref,
+  repositoryAiHeading,
+  repositoryAiStats,
+  sessionNextStep,
+  stepsLabel,
+  toolCallsLabel,
+  type RepositoryAiGlance,
+  type RepositoryAiStat,
+} from "./aiOverview";
+import type {
+  RepositoryAiActivity,
+  RepositoryAiEmployeeWork,
+  RepositoryAiOverview,
+  RepositoryAiSessionRow,
+  RepositoryGrant,
+} from "../../lib/api";
+
+/**
+ * The Repository Overview page, as far as AI work is concerned.
+ *
+ * Everything visual for the subject the page now leads with. It is a component
+ * file rather than page JSX so it can be rendered in a test: the App has no
+ * browser-like DOM, but `renderToStaticMarkup` is enough to pin the contracts
+ * that matter here — that a running session announces what the employee is
+ * doing rather than a bare spinner, that every listed session is a link to the
+ * place it can be acted on, and that a band with nothing in it is not drawn at
+ * all.
+ *
+ * Wording lives next door in `aiOverview.ts`, which knows nothing about React.
+ */
+
+export function AiWorkStatStrip({ stats }: { stats: RepositoryAiStat[] }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {stats.map((stat) => (
+        <div
+          key={stat.key}
+          className="rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900"
+        >
+          <div className="text-xs text-slate-500 dark:text-slate-400">{stat.label}</div>
+          <div className="mt-2 truncate text-sm font-semibold tabular-nums text-slate-900 dark:text-slate-100">
+            {stat.value}
+          </div>
+          {stat.hint && (
+            <div className="mt-0.5 truncate text-[11px] text-slate-400 dark:text-slate-500">
+              {stat.hint}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One session, as the overview lists it.
+ *
+ * A running session leads with what the employee is doing *right now* — the
+ * newest line out of its activity feed — because a row that only says
+ * &ldquo;Working&rdquo; is a spinner with extra steps. Everything else leads
+ * with what the reader is being asked to do about it.
+ */
+export function AiSessionRow({
+  companyId,
+  session,
+  activity,
+  href,
+}: {
+  companyId: string;
+  session: RepositoryAiSessionRow;
+  activity?: RepositoryAiActivity | null;
+  href: string;
+}) {
+  const running = session.status === "running";
+  const tone = SESSION_STATUS_TONE[session.status];
+  const employeeName = session.employee?.name ?? "Removed employee";
+  const diffstat = diffstatLabel(session);
+  const steps = running ? stepsLabel(activity?.steps) : "";
+  const calls = running ? toolCallsLabel(activity) : "";
+
+  return (
+    <li>
+      <Link
+        to={href}
+        className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/60"
+      >
+        <Avatar
+          name={employeeName}
+          kind="ai"
+          size="sm"
+          className="mt-0.5 shrink-0"
+          src={
+            session.employee
+              ? employeeAvatarUrl(companyId, session.employee.id, session.employee.avatarKey)
+              : null
+          }
+        />
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className="truncate text-[13px] font-medium text-slate-800 dark:text-slate-100">
+              {sessionTitle(session)}
+            </span>
+            <span
+              className={
+                "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium " +
+                TONE_CLASS[tone]
+              }
+            >
+              {running ? (
+                <Spinner size={9} />
+              ) : (
+                <span className={"h-1.5 w-1.5 rounded-full " + DOT_CLASS[tone]} />
+              )}
+              {SESSION_STATUS_LABEL[session.status]}
+            </span>
+          </span>
+          <span className="mt-1 block truncate text-xs text-slate-600 dark:text-slate-300">
+            {running ? activityLine(activity) : sessionNextStep(session)}
+          </span>
+          <span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-slate-400 dark:text-slate-500">
+            <span className="truncate">{employeeName}</span>
+            {steps && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="shrink-0 tabular-nums">{steps}</span>
+              </>
+            )}
+            {calls && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="shrink-0 tabular-nums">{calls}</span>
+              </>
+            )}
+            {diffstat && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="shrink-0 font-mono tabular-nums">{diffstat}</span>
+              </>
+            )}
+            <span aria-hidden>·</span>
+            <span className="shrink-0">{formatRelative(session.updatedAt)}</span>
+          </span>
+        </span>
+        {session.pullRequestUrl && (
+          <GitPullRequest size={14} className="mt-1 shrink-0 text-slate-400" aria-hidden />
+        )}
+      </Link>
+    </li>
+  );
+}
+
+/** A titled list of sessions. Never rendered empty — the caller checks first. */
+export function AiWorkBand({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+      <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-4 py-2.5 dark:border-slate-800">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+          {title}
+        </h3>
+        <span className="font-mono text-[11px] tabular-nums text-slate-300 dark:text-slate-600">
+          {count}
+        </span>
+      </div>
+      <ul className="divide-y divide-slate-100 dark:divide-slate-800">{children}</ul>
+    </section>
+  );
+}
+
+/**
+ * One employee that may work here, and what it has actually done.
+ *
+ * The grant is the fact that it *may*; the tally is the fact that it *has*.
+ * Showing the first without the second is how the old page managed to print
+ * &ldquo;4 employees&rdquo; on a repository no employee had ever touched.
+ */
+export function AiEmployeeRow({
+  companyId,
+  grant,
+  work,
+  workKnown,
+}: {
+  companyId: string;
+  grant: RepositoryGrant;
+  work?: RepositoryAiEmployeeWork | null;
+  /**
+   * Whether the digest has landed. The grants read and the work read are
+   * independent, and grants usually win the race — so without this the roster
+   * would print "No work here yet" under an employee that has landed a dozen
+   * sessions, purely because the other request had not come back.
+   */
+  workKnown: boolean;
+}) {
+  const employee = grant.employee;
+  const name = employee?.name ?? "Removed employee";
+  return (
+    <li className="flex items-center gap-3 px-4 py-3">
+      <Avatar
+        name={name}
+        kind="ai"
+        size="sm"
+        className="shrink-0"
+        src={employee ? employeeAvatarUrl(companyId, employee.id, employee.avatarKey) : null}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="truncate text-[13px] font-medium text-slate-800 dark:text-slate-100">
+            {name}
+          </span>
+          <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            {grant.accessLevel === "write" ? "Can prepare work" : "Read only"}
+          </span>
+          {employee?.pullRequestReady && (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300">
+              <GitPullRequest size={9} /> Can open pull requests
+            </span>
+          )}
+        </div>
+        {workKnown && (
+          <div className="mt-0.5 truncate text-[11px] text-slate-400 dark:text-slate-500">
+            {employeeWorkLabel(work)}
+            {work?.lastActiveAt ? ` · ${formatRelative(work.lastActiveAt)}` : ""}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function StripSkeleton() {
+  return (
+    <div className="grid animate-pulse gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {[0, 1, 2, 3].map((key) => (
+        <div
+          key={key}
+          className="h-[74px] rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900"
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The whole AI-work section of the Repository Overview.
+ *
+ * Bands hide themselves when empty, exactly as Home's panels do: an empty
+ * queue is not news, and six cards saying nothing is what pushed the one thing
+ * that did need a person below the fold there. What a repository with no AI
+ * work at all gets instead is one sentence and the button that starts some.
+ */
+export function AiWorkOverview({
+  companyId,
+  overview,
+  error,
+  glance,
+  grants,
+  aiBase,
+  accessHref,
+  onRetry,
+}: {
+  companyId: string;
+  /** Null until the first read lands. */
+  overview: RepositoryAiOverview | null;
+  error: string | null;
+  glance: RepositoryAiGlance;
+  /** Null until the grants read lands; `[]` when nobody is granted. */
+  grants: RepositoryGrant[] | null;
+  aiBase: string;
+  accessHref: string;
+  onRetry: () => Promise<void>;
+}) {
+  const bands = groupAiOverviewSessions(overview?.sessions ?? []);
+  const activity = activityBySession(overview?.activity ?? []);
+  const work = employeeWorkById(overview?.employees ?? []);
+  const read = overview !== null ? "ready" : error ? "failed" : "loading";
+  const { headline, subline } = repositoryAiHeading(read, glance);
+  const capped = overview ? cappedNote(overview.capped, overview.counts) : "";
+  const anySessions = (overview?.counts.total ?? 0) > 0;
+  const listed = overview?.sessions.length ?? 0;
+  const notListed = Math.max(0, glance.counts.total - glance.counts.archived - listed);
+
+  return (
+    <section className="mt-7">
+      <div className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/20">
+            <Bot size={17} />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              {headline}
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm text-slate-500 dark:text-slate-400">{subline}</p>
+          </div>
+        </div>
+        <Link
+          to={aiBase}
+          className={buttonClassName({ className: "shrink-0 justify-center sm:w-auto" })}
+        >
+          <Sparkles size={15} /> Start a work session
+        </Link>
+      </div>
+
+      {error && (
+        <div className="mt-3">
+          <InlineRetry message={error} onRetry={onRetry} compact />
+        </div>
+      )}
+
+      {overview === null && !error ? (
+        <div className="mt-3">
+          <StripSkeleton />
+        </div>
+      ) : (
+        overview !== null &&
+        anySessions && (
+          <div className="mt-3">
+            <AiWorkStatStrip stats={repositoryAiStats(glance)} />
+            <p className="mt-2 text-[11px] text-slate-400 dark:text-slate-500">
+              {landedSentence(glance.counts, glance.landed)}
+              {capped ? ` ${capped}` : ""}
+            </p>
+          </div>
+        )
+      )}
+
+      {overview !== null && (
+        <div className="mt-3 space-y-3">
+          {AI_OVERVIEW_GROUP_ORDER.map((band) =>
+            bands[band].length === 0 ? null : (
+              <AiWorkBand
+                key={band}
+                title={AI_OVERVIEW_GROUP_LABEL[band]}
+                count={bands[band].length}
+              >
+                {bands[band].map((session) => (
+                  <AiSessionRow
+                    key={session.id}
+                    companyId={companyId}
+                    session={session}
+                    activity={activity.get(session.id) ?? null}
+                    href={overviewSessionHref(aiBase, session.id)}
+                  />
+                ))}
+              </AiWorkBand>
+            ),
+          )}
+          {notListed > 0 && (
+            <Link
+              to={aiBase}
+              className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+            >
+              {notListed} more in AI work <ArrowRight size={13} />
+            </Link>
+          )}
+        </div>
+      )}
+
+      {grants !== null && grants.length > 0 && (
+        <section className="mt-3 overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+          <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-4 py-2.5 dark:border-slate-800">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              Who works here
+            </h3>
+            <Link
+              to={accessHref}
+              className="text-[11px] font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+            >
+              Manage AI access
+            </Link>
+          </div>
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {grants.map((grant) => (
+              <AiEmployeeRow
+                key={grant.id}
+                companyId={companyId}
+                grant={grant}
+                work={grant.employee ? (work.get(grant.employee.id) ?? null) : null}
+                workKnown={overview !== null}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {grants !== null && grants.length === 0 && (
+        <div className="mt-3 flex flex-col gap-3 rounded-xl border border-dashed border-slate-300 bg-white px-5 py-6 dark:border-slate-700 dark:bg-slate-900 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-slate-900 dark:text-slate-100">
+              No AI employee has access yet
+            </div>
+            <p className="mt-0.5 max-w-xl text-sm text-slate-500 dark:text-slate-400">
+              Only an employee you grant gets a checkout of this repository, so only a granted one
+              can be asked to work in it. It never sees the credentials behind the remote.
+            </p>
+          </div>
+          <Link
+            to={accessHref}
+            className={buttonClassName({ variant: "secondary", className: "shrink-0" })}
+          >
+            <Users size={15} /> Grant access
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/App/client/components/repositories/aiOverview.test.ts
+++ b/App/client/components/repositories/aiOverview.test.ts
@@ -1,0 +1,895 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import type {
+  RepositoryAiActivity,
+  RepositoryAiCounts,
+  RepositoryAiEmployeeWork,
+  RepositoryAiLanded,
+  RepositoryWorkSession,
+  RepositoryWorkSessionStatus,
+} from "../../lib/api";
+import { SESSION_STATUS_LABEL } from "./sessionState";
+import {
+  AI_OVERVIEW_GROUP_LABEL,
+  AI_OVERVIEW_GROUP_ORDER,
+  activityBySession,
+  activityLine,
+  aiOverviewGroupOf,
+  cappedNote,
+  diffstatLabel,
+  employeeWorkById,
+  employeeWorkLabel,
+  groupAiOverviewSessions,
+  landedSentence,
+  overviewSessionHref,
+  repositoryAiGlanceOf,
+  repositoryAiHeadline,
+  repositoryAiHeading,
+  repositoryAiState,
+  repositoryAiStats,
+  repositoryAiSubline,
+  sessionNextStep,
+  stepsLabel,
+  toolCallsLabel,
+  workingEmployeeNames,
+  workingSubject,
+  type AiOverviewGroup,
+  type RepositoryAiGlance,
+  type RepositoryAiState,
+} from "./aiOverview";
+
+/**
+ * What the Repository Overview says about AI work.
+ *
+ * This module is the page's whole subject — the headline a Member reads first,
+ * the four tiles under it, and the one line per session saying what to do
+ * next. Client tests here have no DOM, so these sentences are only reachable
+ * as functions, and they are the part a reader actually depends on: a headline
+ * that says "0 sessions" where it should say "no employee may work here" sends
+ * somebody to the wrong screen.
+ *
+ * The tables keyed by `RepositoryWorkSessionStatus` are the point of the file:
+ * adding a status without giving it a band and a next step fails to compile
+ * here rather than shipping a session that lands in no list.
+ */
+
+/** Every status, and the band it belongs in. Exhaustive by type. */
+const GROUP_BY_STATUS: Record<RepositoryWorkSessionStatus, AiOverviewGroup> = {
+  running: "running",
+  ready: "attention",
+  empty: "attention",
+  proposed: "attention",
+  published: "recent",
+  discarded: "recent",
+  failed: "attention",
+};
+
+const ALL_STATUSES = Object.keys(GROUP_BY_STATUS) as RepositoryWorkSessionStatus[];
+
+function session(overrides: Partial<RepositoryWorkSession> = {}): RepositoryWorkSession {
+  return {
+    id: "s1",
+    companyId: "c1",
+    repositoryId: "r1",
+    employeeId: "e1",
+    requestedByUserId: "u1",
+    title: "Add a health check",
+    instruction: "Add a health check endpoint and commit it",
+    status: "ready",
+    branch: "genosyn/ada/abcdef12",
+    baseCommit: "aaa",
+    headCommit: "bbb",
+    reply: "Done.",
+    error: "",
+    turnCount: 1,
+    filesChanged: 1,
+    insertions: 3,
+    deletions: 0,
+    publishedBranch: null,
+    pullRequestUrl: null,
+    pullRequestNumber: null,
+    finishedAt: "2026-08-19T10:00:00.000Z",
+    archivedAt: null,
+    createdAt: "2026-08-19T09:00:00.000Z",
+    updatedAt: "2026-08-19T10:00:00.000Z",
+    employee: { id: "e1", name: "Ada", slug: "ada", avatarKey: null },
+    ...overrides,
+  };
+}
+
+function counts(overrides: Partial<RepositoryAiCounts> = {}): RepositoryAiCounts {
+  return { total: 0, running: 0, attention: 0, completed: 0, archived: 0, ...overrides };
+}
+
+function landed(overrides: Partial<RepositoryAiLanded> = {}): RepositoryAiLanded {
+  return { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0, ...overrides };
+}
+
+function glanceOf(overrides: Partial<RepositoryAiGlance> = {}): RepositoryAiGlance {
+  return { counts: counts(), landed: landed(), granted: 0, workingNames: [], ...overrides };
+}
+
+/** One glance per state, so every wording test can name the state it means. */
+const GLANCE = {
+  working: glanceOf({
+    counts: counts({ total: 6, running: 1, completed: 5 }),
+    granted: 2,
+    workingNames: ["Ada"],
+  }),
+  waiting: glanceOf({ counts: counts({ total: 4, attention: 2, completed: 2 }), granted: 2 }),
+  quiet: glanceOf({
+    counts: counts({ total: 3, completed: 3 }),
+    landed: landed({ sessions: 2 }),
+    granted: 2,
+  }),
+  idle: glanceOf({ granted: 2 }),
+  closed: glanceOf(),
+} satisfies Record<RepositoryAiState, RepositoryAiGlance>;
+
+const STATES = Object.keys(GLANCE) as Array<keyof typeof GLANCE>;
+
+function employeeWork(overrides: Partial<RepositoryAiEmployeeWork> = {}): RepositoryAiEmployeeWork {
+  return {
+    employeeId: "e1",
+    sessions: 8,
+    landed: 5,
+    filesChanged: 12,
+    insertions: 900,
+    deletions: 120,
+    lastActiveAt: "2026-08-19T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function activityOf(overrides: Partial<RepositoryAiActivity> = {}): RepositoryAiActivity {
+  return {
+    sessionId: "s1",
+    summary: "Ran npm test",
+    at: "2026-08-19T10:00:00.000Z",
+    steps: null,
+    toolCalls: 0,
+    ...overrides,
+  };
+}
+
+describe("the three bands", () => {
+  test("every status has exactly one band", () => {
+    // A new status with no case here would fall into "Needs you" silently;
+    // the table makes that a decision somebody had to write down.
+    for (const status of ALL_STATUSES) {
+      assert.equal(aiOverviewGroupOf(status), GROUP_BY_STATUS[status], status);
+    }
+  });
+
+  test("only a turn in flight is live work, and only the two decided outcomes are history", () => {
+    assert.deepEqual(
+      ALL_STATUSES.filter((status) => aiOverviewGroupOf(status) === "running"),
+      ["running"],
+    );
+    assert.deepEqual(
+      ALL_STATUSES.filter((status) => aiOverviewGroupOf(status) === "recent"),
+      ["published", "discarded"],
+    );
+    assert.deepEqual(
+      ALL_STATUSES.filter((status) => aiOverviewGroupOf(status) === "attention"),
+      ["ready", "empty", "proposed", "failed"],
+    );
+  });
+
+  test("the bands are listed live work first, and each one is named", () => {
+    assert.deepEqual(AI_OVERVIEW_GROUP_ORDER, ["running", "attention", "recent"]);
+    assert.deepEqual(AI_OVERVIEW_GROUP_LABEL, {
+      running: "Working now",
+      attention: "Needs you",
+      recent: "Recently decided",
+    });
+  });
+
+  test("splits the server's list without reordering or mutating it", () => {
+    const rows = [
+      session({ id: "published", status: "published" }),
+      session({ id: "ready", status: "ready" }),
+      session({ id: "running-a", status: "running" }),
+      session({ id: "failed", status: "failed" }),
+      session({ id: "running-b", status: "running" }),
+      session({ id: "discarded", status: "discarded" }),
+    ];
+
+    const bands = groupAiOverviewSessions(rows);
+
+    assert.deepEqual(
+      bands.running.map((row) => row.id),
+      ["running-a", "running-b"],
+    );
+    assert.deepEqual(
+      bands.attention.map((row) => row.id),
+      ["ready", "failed"],
+    );
+    assert.deepEqual(
+      bands.recent.map((row) => row.id),
+      ["published", "discarded"],
+    );
+    assert.deepEqual(
+      rows.map((row) => row.id),
+      ["published", "ready", "running-a", "failed", "running-b", "discarded"],
+    );
+  });
+
+  test("every band exists for an empty list, so a caller need not check", () => {
+    assert.deepEqual(groupAiOverviewSessions([]), { running: [], attention: [], recent: [] });
+    for (const band of AI_OVERVIEW_GROUP_ORDER) {
+      assert.deepEqual(groupAiOverviewSessions([])[band], []);
+    }
+  });
+});
+
+describe("the state of a repository's AI work", () => {
+  test("names each of the five states", () => {
+    for (const state of STATES) {
+      assert.equal(repositoryAiState(GLANCE[state]), state, state);
+    }
+  });
+
+  test("working outranks waiting, so an unreviewed session cannot hide live work", () => {
+    assert.equal(
+      repositoryAiState(
+        glanceOf({ counts: counts({ total: 9, running: 1, attention: 4 }), granted: 2 }),
+      ),
+      "working",
+    );
+  });
+
+  test("waiting outranks quiet, so a queue is never reported as nothing happening", () => {
+    assert.equal(
+      repositoryAiState(
+        glanceOf({ counts: counts({ total: 9, attention: 1, completed: 8 }), granted: 2 }),
+      ),
+      "waiting",
+    );
+  });
+
+  test("archived work still counts as work having happened here", () => {
+    assert.equal(
+      repositoryAiState(glanceOf({ counts: counts({ total: 3, archived: 3 }), granted: 1 })),
+      "quiet",
+    );
+  });
+
+  test("a repository nobody may work in is closed, not idle", () => {
+    assert.equal(repositoryAiState(glanceOf({ granted: 0 })), "closed");
+    assert.equal(repositoryAiState(glanceOf({ granted: 1 })), "idle");
+  });
+});
+
+describe("who is working, named", () => {
+  test("names nobody when the list is empty or holds only blanks", () => {
+    assert.equal(workingSubject([]), "");
+    assert.equal(workingSubject([""]), "");
+    assert.equal(workingSubject(["   ", "\t"]), "");
+  });
+
+  test("drops blank names before counting, so a blank never becomes an 'other'", () => {
+    assert.equal(workingSubject(["Ada", "  "]), "Ada");
+    assert.equal(workingSubject(["  ", "Ada", "Kaz"]), "Ada and Kaz");
+  });
+
+  test("names one, names two, and counts the rest", () => {
+    assert.equal(workingSubject(["Ada"]), "Ada");
+    assert.equal(workingSubject(["Ada", "Kaz"]), "Ada and Kaz");
+    assert.equal(workingSubject(["Ada", "Kaz", "Rey"]), "Ada, Kaz and 1 other");
+    assert.equal(workingSubject(["Ada", "Kaz", "Rey", "Bo", "Zoe"]), "Ada, Kaz and 3 others");
+  });
+});
+
+describe("the headline", () => {
+  test("names the one employee working", () => {
+    assert.equal(repositoryAiHeadline(GLANCE.working), "Ada is working here now.");
+  });
+
+  test("names two, and counts three or more", () => {
+    const two = glanceOf({
+      counts: counts({ total: 2, running: 2 }),
+      workingNames: ["Ada", "Kaz"],
+    });
+    assert.equal(repositoryAiHeadline(two), "Ada and Kaz are working here now.");
+    const four = glanceOf({
+      counts: counts({ total: 4, running: 4 }),
+      workingNames: ["Ada", "Kaz", "Rey", "Bo"],
+    });
+    assert.equal(repositoryAiHeadline(four), "Ada, Kaz and 2 others are working here now.");
+  });
+
+  test("conjugates for the names it printed, not for the ones it dropped", () => {
+    // A blank name is dropped from the subject, so it must be dropped from the
+    // verb too — counting the raw list produced "Ada are working here now."
+    assert.equal(
+      repositoryAiHeadline(
+        glanceOf({ counts: counts({ total: 2, running: 2 }), workingNames: ["Ada", "  "] }),
+      ),
+      "Ada is working here now.",
+    );
+    assert.equal(
+      repositoryAiHeadline(
+        glanceOf({ counts: counts({ total: 3, running: 3 }), workingNames: [" Ada ", "Kaz", ""] }),
+      ),
+      "Ada and Kaz are working here now.",
+    );
+  });
+
+  test("a running session whose employee was fired still gets a sentence", () => {
+    // Nobody to name is not nothing to say: the turn is still burning tokens.
+    assert.equal(
+      repositoryAiHeadline(glanceOf({ counts: counts({ total: 1, running: 1 }) })),
+      "1 session is running here now.",
+    );
+    assert.equal(
+      repositoryAiHeadline(glanceOf({ counts: counts({ total: 3, running: 3 }) })),
+      "3 sessions are running here now.",
+    );
+  });
+
+  test("adds what is waiting behind the live work, singular and plural", () => {
+    const one = glanceOf({
+      counts: counts({ total: 4, running: 1, attention: 1 }),
+      workingNames: ["Ada"],
+    });
+    assert.equal(
+      repositoryAiHeadline(one),
+      "Ada is working here now. 1 other session is waiting for you.",
+    );
+    const many = glanceOf({
+      counts: counts({ total: 9, running: 2, attention: 3 }),
+      workingNames: ["Ada", "Kaz"],
+    });
+    assert.equal(
+      repositoryAiHeadline(many),
+      "Ada and Kaz are working here now. 3 other sessions are waiting for you.",
+    );
+  });
+
+  test("says nothing about a queue that is empty", () => {
+    assert.doesNotMatch(repositoryAiHeadline(GLANCE.working), /waiting/);
+  });
+
+  test("counts what is waiting when nothing is running", () => {
+    assert.equal(
+      repositoryAiHeadline(glanceOf({ counts: counts({ total: 1, attention: 1 }) })),
+      "1 session is waiting for you to decide.",
+    );
+    assert.equal(repositoryAiHeadline(GLANCE.waiting), "2 sessions are waiting for you to decide.");
+  });
+
+  test("a quiet repository reports what landed, or admits nothing has", () => {
+    assert.equal(
+      repositoryAiHeadline(GLANCE.quiet),
+      "Nothing is running. AI employees have landed 2 sessions here.",
+    );
+    assert.equal(
+      repositoryAiHeadline(
+        glanceOf({ counts: counts({ total: 3, completed: 3 }), landed: landed({ sessions: 1 }) }),
+      ),
+      "Nothing is running. AI employees have landed 1 session here.",
+    );
+    assert.equal(
+      repositoryAiHeadline(glanceOf({ counts: counts({ total: 3, completed: 3 }), granted: 2 })),
+      "Nothing is running, and no AI work has been accepted here yet.",
+    );
+  });
+
+  test("an idle repository says how many employees could be working", () => {
+    assert.equal(
+      repositoryAiHeadline(glanceOf({ granted: 1 })),
+      "1 AI employee can work here. None has yet.",
+    );
+    assert.equal(repositoryAiHeadline(GLANCE.idle), "2 AI employees can work here. None has yet.");
+  });
+
+  test("a repository nobody was granted says so rather than showing a zero", () => {
+    // "0 sessions" and "no employee may work here" are different problems with
+    // different fixes, and only one of them is fixed on the access screen.
+    assert.equal(
+      repositoryAiHeadline(GLANCE.closed),
+      "No AI employee can work in this repository yet.",
+    );
+    assert.doesNotMatch(repositoryAiHeadline(GLANCE.closed), /\d/);
+  });
+
+  test("separates thousands in every number it prints", () => {
+    assert.match(
+      repositoryAiHeadline(
+        glanceOf({
+          counts: counts({ total: 4000, completed: 4000 }),
+          landed: landed({ sessions: 1200 }),
+        }),
+      ),
+      /landed 1,200 sessions/,
+    );
+  });
+
+  test("every state produces one sentence", () => {
+    for (const state of STATES) {
+      const headline = repositoryAiHeadline(GLANCE[state]);
+      assert.ok(headline.length > 0, state);
+      assert.match(headline, /\.$/, state);
+    }
+  });
+});
+
+describe("the line under the headline", () => {
+  test("every state is told what to do about it", () => {
+    for (const state of STATES) {
+      const subline = repositoryAiSubline(GLANCE[state]);
+      assert.ok(subline.length > 0, state);
+      assert.match(subline, /\.$/, state);
+    }
+  });
+
+  test("no two states share an instruction", () => {
+    // A page whose subline is the same whatever is happening has stopped
+    // telling anybody anything.
+    const lines = STATES.map((state) => repositoryAiSubline(GLANCE[state]));
+    assert.equal(new Set(lines).size, lines.length);
+  });
+
+  test("the two empty states point at the two different fixes", () => {
+    assert.match(repositoryAiSubline(GLANCE.idle), /Describe an outcome/);
+    assert.match(repositoryAiSubline(GLANCE.closed), /Grant an AI employee access/);
+  });
+});
+
+describe("the four tiles", () => {
+  const keys = ["running", "attention", "accepted", "changed"];
+
+  test("the same four tiles in the same order, whatever the repository is doing", () => {
+    // A strip that reflows as work starts and stops is unreadable.
+    for (const state of STATES) {
+      assert.deepEqual(
+        repositoryAiStats(GLANCE[state]).map((tile) => tile.key),
+        keys,
+        state,
+      );
+    }
+  });
+
+  test("every tile is labelled", () => {
+    assert.deepEqual(
+      repositoryAiStats(GLANCE.working).map((tile) => tile.label),
+      ["Working now", "Waiting for you", "Accepted", "Lines accepted"],
+    );
+  });
+
+  test("a zero says a word rather than a nought", () => {
+    const stats = repositoryAiStats(GLANCE.closed);
+    assert.equal(stats[0].value, "None");
+    assert.equal(stats[1].value, "None");
+    assert.equal(stats[3].value, "None yet");
+    // The accepted tile is the deliberate exception: its hint counts the total
+    // it is a share of, so the number has to stay a number.
+    assert.equal(stats[2].value, "0 sessions");
+  });
+
+  test("counts sessions, singular and plural, once there are any", () => {
+    const one = repositoryAiStats(
+      glanceOf({
+        counts: counts({ total: 2, running: 1, attention: 1 }),
+        landed: landed({ sessions: 1 }),
+      }),
+    );
+    assert.equal(one[0].value, "1 session");
+    assert.equal(one[1].value, "1 session");
+    assert.equal(one[2].value, "1 session");
+
+    const many = repositoryAiStats(
+      glanceOf({
+        counts: counts({ total: 9, running: 2, attention: 3 }),
+        landed: landed({ sessions: 4 }),
+      }),
+    );
+    assert.equal(many[0].value, "2 sessions");
+    assert.equal(many[1].value, "3 sessions");
+    assert.equal(many[2].value, "4 sessions");
+  });
+
+  test("lines accepted are separated at the thousand and signed with a real minus", () => {
+    const stats = repositoryAiStats(
+      glanceOf({
+        counts: counts({ total: 4 }),
+        landed: landed({ sessions: 4, insertions: 12345, deletions: 6789 }),
+      }),
+    );
+    assert.equal(stats[3].value, "+12,345 / −6,789");
+    // U+2212, not a hyphen: a hyphen next to a "+" reads as a dash.
+    assert.ok(stats[3].value.includes("−"));
+    assert.doesNotMatch(stats[3].value, /-/);
+  });
+
+  test("a landed session that only deleted still shows both sides", () => {
+    const stats = repositoryAiStats(
+      glanceOf({ counts: counts({ total: 1 }), landed: landed({ sessions: 1, deletions: 4 }) }),
+    );
+    assert.equal(stats[3].value, "+0 / −4");
+  });
+
+  test("the hints appear only when they say something", () => {
+    const busy = repositoryAiStats(
+      glanceOf({
+        counts: counts({ total: 12, running: 2, attention: 1 }),
+        landed: landed({ sessions: 5, filesChanged: 9 }),
+        workingNames: ["Ada", "Kaz"],
+      }),
+    );
+    assert.equal(busy[0].hint, "Ada and Kaz");
+    assert.equal(busy[1].hint, "Review, revise, or discard");
+    assert.equal(busy[2].hint, "of 12 in total");
+    assert.equal(busy[3].hint, "across 9 files");
+
+    const empty = repositoryAiStats(GLANCE.closed);
+    assert.deepEqual(
+      empty.map((tile) => tile.hint),
+      [null, null, null, null],
+    );
+  });
+
+  test("a running session with nobody left to name carries no hint at all", () => {
+    // "" would render as an empty second line and jog the tile out of line.
+    const stats = repositoryAiStats(glanceOf({ counts: counts({ total: 1, running: 1 }) }));
+    assert.equal(stats[0].hint, null);
+  });
+
+  test("the hints count in words a person reads, not raw numbers", () => {
+    const stats = repositoryAiStats(
+      glanceOf({
+        counts: counts({ total: 2400 }),
+        landed: landed({ sessions: 1, filesChanged: 1 }),
+      }),
+    );
+    assert.equal(stats[2].hint, "of 2,400 in total");
+    assert.equal(stats[3].hint, "across 1 file");
+  });
+});
+
+describe("how much of it was accepted", () => {
+  test("says nothing when there has never been a session", () => {
+    assert.equal(landedSentence(counts(), landed()), "");
+    assert.equal(landedSentence(counts(), landed({ sessions: 3 })), "");
+  });
+
+  test("says plainly when none of it was accepted", () => {
+    assert.equal(
+      landedSentence(counts({ total: 30 }), landed()),
+      "None of 30 sessions has been accepted.",
+    );
+    assert.equal(
+      landedSentence(counts({ total: 1 }), landed()),
+      "None of 1 session has been accepted.",
+    );
+  });
+
+  test("counts the share once some was", () => {
+    assert.equal(
+      landedSentence(counts({ total: 30 }), landed({ sessions: 12 })),
+      "12 of 30 sessions accepted.",
+    );
+    assert.equal(
+      landedSentence(counts({ total: 1 }), landed({ sessions: 1 })),
+      "1 of 1 session accepted.",
+    );
+    assert.equal(
+      landedSentence(counts({ total: 1200 }), landed({ sessions: 1000 })),
+      "1,000 of 1,200 sessions accepted.",
+    );
+  });
+});
+
+describe("one session's diffstat", () => {
+  test("a session that changed nothing gets no line rather than three zeroes", () => {
+    assert.equal(diffstatLabel({ filesChanged: 0, insertions: 0, deletions: 0 }), "");
+  });
+
+  test("composes files, insertions and deletions with a real minus", () => {
+    assert.equal(
+      diffstatLabel({ filesChanged: 4, insertions: 120, deletions: 8 }),
+      "4 files · +120 · −8",
+    );
+    assert.equal(
+      diffstatLabel({ filesChanged: 1200, insertions: 4000, deletions: 30000 }),
+      "1,200 files · +4,000 · −30,000",
+    );
+  });
+
+  test("one file is one file", () => {
+    assert.equal(
+      diffstatLabel({ filesChanged: 1, insertions: 3, deletions: 0 }),
+      "1 file · +3 · −0",
+    );
+  });
+
+  test("a rename that moved lines but touched no file still gets a line", () => {
+    // Only all three being zero means nothing happened.
+    assert.equal(
+      diffstatLabel({ filesChanged: 0, insertions: 0, deletions: 2 }),
+      "0 files · +0 · −2",
+    );
+  });
+});
+
+describe("what a session wants from a person", () => {
+  /** The next step for every status. Exhaustive by type. */
+  const NEXT_STEP: Record<RepositoryWorkSessionStatus, string> = {
+    running: "Working now",
+    ready: "Read the diff and decide",
+    empty: "Nothing changed — ask for another pass",
+    proposed: "A pull request is open",
+    published: "Merged into this repository",
+    discarded: "Its branch was thrown away",
+    failed: "The last turn failed — ask again",
+  };
+
+  function step(over: Partial<RepositoryWorkSession> & { status: RepositoryWorkSessionStatus }) {
+    return sessionNextStep({ pullRequestNumber: null, publishedBranch: null, ...over });
+  }
+
+  test("every status is told what to do about it, and no two the same", () => {
+    for (const status of ALL_STATUSES) {
+      assert.equal(step({ status }), NEXT_STEP[status], status);
+    }
+    const steps = ALL_STATUSES.map((status) => NEXT_STEP[status]);
+    assert.equal(new Set(steps).size, steps.length);
+  });
+
+  test("a proposed session names its pull request when the server knows the number", () => {
+    assert.equal(step({ status: "proposed", pullRequestNumber: 42 }), "Pull request #42 is open");
+    assert.equal(step({ status: "proposed" }), "A pull request is open");
+  });
+
+  test("a decided session says where the work went, never what its own chip says", () => {
+    // The row already carries the status on a chip beside the title, so
+    // "Accepted" under a chip reading "Accepted" was a second line that made
+    // the row taller and told nobody anything.
+    assert.equal(step({ status: "published", publishedBranch: "main" }), "Merged into main");
+    for (const status of ["published", "discarded"] as const) {
+      assert.notEqual(step({ status }), SESSION_STATUS_LABEL[status]);
+    }
+  });
+
+  test("says what to do, not what the status is called", () => {
+    assert.doesNotMatch(step({ status: "empty" }), /^Empty/);
+    assert.doesNotMatch(step({ status: "failed" }), /^Failed/);
+  });
+});
+
+describe("the live line on a running session", () => {
+  test("a turn that has written no event yet is starting, not stuck", () => {
+    assert.equal(activityLine(null), "Starting…");
+    assert.equal(activityLine(undefined), "Starting…");
+    assert.equal(activityLine(activityOf({ summary: "" })), "Starting…");
+    assert.equal(activityLine(activityOf({ summary: "   \n\t " })), "Starting…");
+  });
+
+  test("a real summary passes through, trimmed", () => {
+    assert.equal(
+      activityLine(activityOf({ summary: "Ran npm test → Exit 1" })),
+      "Ran npm test → Exit 1",
+    );
+    assert.equal(activityLine(activityOf({ summary: "  Read src/app.ts  " })), "Read src/app.ts");
+  });
+
+  test("counts the tool calls behind the line", () => {
+    assert.equal(toolCallsLabel(null), "");
+    assert.equal(toolCallsLabel(undefined), "");
+    assert.equal(toolCallsLabel(activityOf({ toolCalls: 0 })), "");
+    assert.equal(toolCallsLabel(activityOf({ toolCalls: 1 })), "1 tool call");
+    assert.equal(toolCallsLabel(activityOf({ toolCalls: 24 })), "24 tool calls");
+    assert.equal(toolCallsLabel(activityOf({ toolCalls: 2400 })), "2,400 tool calls");
+  });
+});
+
+describe("how far a turn has got", () => {
+  test("says nothing when the employee wrote no step list", () => {
+    assert.equal(stepsLabel(null), "");
+    assert.equal(stepsLabel(undefined), "");
+    assert.equal(stepsLabel({ done: 0, total: 0, current: null }), "");
+  });
+
+  test("counts the step being worked on, not the ones behind it", () => {
+    assert.equal(stepsLabel({ done: 0, total: 7, current: "Read the router" }), "Step 1 of 7");
+    assert.equal(stepsLabel({ done: 2, total: 7, current: "Add the route" }), "Step 3 of 7");
+  });
+
+  test("never reads 'Step 8 of 7' once the list is finished", () => {
+    assert.equal(stepsLabel({ done: 7, total: 7, current: null }), "Step 7 of 7");
+    assert.equal(stepsLabel({ done: 9, total: 7, current: null }), "Step 7 of 7");
+  });
+});
+
+describe("what one employee has done here", () => {
+  test("an employee with no work says so rather than showing three zeroes", () => {
+    assert.equal(employeeWorkLabel(null), "No work here yet");
+    assert.equal(employeeWorkLabel(undefined), "No work here yet");
+    assert.equal(employeeWorkLabel(employeeWork({ sessions: 0 })), "No work here yet");
+  });
+
+  test("names the sessions, the accepted share and the lines", () => {
+    assert.equal(employeeWorkLabel(employeeWork()), "8 sessions · 5 accepted · +900 / −120");
+    assert.equal(
+      employeeWorkLabel(employeeWork({ sessions: 1, landed: 1, insertions: 4000, deletions: 0 })),
+      "1 session · 1 accepted · +4,000 / −0",
+    );
+  });
+
+  test("drops the diffstat when nothing of theirs was accepted", () => {
+    assert.equal(
+      employeeWorkLabel(employeeWork({ sessions: 3, landed: 0, insertions: 0, deletions: 0 })),
+      "3 sessions · 0 accepted",
+    );
+  });
+
+  test("a purely deleting employee still gets a diffstat", () => {
+    assert.equal(
+      employeeWorkLabel(employeeWork({ sessions: 2, landed: 1, insertions: 0, deletions: 40 })),
+      "2 sessions · 1 accepted · +0 / −40",
+    );
+  });
+});
+
+describe("the lookups the rows join through", () => {
+  test("indexes each employee's tally by its employee", () => {
+    const map = employeeWorkById([
+      employeeWork({ employeeId: "ada", sessions: 3 }),
+      employeeWork({ employeeId: "kaz", sessions: 5 }),
+    ]);
+    assert.equal(map.size, 2);
+    assert.equal(map.get("ada")?.sessions, 3);
+    assert.equal(map.get("kaz")?.sessions, 5);
+    assert.equal(map.get("nobody"), undefined);
+    assert.deepEqual(employeeWorkById([]).size, 0);
+  });
+
+  test("indexes each live line by its session", () => {
+    const map = activityBySession([
+      activityOf({ sessionId: "a", summary: "Reading" }),
+      activityOf({ sessionId: "b", summary: "Editing" }),
+    ]);
+    assert.equal(map.size, 2);
+    assert.equal(map.get("a")?.summary, "Reading");
+    assert.equal(map.get("b")?.summary, "Editing");
+    assert.equal(map.get("c"), undefined);
+    assert.deepEqual(activityBySession([]).size, 0);
+  });
+
+  test("a repeated key keeps the last row the server sent", () => {
+    // The server sends one row per key, so this only matters as a rule: the
+    // later row wins, and neither lookup grows a second entry for it.
+    const employees = employeeWorkById([
+      employeeWork({ employeeId: "ada", sessions: 3 }),
+      employeeWork({ employeeId: "ada", sessions: 9 }),
+    ]);
+    assert.equal(employees.size, 1);
+    assert.equal(employees.get("ada")?.sessions, 9);
+
+    const activity = activityBySession([
+      activityOf({ sessionId: "a", summary: "Reading" }),
+      activityOf({ sessionId: "a", summary: "Committing" }),
+    ]);
+    assert.equal(activity.size, 1);
+    assert.equal(activity.get("a")?.summary, "Committing");
+  });
+
+  test("a session row points at its own page in the AI work inbox", () => {
+    assert.equal(
+      overviewSessionHref("/c/acme/repositories/product/ai", "s1"),
+      "/c/acme/repositories/product/ai/s1",
+    );
+  });
+});
+
+describe("when the tallies stopped counting", () => {
+  test("says nothing when nothing was capped", () => {
+    assert.equal(cappedNote(false, counts({ total: 2000 })), "");
+  });
+
+  test("says so, with the number it counted over, rather than letting it pass", () => {
+    assert.equal(
+      cappedNote(true, counts({ total: 2000 })),
+      "Counted over the most recent 2,000 sessions.",
+    );
+  });
+});
+
+describe("who is working, counted once each", () => {
+  function running(id: string, employeeId: string | null, name = "Ada") {
+    return session({
+      id,
+      status: "running",
+      employee: employeeId
+        ? { id: employeeId, name, slug: name.toLowerCase(), avatarKey: null }
+        : null,
+    });
+  }
+
+  test("names an employee once however many sessions it is running", () => {
+    // Two sessions, one colleague. Counting sessions gave the headline two
+    // people and the plural verb to go with them.
+    assert.deepEqual(
+      workingEmployeeNames([running("a", "e1"), running("b", "e1"), running("c", "e2", "Kaz")]),
+      ["Ada", "Kaz"],
+    );
+  });
+
+  test("keeps the order the server listed them in", () => {
+    assert.deepEqual(workingEmployeeNames([running("a", "e2", "Kaz"), running("b", "e1", "Ada")]), [
+      "Kaz",
+      "Ada",
+    ]);
+  });
+
+  test("ignores sessions that are not running and employees that are gone", () => {
+    assert.deepEqual(
+      workingEmployeeNames([
+        session({ id: "ready", status: "ready" }),
+        running("fired", null),
+        running("live", "e1"),
+      ]),
+      ["Ada"],
+    );
+  });
+});
+
+describe("the glance the page reasons over", () => {
+  test("a digest that has not arrived is all zeroes, and still knows the roster", () => {
+    const glance = repositoryAiGlanceOf(null, 3);
+    assert.deepEqual(glance.counts, {
+      total: 0,
+      running: 0,
+      attention: 0,
+      completed: 0,
+      archived: 0,
+    });
+    assert.deepEqual(glance.landed, {
+      sessions: 0,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+    });
+    assert.equal(glance.granted, 3);
+    assert.deepEqual(glance.workingNames, []);
+    // Zeroes are not a claim: the heading is what decides that, from the read
+    // state, and it must not report an absent answer as a quiet repository.
+    assert.equal(repositoryAiHeading("loading", glance).headline, "Reading back the AI work…");
+    assert.equal(
+      repositoryAiHeading("failed", glance).headline,
+      "The AI work here could not be read.",
+    );
+  });
+
+  test("carries the digest through and names the employees working", () => {
+    const glance = repositoryAiGlanceOf(
+      {
+        counts: counts({ total: 4, running: 2, attention: 1, completed: 1 }),
+        landed: landed({ sessions: 1, filesChanged: 3, insertions: 40, deletions: 5 }),
+        sessions: [
+          session({
+            id: "a",
+            status: "running",
+            employee: { id: "e1", name: "Ada", slug: "ada", avatarKey: null },
+          }),
+          session({
+            id: "b",
+            status: "running",
+            employee: { id: "e1", name: "Ada", slug: "ada", avatarKey: null },
+          }),
+        ],
+      },
+      2,
+    );
+    assert.equal(glance.counts.running, 2);
+    assert.equal(glance.granted, 2);
+    assert.deepEqual(glance.workingNames, ["Ada"]);
+    // Two sessions, one person — so the verb is singular.
+    assert.equal(
+      repositoryAiHeading("ready", glance).headline,
+      "Ada is working here now. 1 other session is waiting for you.",
+    );
+  });
+});

--- a/App/client/components/repositories/aiOverview.ts
+++ b/App/client/components/repositories/aiOverview.ts
@@ -1,0 +1,462 @@
+import type {
+  RepositoryAiActivity,
+  RepositoryAiCounts,
+  RepositoryAiEmployeeWork,
+  RepositoryAiLanded,
+  RepositoryAiSessionRow,
+  RepositoryAiStepProgress,
+  RepositoryWorkSession,
+  RepositoryWorkSessionStatus,
+} from "../../lib/api";
+
+/**
+ * What the Repository Overview *says* about AI work.
+ *
+ * The page it belongs to used to open with four facts nobody had asked for —
+ * the default branch, the sign-in mode, the command mode, the number of
+ * grants — and then explained, at length, a workflow the reader had already
+ * used forty times. None of it moved. This module is the replacement subject:
+ * who is working here now, what is waiting on a human, what AI work has
+ * actually landed, and which employee did it.
+ *
+ * Everything here is a pure function on the digest the server already
+ * computed, and it lives beside the page rather than in it for the reason
+ * `lib/workTimeline.ts` gives: client tests in this repo have no DOM, so the
+ * wording — the part a reader actually depends on — has to be reachable
+ * without React. The component owns colour, icons, and layout. This file owns
+ * sentences, grouping, and what a person is being told to do next.
+ */
+
+/** The three bands the overview lists sessions in, in display order. */
+export const AI_OVERVIEW_GROUP_ORDER = ["running", "attention", "recent"] as const;
+
+export type AiOverviewGroup = (typeof AI_OVERVIEW_GROUP_ORDER)[number];
+
+/**
+ * What each band is called, written as what it is *for* rather than as a
+ * status name. "Needs you" is a queue; "Ready / empty / failed / proposed" is
+ * a schema.
+ */
+export const AI_OVERVIEW_GROUP_LABEL: Record<AiOverviewGroup, string> = {
+  running: "Working now",
+  attention: "Needs you",
+  recent: "Recently decided",
+};
+
+/**
+ * Which band a status belongs to — deliberately the same split the AI work
+ * inbox and the server digest use, so a session cannot appear in one place as
+ * live work and in another as history.
+ */
+export function aiOverviewGroupOf(status: RepositoryWorkSessionStatus): AiOverviewGroup {
+  if (status === "running") return "running";
+  if (status === "published" || status === "discarded") return "recent";
+  return "attention";
+}
+
+/**
+ * Split the server's display list into its bands, order preserved.
+ *
+ * The input is never mutated and every band exists even when empty, so a
+ * caller can ask for one without checking whether it is there.
+ */
+export function groupAiOverviewSessions(
+  sessions: readonly RepositoryAiSessionRow[],
+): Record<AiOverviewGroup, RepositoryAiSessionRow[]> {
+  const groups: Record<AiOverviewGroup, RepositoryAiSessionRow[]> = {
+    running: [],
+    attention: [],
+    recent: [],
+  };
+  for (const session of sessions) groups[aiOverviewGroupOf(session.status)].push(session);
+  return groups;
+}
+
+/**
+ * The state of AI work in one repository, as one word.
+ *
+ *   - `working` → a turn is in flight.
+ *   - `waiting` → nothing is running and something is waiting on a human.
+ *   - `quiet`   → work has happened here, and none of it wants anything.
+ *   - `idle`    → an employee could work here and none ever has.
+ *   - `closed`  → no employee has been granted the repository at all.
+ *
+ * Working outranks waiting for the reason Home's roster does: an old session
+ * nobody has reviewed must not make live work look stalled.
+ */
+export type RepositoryAiState = "working" | "waiting" | "quiet" | "idle" | "closed";
+
+/** Everything the headline needs, and nothing a component would have to render. */
+export type RepositoryAiGlance = {
+  counts: RepositoryAiCounts;
+  landed: RepositoryAiLanded;
+  /** AI Employees holding a grant on this repository. */
+  granted: number;
+  /** The employees running a turn right now, in display order. */
+  workingNames: string[];
+};
+
+/**
+ * The employees running a turn in this repository right now, named once each.
+ *
+ * By employee rather than by session: one employee working two sessions is
+ * still one colleague, and listing it twice gives the headline two people and
+ * the wrong verb. A session whose employee was fired mid-turn contributes no
+ * name — the sentence for that case is written from the count instead.
+ */
+export function workingEmployeeNames(sessions: readonly RepositoryAiSessionRow[]): string[] {
+  const byEmployee = new Map<string, string>();
+  for (const session of sessions) {
+    if (session.status !== "running" || !session.employee) continue;
+    if (!byEmployee.has(session.employee.id))
+      byEmployee.set(session.employee.id, session.employee.name);
+  }
+  return [...byEmployee.values()];
+}
+
+/**
+ * What the page reasons over, from the digest and the grants.
+ *
+ * A digest that has not arrived is all zeroes, and the page must not print a
+ * sentence off it — {@link repositoryAiHeading} is what decides that, from the
+ * read state, and this only supplies the numbers. `granted` is passed in
+ * because it comes from the other read.
+ */
+export function repositoryAiGlanceOf(
+  overview: {
+    counts: RepositoryAiCounts;
+    landed: RepositoryAiLanded;
+    sessions: readonly RepositoryAiSessionRow[];
+  } | null,
+  granted: number,
+): RepositoryAiGlance {
+  if (!overview) {
+    return {
+      counts: { total: 0, running: 0, attention: 0, completed: 0, archived: 0 },
+      landed: { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0 },
+      granted,
+      workingNames: [],
+    };
+  }
+  return {
+    counts: overview.counts,
+    landed: overview.landed,
+    granted,
+    workingNames: workingEmployeeNames(overview.sessions),
+  };
+}
+
+export function repositoryAiState(glance: RepositoryAiGlance): RepositoryAiState {
+  if (glance.counts.running > 0) return "working";
+  if (glance.counts.attention > 0) return "waiting";
+  if (glance.counts.total > 0) return "quiet";
+  return glance.granted > 0 ? "idle" : "closed";
+}
+
+function plural(count: number, noun: string, many?: string): string {
+  return `${num(count)} ${count === 1 ? noun : (many ?? `${noun}s`)}`;
+}
+
+/** Thousands separators, pinned so the sentence reads the same everywhere. */
+function num(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * The employees there is actually a name for.
+ *
+ * An employee fired mid-turn leaves a running session with nobody to name, and
+ * a name that is only whitespace is the same thing wearing a hat. Both the
+ * subject of the sentence and the verb after it have to be counted from this
+ * list rather than from the raw one, or a blank beside a real name conjugates
+ * for two people and prints "Ada are working here now."
+ */
+export function namedWorkers(names: readonly string[]): string[] {
+  return names.map((name) => name.trim()).filter((name) => name.length > 0);
+}
+
+/**
+ * The employees working right now, named.
+ *
+ * Two are named, three or more are counted. A list of five names is not a
+ * headline, and the fifth name is not what the reader came for.
+ */
+export function workingSubject(names: readonly string[]): string {
+  const named = namedWorkers(names);
+  if (named.length === 0) return "";
+  if (named.length === 1) return named[0];
+  if (named.length === 2) return `${named[0]} and ${named[1]}`;
+  return `${named[0]}, ${named[1]} and ${plural(named.length - 2, "other")}`;
+}
+
+/**
+ * The one sentence at the top of the page.
+ *
+ * It answers, in order: is anything happening, is anything waiting for me,
+ * has anything ever happened, and can anything happen at all. A repository
+ * nobody has granted gets the sentence that says so rather than a zero, because
+ * "0 sessions" and "no employee may work here" are different problems with
+ * different fixes.
+ */
+export function repositoryAiHeadline(glance: RepositoryAiGlance): string {
+  const { counts } = glance;
+  switch (repositoryAiState(glance)) {
+    case "working": {
+      const named = namedWorkers(glance.workingNames);
+      const who = workingSubject(named);
+      // A session whose employee has since been fired still runs, and still
+      // deserves a sentence — it just has no name to put in front of it.
+      const lead = who
+        ? `${who} ${named.length === 1 ? "is" : "are"} working here now.`
+        : `${plural(counts.running, "session")} ${
+            counts.running === 1 ? "is" : "are"
+          } running here now.`;
+      if (counts.attention === 0) return lead;
+      return `${lead} ${plural(counts.attention, "other session")} ${
+        counts.attention === 1 ? "is" : "are"
+      } waiting for you.`;
+    }
+    case "waiting":
+      return `${plural(counts.attention, "session")} ${
+        counts.attention === 1 ? "is" : "are"
+      } waiting for you to decide.`;
+    case "quiet":
+      return glance.landed.sessions > 0
+        ? `Nothing is running. AI employees have landed ${plural(
+            glance.landed.sessions,
+            "session",
+          )} here.`
+        : "Nothing is running, and no AI work has been accepted here yet.";
+    case "idle":
+      return `${plural(glance.granted, "AI employee")} can work here. None has yet.`;
+    case "closed":
+      return "No AI employee can work in this repository yet.";
+  }
+}
+
+/**
+ * The line under the headline: what to do about it.
+ *
+ * Every state has an action, including the quiet ones, because a page whose
+ * only sentence is a status is a page that has stopped being useful the moment
+ * the status is good.
+ */
+export function repositoryAiSubline(glance: RepositoryAiGlance): string {
+  switch (repositoryAiState(glance)) {
+    case "working":
+      return "Follow the work as it happens, or leave it — nothing reaches this repository until you accept it.";
+    case "waiting":
+      return "Read the diff and accept it, ask for another pass, or throw it away.";
+    case "quiet":
+      return "Hand over the next piece of work and review what comes back.";
+    case "idle":
+      return "Describe an outcome and one of them will work on a branch of its own.";
+    case "closed":
+      return "Grant an AI employee access and it gets a checkout of this repository to work in.";
+  }
+}
+
+/**
+ * Whether the digest has arrived.
+ *
+ * Three states rather than two, because "we have not been answered yet" and
+ * "we were answered with a failure" are the same absence of an answer, and
+ * neither of them is a quiet repository.
+ */
+export type RepositoryAiReadState = "loading" | "failed" | "ready";
+
+/**
+ * The two sentences at the top of the band, including when there is nothing to
+ * say yet.
+ *
+ * A read that has not landed and a read that failed both leave the page not
+ * knowing what is happening here, and reporting either as "no AI employee has
+ * worked here" would be a definite claim about a repository whose work the page
+ * has just admitted it cannot see. Home's `teamSentence` states the same rule
+ * about the same mistake.
+ */
+export function repositoryAiHeading(
+  read: RepositoryAiReadState,
+  glance: RepositoryAiGlance,
+): { headline: string; subline: string } {
+  if (read === "loading") {
+    return {
+      headline: "Reading back the AI work…",
+      subline: "What employees have done here, and what is waiting for you.",
+    };
+  }
+  if (read === "failed") {
+    return {
+      headline: "The AI work here could not be read.",
+      subline: "Nothing else on this page is affected. Ask for it again below.",
+    };
+  }
+  return { headline: repositoryAiHeadline(glance), subline: repositoryAiSubline(glance) };
+}
+
+/** "12 of 30 sessions accepted", for the sentence under the tallies. */
+export function landedSentence(counts: RepositoryAiCounts, landed: RepositoryAiLanded): string {
+  if (counts.total === 0) return "";
+  if (landed.sessions === 0) return `None of ${plural(counts.total, "session")} has been accepted.`;
+  return `${num(landed.sessions)} of ${plural(counts.total, "session")} accepted.`;
+}
+
+/** One tile in the strip that replaced the repository's settings cards. */
+export type RepositoryAiStat = {
+  key: "running" | "attention" | "accepted" | "changed";
+  label: string;
+  value: string;
+  /** The smaller second line, or null when the value says it all. */
+  hint: string | null;
+};
+
+/**
+ * The four numbers worth a tile.
+ *
+ * They are the same four in the same order whatever the repository is doing,
+ * including when they are zero: a strip that reflows as work starts and stops
+ * is unreadable, and the whole strip is hidden by the page when the repository
+ * has never had any AI work at all.
+ */
+export function repositoryAiStats(glance: RepositoryAiGlance): RepositoryAiStat[] {
+  const { counts, landed } = glance;
+  return [
+    {
+      key: "running",
+      label: "Working now",
+      value: counts.running === 0 ? "None" : plural(counts.running, "session"),
+      hint: counts.running > 0 ? workingSubject(glance.workingNames) || null : null,
+    },
+    {
+      key: "attention",
+      label: "Waiting for you",
+      value: counts.attention === 0 ? "None" : plural(counts.attention, "session"),
+      hint: counts.attention > 0 ? "Review, revise, or discard" : null,
+    },
+    {
+      key: "accepted",
+      label: "Accepted",
+      value: plural(landed.sessions, "session"),
+      hint: counts.total > 0 ? `of ${num(counts.total)} in total` : null,
+    },
+    {
+      key: "changed",
+      label: "Lines accepted",
+      value:
+        landed.insertions === 0 && landed.deletions === 0
+          ? "None yet"
+          : `+${num(landed.insertions)} / −${num(landed.deletions)}`,
+      hint: landed.filesChanged > 0 ? `across ${plural(landed.filesChanged, "file")}` : null,
+    },
+  ];
+}
+
+/** "4 files · +120 · −8", or an empty string when a session changed nothing. */
+export function diffstatLabel(
+  session: Pick<RepositoryWorkSession, "filesChanged" | "insertions" | "deletions">,
+): string {
+  if (session.filesChanged === 0 && session.insertions === 0 && session.deletions === 0) return "";
+  return `${plural(session.filesChanged, "file")} · +${num(session.insertions)} · −${num(
+    session.deletions,
+  )}`;
+}
+
+/**
+ * What this session wants from the reader, in words.
+ *
+ * Never the status name. A status says what the *work* is, and the row already
+ * carries one on a chip beside the title; this line has to earn its place by
+ * saying something the chip does not. For a session still in the queue that is
+ * the next move — and for one that has been decided it is where the work went,
+ * because "Accepted" printed under a chip reading "Accepted" is a row that got
+ * longer without getting more informative.
+ */
+export function sessionNextStep(
+  session: Pick<RepositoryWorkSession, "status" | "pullRequestNumber" | "publishedBranch">,
+): string {
+  switch (session.status) {
+    case "running":
+      return "Working now";
+    case "ready":
+      return "Read the diff and decide";
+    case "empty":
+      return "Nothing changed — ask for another pass";
+    case "proposed":
+      return session.pullRequestNumber
+        ? `Pull request #${session.pullRequestNumber} is open`
+        : "A pull request is open";
+    case "failed":
+      return "The last turn failed — ask again";
+    case "published":
+      return session.publishedBranch
+        ? `Merged into ${session.publishedBranch}`
+        : "Merged into this repository";
+    case "discarded":
+      return "Its branch was thrown away";
+    default:
+      return "";
+  }
+}
+
+/**
+ * The live line for a running session.
+ *
+ * A turn that has not written an event yet is *starting*, which is a fact, and
+ * saying nothing there would leave a row that looks stuck.
+ */
+export function activityLine(activity: RepositoryAiActivity | null | undefined): string {
+  const summary = activity?.summary?.trim() ?? "";
+  return summary || "Starting…";
+}
+
+/** "Step 3 of 7", or an empty string when the employee wrote no step list. */
+export function stepsLabel(steps: RepositoryAiStepProgress | null | undefined): string {
+  if (!steps || steps.total === 0) return "";
+  return `Step ${Math.min(steps.done + 1, steps.total)} of ${steps.total}`;
+}
+
+/** "24 tool calls" — how much work is behind the one line above it. */
+export function toolCallsLabel(activity: RepositoryAiActivity | null | undefined): string {
+  const calls = activity?.toolCalls ?? 0;
+  return calls === 0 ? "" : plural(calls, "tool call");
+}
+
+/** What one employee has done here: "8 sessions · 5 accepted · +900 −120". */
+export function employeeWorkLabel(work: RepositoryAiEmployeeWork | null | undefined): string {
+  if (!work || work.sessions === 0) return "No work here yet";
+  const parts = [plural(work.sessions, "session")];
+  parts.push(`${num(work.landed)} accepted`);
+  if (work.insertions > 0 || work.deletions > 0) {
+    parts.push(`+${num(work.insertions)} / −${num(work.deletions)}`);
+  }
+  return parts.join(" · ");
+}
+
+/** Index the per-employee tallies so a grant row can find its own. */
+export function employeeWorkById(
+  employees: readonly RepositoryAiEmployeeWork[],
+): Map<string, RepositoryAiEmployeeWork> {
+  return new Map(employees.map((row) => [row.employeeId, row]));
+}
+
+/** Index the live lines so a running session row can find its own. */
+export function activityBySession(
+  activity: readonly RepositoryAiActivity[],
+): Map<string, RepositoryAiActivity> {
+  return new Map(activity.map((row) => [row.sessionId, row]));
+}
+
+/** Where a session row goes: its own page in the AI work inbox. */
+export function overviewSessionHref(aiBase: string, sessionId: string): string {
+  return `${aiBase}/${sessionId}`;
+}
+
+/**
+ * What the page says when the tallies stopped counting.
+ *
+ * A number that quietly means "the first two thousand" is worse than one that
+ * says so, which is the same rule the work timeline states about its own caps.
+ */
+export function cappedNote(capped: boolean, counts: RepositoryAiCounts): string {
+  return capped ? `Counted over the most recent ${num(counts.total)} sessions.` : "";
+}

--- a/App/client/lib/api.ts
+++ b/App/client/lib/api.ts
@@ -2920,6 +2920,110 @@ export type RepositoryWorkSessionEventsResponse = {
   more: boolean;
 };
 
+// ─────────────────────── the repository's AI work ───────────────────────
+
+/**
+ * How many sessions sit in each state.
+ *
+ * `running`, `attention` and `completed` partition the sessions that are not
+ * archived; `archived` is the rest. The four add up to `total` exactly once.
+ */
+export type RepositoryAiCounts = {
+  total: number;
+  running: number;
+  attention: number;
+  completed: number;
+  archived: number;
+};
+
+/**
+ * What AI work has actually put into this repository — accepted sessions only.
+ * A branch nobody merged changed nothing here, and counting it would measure
+ * how much the employees typed rather than how much of it was any good.
+ */
+export type RepositoryAiLanded = {
+  sessions: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+};
+
+/** One employee's tally here, joined onto its grant by `employeeId`. */
+export type RepositoryAiEmployeeWork = {
+  employeeId: string;
+  sessions: number;
+  landed: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  lastActiveAt: string | null;
+};
+
+/** Where a turn in flight has got to, from the employee's own step list. */
+export type RepositoryAiStepProgress = {
+  done: number;
+  total: number;
+  current: string | null;
+};
+
+/** The live line for one running session, scoped to the turn in flight. */
+export type RepositoryAiActivity = {
+  sessionId: string;
+  /** "Ran npm test → Exit 1", "Read src/app.ts" — empty before the first event. */
+  summary: string;
+  at: string | null;
+  steps: RepositoryAiStepProgress | null;
+  /** Tool calls the turn in flight has made. */
+  toolCalls: number;
+};
+
+/**
+ * A session as the Overview lists it.
+ *
+ * Deliberately not the whole row: the digest is re-read on every activity event
+ * of a running turn, and the three large fields on a session — the brief in
+ * full, the employee's report, the failure text — are all things this list
+ * never shows. `instruction` survives, clipped, because a session nobody
+ * renamed is titled from it.
+ */
+export type RepositoryAiSessionRow = Pick<
+  RepositoryWorkSession,
+  | "id"
+  | "employeeId"
+  | "status"
+  | "title"
+  | "branch"
+  | "turnCount"
+  | "filesChanged"
+  | "insertions"
+  | "deletions"
+  | "publishedBranch"
+  | "pullRequestUrl"
+  | "pullRequestNumber"
+  | "finishedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "updatedAt"
+  | "employee"
+> & {
+  /** The opening instruction, clipped by the server to ~200 characters. */
+  instruction: string;
+};
+
+/** `GET /repositories/:slug/ai-overview` — the Overview page's whole subject. */
+export type RepositoryAiOverview = {
+  counts: RepositoryAiCounts;
+  landed: RepositoryAiLanded;
+  totals: { turns: number; discarded: number };
+  lastActiveAt: string | null;
+  employees: RepositoryAiEmployeeWork[];
+  /** True when the tallies stopped counting. Never let a cap go unsaid. */
+  capped: boolean;
+  /** The sessions the page lists, already in display order. */
+  sessions: RepositoryAiSessionRow[];
+  activity: RepositoryAiActivity[];
+};
+
 // ───────────────────────── Finance AI access ────────────────────────────
 
 /** read < invoice < full — see EmployeeFinanceGrant on the server. */

--- a/App/client/pages/RepositoryOverview.tsx
+++ b/App/client/pages/RepositoryOverview.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Link } from "react-router-dom";
 import {
   AlertCircle,
-  ArrowRight,
   BookOpen,
   Check,
   CheckCircle2,
+  ChevronDown,
   CircleDot,
   FileCode,
   Code2,
@@ -22,8 +22,11 @@ import { Spinner } from "../components/ui/Spinner";
 import { useLiveRefetch } from "../components/CompanySocket";
 import { ConnectForgeModal } from "../components/repositories/ConnectForgeModal";
 import { MarkdownPreview } from "../components/repositories/MarkdownPreview";
+import { AiWorkOverview } from "../components/repositories/AiWorkOverview";
+import { repositoryAiGlanceOf } from "../components/repositories/aiOverview";
 import {
   api,
+  RepositoryAiOverview,
   RepositoryCommandMode,
   RepositoryFileContent,
   RepositoryGrant,
@@ -31,6 +34,7 @@ import {
   RepositoryTestResult,
   RepositoryTreeResponse,
 } from "../lib/api";
+import { errorMessage } from "../lib/errors";
 import { SyncBadge, signInLabel } from "./RepositoriesIndex";
 import { useRepositoriesContext } from "./RepositoriesLayout";
 import { AsyncResourceTagPicker } from "../components/TagPicker";
@@ -42,12 +46,46 @@ const COMMAND_MODE_LABEL: Record<RepositoryCommandMode, string> = {
   all: "Any command",
 };
 
+/**
+ * A Repository, opened.
+ *
+ * This page used to answer "what is this repository": the default branch, the
+ * sign-in mode, the command mode, a grant count, and a three-step explainer of
+ * a workflow the reader had used forty times. Every one of those is a setting
+ * somebody chose once. Nothing on the page moved between visits, which on a
+ * product whose entire premise is that AI employees do the work made the first
+ * screen of a repository the least informative one in the section.
+ *
+ * So the subject is the work now. Who is working here this minute and on what,
+ * what has come back and is waiting for a person to decide, what AI work has
+ * actually been accepted into the repository, and which employee did it. The
+ * settings are still here — they are one disclosure down, under
+ * &ldquo;Repository details&rdquo;, where a fact you need twice a quarter
+ * belongs.
+ *
+ * The set-up explainer survives too, and only for as long as it is true: a
+ * repository nobody can work in still needs to be told what to grant.
+ */
 export default function RepositoryOverview() {
   const { company, repo, reload } = useRepositoriesContext();
   const [testing, setTesting] = React.useState(false);
   const [testResult, setTestResult] = React.useState<RepositoryTestResult | null>(null);
   const [grants, setGrants] = React.useState<RepositoryGrant[] | null>(null);
   const [connectOpen, setConnectOpen] = React.useState(false);
+  const [overview, setOverview] = React.useState<RepositoryAiOverview | null>(null);
+  const [overviewError, setOverviewError] = React.useState<string | null>(null);
+  /**
+   * Which digest read is the current one.
+   *
+   * Both reads here are refetched by a socket frame, and the AI-work one is
+   * refetched on every activity event of a running turn — so two are regularly
+   * in flight at once, and switching repositories leaves an older one still
+   * running against the page that replaced it. Without this counter the slower
+   * answer wins and the page shows another repository's work.
+   */
+  const overviewRequest = React.useRef(0);
+  /** Settings are a reference, not a headline. Closed until somebody asks. */
+  const [detailsOpen, setDetailsOpen] = React.useState(false);
   /** Only consulted once every step is green; before that the steps are the point. */
   const [stepsOpen, setStepsOpen] = React.useState(false);
   /** `null` = there is no README; `undefined` = we have not looked yet. */
@@ -55,22 +93,70 @@ export default function RepositoryOverview() {
   const [readme, setReadme] = React.useState<string | null>(null);
 
   const repoSlug = repo?.slug ?? null;
+  const repoId = repo?.id ?? null;
 
+  /**
+   * Who may work here.
+   *
+   * A failure leaves `grants` null rather than empty. They used to be the same
+   * thing, which was survivable while the list only tinted a badge — but the
+   * page now says "No AI employee has access yet" and asks the reader to go
+   * and grant one, and printing that because a request failed sends somebody
+   * to fix a problem they do not have. Keyed on the slug, not the whole
+   * `repo` object: the layout rebuilds that array on every repository frame,
+   * and depending on it refetched the grants each time.
+   */
   const reloadGrants = React.useCallback(() => {
-    if (!repo) return;
+    if (!repoSlug) return;
     api
-      .get<RepositoryGrantsResponse>(
-        `/api/companies/${company.id}/repositories/${repo.slug}/grants`,
-      )
+      .get<RepositoryGrantsResponse>(`/api/companies/${company.id}/repositories/${repoSlug}/grants`)
       .then((response) => setGrants(response.direct))
-      .catch(() => setGrants([]));
-  }, [company.id, repo]);
+      .catch(() => setGrants(null));
+  }, [company.id, repoSlug]);
+
+  /**
+   * The AI work digest. Read separately from the grants because the two answer
+   * different questions and fail independently: a broken grants read must not
+   * blank the work, and vice versa.
+   */
+  const reloadOverview = React.useCallback(async () => {
+    if (!repoSlug) return;
+    const request = ++overviewRequest.current;
+    try {
+      const next = await api.get<RepositoryAiOverview>(
+        `/api/companies/${company.id}/repositories/${repoSlug}/ai-overview`,
+      );
+      if (request !== overviewRequest.current) return;
+      setOverview(next);
+      setOverviewError(null);
+    } catch (err) {
+      if (request !== overviewRequest.current) return;
+      setOverviewError(errorMessage(err, "Could not load the AI work here"));
+    }
+  }, [company.id, repoSlug]);
 
   React.useEffect(() => {
     reloadGrants();
   }, [reloadGrants]);
 
+  React.useEffect(() => {
+    overviewRequest.current += 1;
+    setOverview(null);
+    setOverviewError(null);
+    setGrants(null);
+    // A connection result belongs to the repository it was run against. The
+    // component is reused across `:slug` navigations, so without this the
+    // previous repository's answer is still on screen under the new name.
+    setTestResult(null);
+    setDetailsOpen(false);
+    void reloadOverview();
+  }, [reloadOverview]);
+
   useLiveRefetch("grant", reloadGrants);
+  // Scoped to this repository: every session, turn, and activity event the
+  // server writes announces itself as a `repository` change, which is exactly
+  // what makes a running turn readable here without a poll.
+  useLiveRefetch("repository", reloadOverview, repoId);
 
   /**
    * Show the README the way every git host does. The root listing comes first
@@ -133,6 +219,15 @@ export default function RepositoryOverview() {
   // bar the server puts on pushing.
   const canConnect = company.role === "owner" || company.role === "admin";
 
+  /**
+   * What the headline reasons over.
+   *
+   * `granted` prefers the grants read over `repo.grantCount` so the two halves
+   * of the page cannot disagree about who may work here, and falls back to the
+   * stored count while that read is outstanding or has failed.
+   */
+  const glance = repositoryAiGlanceOf(overview, grants?.length ?? currentRepo.grantCount);
+
   async function test() {
     setTesting(true);
     setTestResult(null);
@@ -184,7 +279,7 @@ export default function RepositoryOverview() {
         </div>
         <div className="flex shrink-0 gap-2">
           <Link to={`${base}/files`}>
-            <Button>
+            <Button variant="secondary">
               <FileCode size={15} /> Open files
             </Button>
           </Link>
@@ -235,30 +330,99 @@ export default function RepositoryOverview() {
         </section>
       )}
 
-      <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <SummaryCard
-          icon={<GitBranch size={16} />}
-          label="Default branch"
-          value={repo.defaultBranch}
-        />
-        <SummaryCard
-          icon={<Users size={16} />}
-          label="AI access"
-          value={`${repo.grantCount} ${repo.grantCount === 1 ? "employee" : "employees"}`}
-        />
-        <SummaryCard
-          icon={<CircleDot size={16} />}
-          label="Sign-in"
-          // `authMode.toUpperCase()` printed SSH / HTTPS, which names a
-          // protocol rather than answering the question the card asks.
-          value={repo.origin === "local" ? "Not needed" : signInLabel(repo)}
-        />
-        <SummaryCard
-          icon={<Terminal size={16} />}
-          label="AI commands"
-          value={COMMAND_MODE_LABEL[repo.commandMode]}
-        />
-      </div>
+      <AiWorkOverview
+        companyId={company.id}
+        overview={overview}
+        error={overviewError}
+        glance={glance}
+        grants={grants}
+        aiBase={`${base}/ai`}
+        accessHref={`${base}/access`}
+        onRetry={reloadOverview}
+      />
+
+      {/* The explainer is a tutorial, and a tutorial that has been true for six
+        months is furniture. It stays for as long as a step is not green, and
+        folds itself away the moment they all are. */}
+      <section className="mt-8">
+        <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              How work reaches this repository
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+              {allStepsReady
+                ? "Everything is set up — an employee can read this repository, work on it, and hand the result back."
+                : "Every AI employee already knows how to read and write. What you grant decides which repositories it may touch, and how far its work can travel."}
+            </p>
+          </div>
+          {allStepsReady && (
+            <button
+              type="button"
+              onClick={() => setStepsOpen((current) => !current)}
+              aria-expanded={stepsOpen}
+              className="text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+            >
+              {stepsOpen ? "Hide the steps" : "How this works"}
+            </button>
+          )}
+        </div>
+        {showSteps && (
+          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+            <WorkflowStep
+              number="1"
+              icon={<Code2 size={17} />}
+              title="Read and edit the files"
+              detail="Reading, editing, searching, and running tests are built in. Nothing to set up."
+              status="Ready"
+              ready
+            />
+            <WorkflowStep
+              number="2"
+              icon={<GitBranch size={17} />}
+              title="Work on a branch and commit"
+              detail="An employee you grant access to gets its own copy of this repository. It never sees the credentials behind it."
+              status={
+                grants === null
+                  ? "Checking…"
+                  : writeGrants.length > 0
+                    ? `${writeGrants.length} ready`
+                    : "Nobody yet"
+              }
+              ready={writeGrants.length > 0}
+            />
+            <WorkflowStep
+              number="3"
+              icon={<GitPullRequest size={17} />}
+              title="Hand the work back to you"
+              detail={
+                // Three different situations, and only the first has a next
+                // step. A remote on a host no Integration covers — a GitLab,
+                // a Bitbucket, a plain git server — can never get a pull
+                // request button, so promising one is worse than silence:
+                // it sends the reader looking for a Connection that does not
+                // exist, on a step that will never turn green.
+                repo.forge
+                  ? `You read the diff and decide whether it lands. Grant the employee a ${repo.forge.name} Connection and it can open the pull request itself.`
+                  : repo.origin === "remote"
+                    ? "You read the diff and decide whether it lands, then push it from here. Opening a pull request needs GitHub or a Forgejo / Gitea server Genosyn can reach."
+                    : "You read the diff and decide whether it lands. Connect this repository to a git host and the employee can open the pull request itself."
+              }
+              status={
+                grants === null
+                  ? "Checking…"
+                  : prReady.length > 0
+                    ? `${prReady.length} ready`
+                    : repo.forge
+                      ? "Needs a Connection"
+                      : "Review here"
+              }
+              ready={prReady.length > 0}
+              last
+            />
+          </div>
+        )}
+      </section>
 
       {readmeName && (
         <section className="mt-8">
@@ -286,150 +450,108 @@ export default function RepositoryOverview() {
         </section>
       )}
 
+      {/* Settings, kept and demoted. They were the first thing on this page and
+        none of them had changed since the day the repository was added. */}
       <section className="mt-8">
-        <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
-          <div>
-            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
-              What an AI employee can do here
-            </h2>
-            <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
-              {allStepsReady
-                ? "Everything is set up — an employee can read this repository, work on it, and hand the result back."
-                : "Every AI employee already knows how to read and write. What you grant decides which repositories it may touch, and how far its work can travel."}
-            </p>
-          </div>
-          {/* Once every step is green this is a tutorial nobody needs any
-            more, and it was taking most of the page on a repository someone
-            has used for six months. It folds itself away and stays available. */}
-          {allStepsReady && (
-            <button
-              type="button"
-              onClick={() => setStepsOpen((current) => !current)}
-              aria-expanded={stepsOpen}
-              className="text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
-            >
-              {stepsOpen ? "Hide the steps" : "How this works"}
-            </button>
-          )}
-        </div>
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
-          {showSteps && (
-            <>
-              <WorkflowStep
-                number="1"
-                icon={<Code2 size={17} />}
-                title="Read and edit the files"
-                detail="Reading, editing, searching, and running tests are built in. Nothing to set up."
-                status="Ready"
-                ready
-              />
-              <WorkflowStep
-                number="2"
-                icon={<GitBranch size={17} />}
-                title="Work on a branch and commit"
-                detail="An employee you grant access to gets its own copy of this repository. It never sees the credentials behind it."
-                status={
-                  grants === null
-                    ? "Checking…"
-                    : writeGrants.length > 0
-                      ? `${writeGrants.length} ready`
-                      : "Nobody yet"
-                }
-                ready={writeGrants.length > 0}
-              />
-              <WorkflowStep
-                number="3"
-                icon={<GitPullRequest size={17} />}
-                title="Hand the work back to you"
-                detail={
-                  // Three different situations, and only the first has a next
-                  // step. A remote on a host no Integration covers — a GitLab,
-                  // a Bitbucket, a plain git server — can never get a pull
-                  // request button, so promising one is worse than silence:
-                  // it sends the reader looking for a Connection that does not
-                  // exist, on a step that will never turn green.
-                  repo.forge
-                    ? `You read the diff and decide whether it lands. Grant the employee a ${repo.forge.name} Connection and it can open the pull request itself.`
-                    : repo.origin === "remote"
-                      ? "You read the diff and decide whether it lands, then push it from here. Opening a pull request needs GitHub or a Forgejo / Gitea server Genosyn can reach."
-                      : "You read the diff and decide whether it lands. Connect this repository to a git host and the employee can open the pull request itself."
-                }
-                status={
-                  grants === null
-                    ? "Checking…"
-                    : prReady.length > 0
-                      ? `${prReady.length} ready`
-                      : repo.forge
-                        ? "Needs a Connection"
-                        : "Review here"
-                }
-                ready={prReady.length > 0}
-                last
-              />
-            </>
-          )}
-          <div
-            className={
-              "flex flex-col gap-3 bg-slate-50/70 px-4 py-3 text-xs text-slate-600 sm:flex-row sm:items-center sm:justify-between dark:bg-slate-800/30 dark:text-slate-300 " +
-              (showSteps ? "border-t border-slate-100 dark:border-slate-800" : "")
-            }
-          >
-            {/* The example used to be dead text beside a link to a different
-              page. It is the action now, and it lands where it is used. */}
-            <span>
-              {currentRepo.kind === "documents"
-                ? "Try: “Read the pricing page and rewrite it to lead with the enterprise tier.”"
-                : "Try: “Add a health check endpoint, cover it with a test, and run the suite.”"}
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((current) => !current)}
+          aria-expanded={detailsOpen}
+          className="flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800/60"
+        >
+          <span>
+            <span className="block text-sm font-medium text-slate-900 dark:text-slate-100">
+              Repository details
             </span>
-            <Link
-              to={`${base}/ai`}
-              className="inline-flex shrink-0 items-center gap-1 font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
-            >
-              Ask an employee to do something <ArrowRight size={13} />
-            </Link>
-          </div>
-        </div>
-      </section>
+            <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+              Branch, sign-in, what an employee may run
+              {repo.origin === "remote" ? ", and the connection check" : ""}.
+            </span>
+          </span>
+          <ChevronDown
+            size={16}
+            className={
+              "shrink-0 text-slate-400 transition-transform " + (detailsOpen ? "rotate-180" : "")
+            }
+          />
+        </button>
 
-      {repo.origin === "remote" && (
-        <section className="mt-8">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <div>
-              <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
-                Connection health
-              </h2>
-              <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
-                Verify the clone URL and available sign-in before assigning work.
-              </p>
+        {detailsOpen && (
+          <>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <SummaryCard
+                icon={<GitBranch size={16} />}
+                label="Default branch"
+                value={repo.defaultBranch}
+              />
+              <SummaryCard
+                icon={<Users size={16} />}
+                label="AI access"
+                // The same source the roster above counts, so the two cannot
+                // disagree on one screen: `repo.grantCount` only moves when the
+                // layout refetches the repository list, while the roster is
+                // refreshed by every grant change.
+                value={`${glance.granted} ${glance.granted === 1 ? "employee" : "employees"}`}
+              />
+              <SummaryCard
+                icon={<CircleDot size={16} />}
+                label="Sign-in"
+                // `authMode.toUpperCase()` printed SSH / HTTPS, which names a
+                // protocol rather than answering the question the card asks.
+                value={repo.origin === "local" ? "Not needed" : signInLabel(repo)}
+              />
+              <SummaryCard
+                icon={<Terminal size={16} />}
+                label="AI commands"
+                value={COMMAND_MODE_LABEL[repo.commandMode]}
+              />
             </div>
-            <Button variant="secondary" onClick={test} disabled={testing}>
-              {testing ? <Spinner size={14} /> : <Plug size={14} />}
-              {testing ? "Testing…" : "Test connection"}
-            </Button>
-          </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
-            {testResult ? (
-              <Result result={testResult} />
-            ) : repo.lastSyncStatus === "error" && repo.lastSyncError ? (
-              <div className="flex items-start gap-2 text-sm text-rose-700 dark:text-rose-300">
-                <AlertCircle size={16} className="mt-0.5 shrink-0" />
-                <span className="break-words">{repo.lastSyncError}</span>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
-                {repo.lastSyncStatus === "ok" ? (
-                  <CheckCircle2 size={16} className="text-emerald-600 dark:text-emerald-400" />
-                ) : (
-                  <Plug size={16} className="text-slate-400" />
-                )}
-                {repo.lastSyncStatus === "ok"
-                  ? "The most recent connection check succeeded."
-                  : "This repository has not been tested yet."}
+
+            {repo.origin === "remote" && (
+              <div className="mt-3 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      Connection health
+                    </div>
+                    <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+                      Verify the clone URL and available sign-in before assigning work.
+                    </p>
+                  </div>
+                  <Button variant="secondary" onClick={test} disabled={testing}>
+                    {testing ? <Spinner size={14} /> : <Plug size={14} />}
+                    {testing ? "Testing…" : "Test connection"}
+                  </Button>
+                </div>
+                <div className="mt-3 border-t border-slate-100 pt-3 dark:border-slate-800">
+                  {testResult ? (
+                    <Result result={testResult} />
+                  ) : repo.lastSyncStatus === "error" && repo.lastSyncError ? (
+                    <div className="flex items-start gap-2 text-sm text-rose-700 dark:text-rose-300">
+                      <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                      <span className="break-words">{repo.lastSyncError}</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                      {repo.lastSyncStatus === "ok" ? (
+                        <CheckCircle2
+                          size={16}
+                          className="text-emerald-600 dark:text-emerald-400"
+                        />
+                      ) : (
+                        <Plug size={16} className="text-slate-400" />
+                      )}
+                      {repo.lastSyncStatus === "ok"
+                        ? "The most recent connection check succeeded."
+                        : "This repository has not been tested yet."}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
-          </div>
-        </section>
-      )}
+          </>
+        )}
+      </section>
 
       <ConnectForgeModal
         open={connectOpen}

--- a/App/server/routes/repositoryAiOverviewRoutes.test.ts
+++ b/App/server/routes/repositoryAiOverviewRoutes.test.ts
@@ -1,0 +1,505 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import express from "express";
+
+import { config } from "../../config.js";
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { Company } from "../db/entities/Company.js";
+import { EmployeeRepositoryGrant } from "../db/entities/EmployeeRepositoryGrant.js";
+import { Membership, type Role } from "../db/entities/Membership.js";
+import { Repository } from "../db/entities/Repository.js";
+import {
+  RepositoryWorkSession,
+  type RepositoryWorkSessionStatus,
+} from "../db/entities/RepositoryWorkSession.js";
+import { RepositoryWorkSessionEvent } from "../db/entities/RepositoryWorkSessionEvent.js";
+import { RepositoryWorkSessionTurn } from "../db/entities/RepositoryWorkSessionTurn.js";
+import { User } from "../db/entities/User.js";
+import { errorHandler } from "../middleware/error.js";
+import { repositoryCheckoutExists } from "../services/repositoryWorkspace.js";
+import { closeTestDb, initTestDb, insert, resetTestDb } from "../test/dbHarness.js";
+import { repositoryContentRouter } from "./repositoryContent.js";
+
+/**
+ * The one request the Repository Overview page is built on.
+ *
+ * `services/repositoryAiOverview.ts` is covered as arithmetic over rows. What
+ * only exists here is the HTTP contract the page reads: the eight fields it
+ * draws, that an ordinary Member may ask for them — this is a read, the same
+ * class as the session list — and that a session filed out of the inbox still
+ * counts even though it is no longer listed.
+ *
+ * The last group is the one worth keeping honest. The route is mounted with
+ * `workspace: false`, so a repository whose remote resolves nowhere still
+ * answers what its employees did — a question that has nothing to do with the
+ * files on disk. That is a one-word option somebody could drop while tidying,
+ * so it is pinned here rather than assumed.
+ */
+
+let server: Server;
+let baseUrl = "";
+let dataDir: string;
+const originalDataDir = config.dataDir;
+let actingUserId: string | null = null;
+const codingTools = config.agent.codingTools as {
+  enabled: boolean;
+  executionMode: "host" | "bubblewrap" | "disabled";
+  allowUnsafeHostExecution: boolean;
+};
+const originalCodingTools = { ...codingTools };
+
+before(async () => {
+  await initTestDb();
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "genosyn-ai-overview-routes-"));
+  (config as { dataDir: string }).dataDir = dataDir;
+  // Same reason the work-session route tests do this: no server boots here, so
+  // the shipped `bubblewrap` default would send every Git child through a
+  // sandbox this host may not have. Pin the mode `resolveCodingExecutionMode`
+  // settles on wherever bubblewrap cannot run, so this file pins the route
+  // contract rather than the host's user-namespace policy.
+  codingTools.enabled = true;
+  codingTools.executionMode = "disabled";
+  codingTools.allowUnsafeHostExecution = false;
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { session: unknown }).session = actingUserId
+      ? { userId: actingUserId, sessionVersion: 0, authenticatedAt: Date.now() }
+      : null;
+    next();
+  });
+  app.use("/api/companies/:cid", repositoryContentRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  await closeTestDb();
+  (config as { dataDir: string }).dataDir = originalDataDir;
+  Object.assign(codingTools, originalCodingTools);
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+let company: Company;
+let owner: User;
+let member: User;
+let outsider: User;
+let employee: AIEmployee;
+let repository: Repository;
+
+beforeEach(async () => {
+  await resetTestDb();
+  owner = await insert(User, {
+    email: "owner@example.com",
+    name: "Owner",
+    passwordHash: "x",
+    sessionVersion: 0,
+  });
+  member = await insert(User, {
+    email: "member@example.com",
+    name: "Member",
+    passwordHash: "x",
+    sessionVersion: 0,
+  });
+  outsider = await insert(User, {
+    email: "outsider@example.com",
+    name: "Outsider",
+    passwordHash: "x",
+    sessionVersion: 0,
+  });
+  company = await insert(Company, { name: "Acme", slug: "acme", ownerId: owner.id });
+  await insert(Membership, { companyId: company.id, userId: owner.id, role: "owner" as Role });
+  await insert(Membership, { companyId: company.id, userId: member.id, role: "member" as Role });
+  employee = await insert(AIEmployee, {
+    companyId: company.id,
+    name: "Ada",
+    slug: "ada",
+    role: "Engineer",
+  });
+  repository = await insert(Repository, {
+    companyId: company.id,
+    name: "Strategy",
+    slug: "strategy",
+    description: "",
+    origin: "local",
+    kind: "documents",
+    gitUrl: "",
+    defaultBranch: "main",
+    authMode: "none",
+    committerName: "Genosyn",
+    committerEmail: "repositories@genosyn.local",
+    lastSyncStatus: "unknown",
+    lastSyncError: "",
+  });
+  await insert(EmployeeRepositoryGrant, {
+    employeeId: employee.id,
+    repositoryId: repository.id,
+    accessLevel: "write",
+  });
+  actingUserId = member.id;
+});
+
+type OverviewBody = {
+  counts: {
+    total: number;
+    running: number;
+    attention: number;
+    completed: number;
+    archived: number;
+  };
+  landed: { sessions: number; filesChanged: number; insertions: number; deletions: number };
+  totals: { turns: number; discarded: number };
+  lastActiveAt: string | null;
+  employees: Array<{
+    employeeId: string;
+    sessions: number;
+    landed: number;
+    lastActiveAt: string | null;
+  }>;
+  capped: boolean;
+  sessions: Array<{ id: string; status: string; employee: { name: string } | null }>;
+  activity: Array<{
+    sessionId: string;
+    summary: string;
+    at: string | null;
+    steps: { done: number; total: number; current: string | null } | null;
+    toolCalls: number;
+  }>;
+};
+
+const overviewUrl = (slug = "strategy") =>
+  `${baseUrl}/api/companies/${company.id}/repositories/${slug}/ai-overview`;
+
+async function call(
+  method: "GET" | "POST",
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await fetch(url, {
+    method,
+    headers: body === undefined ? {} : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : {} };
+}
+
+/** The digest, as the page reads it. Every test here goes through the wire. */
+async function overview(): Promise<OverviewBody> {
+  const result = await call("GET", overviewUrl());
+  assert.equal(result.status, 200);
+  return result.body as unknown as OverviewBody;
+}
+
+async function seedSession(
+  values: Partial<RepositoryWorkSession> & { status: RepositoryWorkSessionStatus },
+): Promise<RepositoryWorkSession> {
+  return insert(RepositoryWorkSession, {
+    companyId: company.id,
+    repositoryId: repository.id,
+    employeeId: employee.id,
+    requestedByUserId: member.id,
+    title: values.status,
+    instruction: "Rewrite the plan",
+    turnCount: 1,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    ...values,
+  });
+}
+
+/** One session per outcome the page draws, with a distinct turn count each. */
+async function seedEveryOutcome(): Promise<Record<string, RepositoryWorkSession>> {
+  return {
+    running: await seedSession({ status: "running", turnCount: 1 }),
+    ready: await seedSession({ status: "ready", turnCount: 2 }),
+    archived: await seedSession({
+      status: "ready",
+      turnCount: 3,
+      archivedAt: new Date("2024-05-01T00:00:00.000Z"),
+    }),
+    published: await seedSession({
+      status: "published",
+      turnCount: 4,
+      filesChanged: 3,
+      insertions: 40,
+      deletions: 5,
+    }),
+    discarded: await seedSession({
+      status: "discarded",
+      turnCount: 5,
+      filesChanged: 9,
+      insertions: 90,
+      deletions: 90,
+    }),
+  };
+}
+
+describe("reading the digest", () => {
+  test("answers with every field the Overview page draws", async () => {
+    await seedEveryOutcome();
+    const result = await call("GET", overviewUrl());
+    assert.equal(result.status, 200);
+    assert.deepEqual(Object.keys(result.body).sort(), [
+      "activity",
+      "capped",
+      "counts",
+      "employees",
+      "landed",
+      "lastActiveAt",
+      "sessions",
+      "totals",
+    ]);
+    const body = result.body as unknown as OverviewBody;
+    assert.equal(body.capped, false);
+    assert.match(String(body.lastActiveAt), /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("an ordinary Member may read it — it is not an admin surface", async () => {
+    await seedSession({ status: "ready" });
+    actingUserId = member.id;
+    const body = await overview();
+    assert.equal(body.counts.attention, 1);
+  });
+
+  test("a non-member gets nothing", async () => {
+    actingUserId = outsider.id;
+    const result = await call("GET", overviewUrl());
+    assert.equal(result.status, 403);
+  });
+
+  test("a signed-out request does not get the digest", async () => {
+    actingUserId = null;
+    const result = await call("GET", overviewUrl());
+    assert.equal(result.status, 401);
+  });
+
+  test("an unknown repository is not found", async () => {
+    const result = await call("GET", overviewUrl("no-such-repository"));
+    assert.equal(result.status, 404);
+    assert.equal(result.body.error, "Repository not found");
+  });
+});
+
+describe("what the digest says about the rows", () => {
+  test("counts every session once and splits them by outcome", async () => {
+    await seedEveryOutcome();
+    const body = await overview();
+    assert.deepEqual(body.counts, {
+      total: 5,
+      running: 1,
+      attention: 1,
+      completed: 2,
+      archived: 1,
+    });
+    // The four buckets are a partition of `total`, which is the only reason the
+    // numbers on the page can be read as parts of one whole.
+    const { running, attention, completed, archived, total } = body.counts;
+    assert.equal(running + attention + completed + archived, total);
+  });
+
+  test("an archived session is counted but not listed", async () => {
+    const seeded = await seedEveryOutcome();
+    const body = await overview();
+    assert.deepEqual(
+      body.sessions.map((row) => row.id).sort(),
+      [seeded.running.id, seeded.ready.id, seeded.published.id, seeded.discarded.id].sort(),
+    );
+    assert.equal(
+      body.sessions.some((row) => row.id === seeded.archived.id),
+      false,
+    );
+    assert.equal(body.counts.archived, 1);
+    assert.equal(body.counts.total, 5);
+  });
+
+  test("only accepted work counts as landed", async () => {
+    await seedEveryOutcome();
+    const body = await overview();
+    // The published session alone. The discarded one's nine files never reached
+    // the repository, however much the employee typed into them.
+    assert.deepEqual(body.landed, { sessions: 1, filesChanged: 3, insertions: 40, deletions: 5 });
+    // Turns are counted across every session, archived ones included — the
+    // instruction was still given.
+    assert.deepEqual(body.totals, { turns: 15, discarded: 1 });
+  });
+
+  test("credits the employee for all of its work, listed or not", async () => {
+    await seedEveryOutcome();
+    const body = await overview();
+    assert.equal(body.employees.length, 1);
+    assert.equal(body.employees[0].employeeId, employee.id);
+    assert.equal(body.employees[0].sessions, 5);
+    assert.equal(body.employees[0].landed, 1);
+    assert.match(String(body.employees[0].lastActiveAt), /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("names the employee on each listed session, the way the list route does", async () => {
+    await seedSession({ status: "ready" });
+    const body = await overview();
+    assert.equal(body.sessions.length, 1);
+    assert.equal(body.sessions[0].employee?.name, "Ada");
+  });
+
+  test("another repository's sessions are not counted here", async () => {
+    await seedEveryOutcome();
+    const other = await insert(Repository, {
+      companyId: company.id,
+      name: "Other",
+      slug: "other",
+      description: "",
+      origin: "local",
+      kind: "code",
+      gitUrl: "",
+      defaultBranch: "main",
+      authMode: "none",
+      lastSyncStatus: "unknown",
+      lastSyncError: "",
+    });
+    await insert(RepositoryWorkSession, {
+      companyId: company.id,
+      repositoryId: other.id,
+      employeeId: employee.id,
+      requestedByUserId: member.id,
+      title: "Elsewhere",
+      instruction: "Elsewhere",
+      status: "published",
+      turnCount: 7,
+      filesChanged: 11,
+      insertions: 11,
+      deletions: 11,
+    });
+    const body = await overview();
+    assert.equal(body.counts.total, 5);
+    assert.deepEqual(body.landed, { sessions: 1, filesChanged: 3, insertions: 40, deletions: 5 });
+    assert.equal(body.totals.turns, 15);
+  });
+
+  test("says nothing rather than guessing where no employee has worked", async () => {
+    const body = await overview();
+    assert.deepEqual(body.counts, {
+      total: 0,
+      running: 0,
+      attention: 0,
+      completed: 0,
+      archived: 0,
+    });
+    assert.deepEqual(body.sessions, []);
+    assert.deepEqual(body.activity, []);
+    assert.deepEqual(body.employees, []);
+    assert.equal(body.lastActiveAt, null);
+  });
+});
+
+describe("the live line for a turn in flight", () => {
+  test("comes back with the newest readable event and the employee's own progress", async () => {
+    const session = await seedSession({ status: "running" });
+    const turn = await insert(RepositoryWorkSessionTurn, {
+      companyId: company.id,
+      sessionId: session.id,
+      ordinal: 1,
+      instruction: "Rewrite the plan",
+      reply: "",
+      status: "running",
+      requestedByUserId: member.id,
+    });
+    const event = (values: Partial<RepositoryWorkSessionEvent>) =>
+      insert(RepositoryWorkSessionEvent, {
+        companyId: company.id,
+        repositoryId: repository.id,
+        sessionId: session.id,
+        turnId: turn.id,
+        summary: "",
+        detailJson: "",
+        ...values,
+      });
+    await event({
+      ordinal: 1,
+      kind: "text",
+      detailJson: JSON.stringify({ text: "I will start with the plan." }),
+    });
+    await event({ ordinal: 2, kind: "tool_use", name: "read_file", summary: "Read docs/plan.md" });
+    await event({ ordinal: 3, kind: "tool_result", summary: "Ran npm test → Exit 1" });
+    await event({
+      ordinal: 4,
+      kind: "steps",
+      summary: "Updated the plan",
+      detailJson: JSON.stringify({
+        steps: [
+          { text: "Read the plan", status: "completed" },
+          { text: "Rewrite it", status: "in_progress" },
+          { text: "Run the tests", status: "pending" },
+        ],
+      }),
+    });
+
+    const body = await overview();
+    assert.equal(body.activity.length, 1);
+    const line = body.activity[0];
+    assert.equal(line.sessionId, session.id);
+    // The newest event is the step update, and its summary is deliberately not
+    // the line — the progress beside it already says that. The tool result
+    // under it is the newest thing that tells a reader something else.
+    assert.equal(line.summary, "Ran npm test → Exit 1");
+    assert.deepEqual(line.steps, { done: 1, total: 3, current: "Rewrite it" });
+    assert.equal(line.toolCalls, 1);
+    assert.match(String(line.at), /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("a session nobody is working on gets no live line", async () => {
+    await seedSession({ status: "ready" });
+    const body = await overview();
+    assert.equal(body.sessions.length, 1);
+    assert.deepEqual(body.activity, []);
+  });
+});
+
+describe("a remote that cannot be reached", () => {
+  /** RFC 6761 reserves `.invalid`, so this fails in DNS rather than dialing out. */
+  const unreachable = "https://genosyn.invalid/acme/strategy.git";
+
+  beforeEach(async () => {
+    await AppDataSource.getRepository(Repository).update(
+      { id: repository.id },
+      { origin: "remote", gitUrl: unreachable },
+    );
+  });
+
+  test("does not stop the page from saying what the employees did", async () => {
+    await seedEveryOutcome();
+    const body = await overview();
+    assert.equal(body.counts.total, 5);
+    // The point of `workspace: false`: no clone was attempted at all, so there
+    // is still nothing on disk for this repository.
+    const row = await AppDataSource.getRepository(Repository).findOneByOrFail({
+      id: repository.id,
+    });
+    assert.equal(row.gitUrl, unreachable);
+    assert.equal(repositoryCheckoutExists(row), false);
+  });
+
+  test("the workspace routes on the same repository do fail — the digest is the exception", async () => {
+    // Without this the test above proves nothing: it would pass just as well on
+    // a remote that happened to be reachable.
+    const result = await call(
+      "GET",
+      `${baseUrl}/api/companies/${company.id}/repositories/strategy/workspace/status`,
+    );
+    assert.equal(result.status, 400);
+    assert.match(String(result.body.error), /clone/);
+  });
+});

--- a/App/server/routes/repositoryContent.ts
+++ b/App/server/routes/repositoryContent.ts
@@ -75,6 +75,7 @@ import {
   serializeWorkSessionAttachment,
   WORK_SESSION_ATTACHMENTS_MAX,
 } from "../services/repositoryWorkSessionAttachments.js";
+import { repositoryAiOverview } from "../services/repositoryAiOverview.js";
 
 /**
  * Working with a Repository's *contents* — the file tree, the editor, history,
@@ -649,6 +650,26 @@ repositoryContentRouter.get(
     });
     res.json({ sessions: await hydrateSessions(repo.companyId, sessions) });
   }),
+);
+
+/**
+ * What AI Employees have done in this repository, digested.
+ *
+ * The Overview page's whole subject. It takes no parameters — there is
+ * deliberately nothing to page through here, because a digest that can be
+ * paged is a list, and the list is the AI work inbox one click away. Mounted
+ * with `workspace: false` for the reason the session reads are: this answers a
+ * question *about* the repository, and a remote that cannot be reached must
+ * not be able to hide the answer behind a clone error.
+ */
+repositoryContentRouter.get(
+  "/repositories/:slug/ai-overview",
+  withRepository(
+    async (repo, _req, res) => {
+      res.json(await repositoryAiOverview(repo));
+    },
+    { workspace: false },
+  ),
 );
 
 /** The AI Employees a Member can send at this repository — those granted it. */

--- a/App/server/services/repositoryAiOverview.test.ts
+++ b/App/server/services/repositoryAiOverview.test.ts
@@ -1,0 +1,847 @@
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, test } from "node:test";
+
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import { Company } from "../db/entities/Company.js";
+import { Repository } from "../db/entities/Repository.js";
+import {
+  RepositoryWorkSession,
+  type RepositoryWorkSessionStatus,
+} from "../db/entities/RepositoryWorkSession.js";
+import { RepositoryWorkSessionEvent } from "../db/entities/RepositoryWorkSessionEvent.js";
+import { RepositoryWorkSessionTurn } from "../db/entities/RepositoryWorkSessionTurn.js";
+import { closeTestDb, initTestDb, insert, resetTestDb, testId } from "../test/dbHarness.js";
+import {
+  AI_OVERVIEW_LIST_LIMIT,
+  AI_OVERVIEW_RECENT_LIMIT,
+  activitySummary,
+  aiOverviewGroup,
+  pickOverviewSessionIds,
+  repositoryAiOverview,
+  stepProgress,
+  summarizeRepositoryAiWork,
+  type RepositoryAiSessionStat,
+} from "./repositoryAiOverview.js";
+
+/**
+ * The numbers and sentences the Repository Overview leads with.
+ *
+ * Everything here is a claim a reader will believe without checking: that the
+ * four counts are the whole story ("11 sessions" had better be the same 11 the
+ * four buckets describe), that "landed" means work a Member accepted rather
+ * than work an employee typed, and that a session filed out of the inbox stops
+ * appearing in a queue without its commits vanishing from the totals. Those are
+ * arithmetic, so they are pinned as arithmetic — including the partition
+ * itself, which is the invariant a fifth bucket or a fifth status would quietly
+ * break.
+ *
+ * The rest pins the reading of rows the server did not write: an employee's own
+ * step list, and narration that arrives as JSON. Both are read defensively on
+ * purpose, and a defensive read is only defensive while something proves the
+ * malformed cases still return "nothing" rather than `NaN`, `"0 of 0"`, or a
+ * thrown error on a page that is meant to be a glance.
+ *
+ * The last block runs the digest against a real database, because the display
+ * order, the hydration of employees, and "the newest steps event, however far
+ * behind the tail it is" are claims about queries that no pure test can make.
+ */
+
+before(initTestDb);
+after(closeTestDb);
+
+function at(iso: string): Date {
+  return new Date(iso);
+}
+
+// ─────────────────────────── the arithmetic ─────────────────────────────
+
+let nextStatId = 0;
+
+function stat(over: Partial<RepositoryAiSessionStat> = {}): RepositoryAiSessionStat {
+  nextStatId += 1;
+  return {
+    id: `stat-${nextStatId}`,
+    employeeId: "employee-1",
+    status: "ready",
+    archivedAt: null,
+    turnCount: 1,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    updatedAt: at("2026-01-01T00:00:00.000Z"),
+    ...over,
+  };
+}
+
+describe("aiOverviewGroup", () => {
+  test("splits the statuses the way the AI work inbox does", () => {
+    assert.equal(aiOverviewGroup("running"), "running");
+    assert.equal(aiOverviewGroup("published"), "completed");
+    assert.equal(aiOverviewGroup("discarded"), "completed");
+    // `empty` is a finished answer of "nothing to change" — it still wants a
+    // human to say so, which is why it is attention rather than completed.
+    for (const status of [
+      "ready",
+      "empty",
+      "proposed",
+      "failed",
+    ] as RepositoryWorkSessionStatus[]) {
+      assert.equal(aiOverviewGroup(status), "attention");
+    }
+  });
+});
+
+describe("summarizeRepositoryAiWork", () => {
+  test("the four counts partition the sessions and add up to the total exactly once", () => {
+    const rows = [
+      stat({ status: "running" }),
+      stat({ status: "running" }),
+      stat({ status: "ready" }),
+      stat({ status: "empty" }),
+      stat({ status: "proposed" }),
+      stat({ status: "failed" }),
+      stat({ status: "published" }),
+      stat({ status: "discarded" }),
+      stat({ status: "running", archivedAt: at("2026-02-01T00:00:00.000Z") }),
+      stat({ status: "ready", archivedAt: "2026-02-01T00:00:00.000Z" }),
+      stat({ status: "published", archivedAt: at("2026-02-01T00:00:00.000Z") }),
+    ];
+
+    const { counts } = summarizeRepositoryAiWork(rows);
+
+    assert.deepEqual(counts, { total: 11, running: 2, attention: 4, completed: 2, archived: 3 });
+    assert.equal(
+      counts.running + counts.attention + counts.completed + counts.archived,
+      counts.total,
+      "every session is counted in exactly one bucket",
+    );
+    assert.equal(counts.total, rows.length);
+  });
+
+  test("a session waiting on a human stops waiting once it is filed away", () => {
+    const { counts } = summarizeRepositoryAiWork([
+      stat({ status: "ready" }),
+      stat({ status: "ready", archivedAt: at("2026-02-02T00:00:00.000Z") }),
+    ]);
+
+    assert.equal(counts.attention, 1);
+    assert.equal(counts.archived, 1);
+    assert.equal(counts.total, 2);
+  });
+
+  test("landed counts published work only, and filing it away does not un-land it", () => {
+    const { landed, counts } = summarizeRepositoryAiWork([
+      stat({ status: "published", filesChanged: 3, insertions: 40, deletions: 5 }),
+      stat({
+        status: "published",
+        filesChanged: 1,
+        insertions: 2,
+        deletions: 1,
+        archivedAt: at("2026-02-03T00:00:00.000Z"),
+      }),
+      stat({ status: "discarded", filesChanged: 9, insertions: 900, deletions: 900 }),
+      stat({ status: "ready", filesChanged: 7, insertions: 70, deletions: 7 }),
+      stat({ status: "proposed", filesChanged: 5, insertions: 50, deletions: 5 }),
+    ]);
+
+    assert.deepEqual(landed, { sessions: 2, filesChanged: 4, insertions: 42, deletions: 6 });
+    // A branch nobody accepted changed nothing here, however big its diff was.
+    assert.equal(counts.completed, 2);
+  });
+
+  test("totals count every instruction given and every session thrown away", () => {
+    const { totals } = summarizeRepositoryAiWork([
+      stat({ status: "running", turnCount: 2 }),
+      stat({ status: "discarded", turnCount: 5 }),
+      stat({ status: "discarded", turnCount: 1, archivedAt: at("2026-02-04T00:00:00.000Z") }),
+      stat({ status: "published", turnCount: 3 }),
+      stat({ status: "ready", turnCount: 0 }),
+    ]);
+
+    assert.deepEqual(totals, { turns: 11, discarded: 2 });
+  });
+
+  test("an employee's tally counts every session but lands only published work", () => {
+    const { employees } = summarizeRepositoryAiWork([
+      stat({
+        employeeId: "ada",
+        status: "published",
+        filesChanged: 2,
+        insertions: 20,
+        deletions: 2,
+        updatedAt: at("2026-03-01T10:00:00.000Z"),
+      }),
+      stat({
+        employeeId: "ada",
+        status: "ready",
+        filesChanged: 9,
+        insertions: 90,
+        deletions: 9,
+        updatedAt: at("2026-03-03T10:00:00.000Z"),
+      }),
+      stat({
+        employeeId: "ada",
+        status: "discarded",
+        filesChanged: 9,
+        insertions: 90,
+        deletions: 9,
+        updatedAt: at("2026-03-02T10:00:00.000Z"),
+      }),
+      stat({ employeeId: "bo", status: "running", updatedAt: at("2026-03-04T10:00:00.000Z") }),
+    ]);
+
+    assert.deepEqual(
+      employees.find((row) => row.employeeId === "ada"),
+      {
+        employeeId: "ada",
+        sessions: 3,
+        landed: 1,
+        filesChanged: 2,
+        insertions: 20,
+        deletions: 2,
+        lastActiveAt: "2026-03-03T10:00:00.000Z",
+      },
+    );
+    assert.deepEqual(
+      employees.find((row) => row.employeeId === "bo"),
+      {
+        employeeId: "bo",
+        sessions: 1,
+        landed: 0,
+        filesChanged: 0,
+        insertions: 0,
+        deletions: 0,
+        lastActiveAt: "2026-03-04T10:00:00.000Z",
+      },
+    );
+  });
+
+  test("employees are ordered by landed, then sessions, then recency, then id", () => {
+    const rows = [
+      // Two employees whose tallies are identical down to the millisecond: the
+      // id breaks the tie, so the page does not reshuffle between two reads.
+      stat({ employeeId: "fox", updatedAt: at("2026-05-03T00:00:00.000Z") }),
+      stat({ employeeId: "eve", updatedAt: at("2026-05-03T00:00:00.000Z") }),
+      stat({ employeeId: "dan", updatedAt: at("2026-05-04T00:00:00.000Z") }),
+      stat({ employeeId: "cat", updatedAt: at("2026-05-05T00:00:00.000Z") }),
+      stat({ employeeId: "bob", status: "published" }),
+      stat({ employeeId: "bob", status: "ready" }),
+      stat({ employeeId: "amy", status: "published" }),
+      stat({ employeeId: "amy", status: "ready" }),
+      stat({ employeeId: "amy", status: "failed" }),
+      stat({ employeeId: "zed", status: "published" }),
+      stat({ employeeId: "zed", status: "published" }),
+    ];
+
+    const { employees } = summarizeRepositoryAiWork(rows);
+
+    assert.deepEqual(
+      employees.map((row) => row.employeeId),
+      ["zed", "amy", "bob", "cat", "dan", "eve", "fox"],
+    );
+  });
+
+  test("lastActiveAt is the newest moment anything here moved", () => {
+    const { lastActiveAt } = summarizeRepositoryAiWork([
+      stat({ updatedAt: at("2026-04-01T00:00:00.000Z") }),
+      stat({ updatedAt: at("2026-06-01T12:30:00.000Z") }),
+      stat({
+        updatedAt: at("2026-05-01T00:00:00.000Z"),
+        archivedAt: at("2026-05-01T00:00:00.000Z"),
+      }),
+    ]);
+
+    assert.equal(lastActiveAt, "2026-06-01T12:30:00.000Z");
+  });
+
+  test("no rows is zeroes and nulls, not a division by nothing", () => {
+    const summary = summarizeRepositoryAiWork([]);
+
+    assert.deepEqual(summary.counts, {
+      total: 0,
+      running: 0,
+      attention: 0,
+      completed: 0,
+      archived: 0,
+    });
+    assert.deepEqual(summary.landed, { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0 });
+    assert.deepEqual(summary.totals, { turns: 0, discarded: 0 });
+    assert.equal(summary.lastActiveAt, null);
+    assert.deepEqual(summary.employees, []);
+  });
+
+  test("a driver that hands back date strings still dates the work", () => {
+    const summary = summarizeRepositoryAiWork([
+      stat({ employeeId: "ada", updatedAt: "2026-07-01T09:00:00.000Z" }),
+      stat({ employeeId: "ada", updatedAt: "2026-07-02T09:00:00.000Z" }),
+    ]);
+
+    assert.equal(summary.lastActiveAt, "2026-07-02T09:00:00.000Z");
+    assert.equal(summary.employees[0].lastActiveAt, "2026-07-02T09:00:00.000Z");
+  });
+
+  test("an unreadable timestamp is dropped rather than turned into NaN", () => {
+    const summary = summarizeRepositoryAiWork([
+      stat({ employeeId: "ada", updatedAt: "2026-07-01T09:00:00.000Z" }),
+      stat({ employeeId: "bo", updatedAt: "not a date at all" }),
+    ]);
+
+    assert.equal(summary.lastActiveAt, "2026-07-01T09:00:00.000Z");
+    assert.equal(summary.employees.find((row) => row.employeeId === "bo")?.lastActiveAt, null);
+    // `new Date(NaN).toISOString()` throws, so serialising is the real check.
+    assert.doesNotMatch(JSON.stringify(summary), /NaN|Invalid/);
+
+    const rubbishOnly = summarizeRepositoryAiWork([stat({ updatedAt: "" })]);
+    assert.equal(rubbishOnly.lastActiveAt, null);
+    assert.equal(rubbishOnly.counts.total, 1);
+  });
+});
+
+// ──────────────────────────── what is listed ────────────────────────────
+
+describe("pickOverviewSessionIds", () => {
+  test("live work first, then what waits on a human, then a tail of finished work", () => {
+    const ids = pickOverviewSessionIds([
+      stat({ id: "run-old", status: "running", updatedAt: at("2026-08-01T00:00:00.000Z") }),
+      stat({ id: "run-new", status: "running", updatedAt: at("2026-08-09T00:00:00.000Z") }),
+      stat({ id: "wait-old", status: "failed", updatedAt: at("2026-08-02T00:00:00.000Z") }),
+      stat({ id: "wait-new", status: "ready", updatedAt: at("2026-08-08T00:00:00.000Z") }),
+      stat({ id: "done-old", status: "discarded", updatedAt: at("2026-08-03T00:00:00.000Z") }),
+      stat({ id: "done-new", status: "published", updatedAt: at("2026-08-07T00:00:00.000Z") }),
+    ]);
+
+    assert.deepEqual(ids, ["run-new", "run-old", "wait-new", "wait-old", "done-new", "done-old"]);
+  });
+
+  test("an archived session is never listed, however recently it moved", () => {
+    const ids = pickOverviewSessionIds([
+      stat({ id: "listed", status: "ready", updatedAt: at("2026-08-01T00:00:00.000Z") }),
+      // Newest of the three, and running: it would lead the list if archiving
+      // did not take a row out of every queue.
+      stat({
+        id: "filed-running",
+        status: "running",
+        updatedAt: at("2026-08-20T00:00:00.000Z"),
+        archivedAt: at("2026-08-20T00:00:00.000Z"),
+      }),
+      stat({
+        id: "filed-published",
+        status: "published",
+        updatedAt: at("2026-08-19T00:00:00.000Z"),
+        archivedAt: "2026-08-19T00:00:00.000Z",
+      }),
+    ]);
+
+    assert.deepEqual(ids, ["listed"]);
+  });
+
+  test("the finished tail stops at the recent limit", () => {
+    const rows = Array.from({ length: AI_OVERVIEW_RECENT_LIMIT + 4 }, (_, i) =>
+      stat({
+        id: `done-${i}`,
+        status: i % 2 === 0 ? "published" : "discarded",
+        updatedAt: at(`2026-09-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`),
+      }),
+    );
+
+    const ids = pickOverviewSessionIds(rows);
+
+    assert.equal(ids.length, AI_OVERVIEW_RECENT_LIMIT);
+    assert.deepEqual(ids, ["done-9", "done-8", "done-7", "done-6", "done-5", "done-4"]);
+  });
+
+  test("the whole list stops at the list limit, and the queues get the room", () => {
+    const rows = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        stat({
+          id: `run-${i}`,
+          status: "running",
+          updatedAt: at(`2026-10-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`),
+        }),
+      ),
+      ...Array.from({ length: 20 }, (_, i) =>
+        stat({
+          id: `wait-${i}`,
+          status: "ready",
+          updatedAt: at(`2026-11-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`),
+        }),
+      ),
+      ...Array.from({ length: 10 }, (_, i) =>
+        stat({
+          id: `done-${i}`,
+          status: "published",
+          updatedAt: at(`2026-12-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`),
+        }),
+      ),
+    ];
+
+    const ids = pickOverviewSessionIds(rows);
+
+    assert.equal(ids.length, AI_OVERVIEW_LIST_LIMIT);
+    assert.equal(ids.filter((id) => id.startsWith("run-")).length, 5);
+    assert.equal(ids.filter((id) => id.startsWith("wait-")).length, 19);
+    // Finished work is the first thing dropped when the queues fill the page.
+    assert.equal(
+      ids.some((id) => id.startsWith("done-")),
+      false,
+    );
+    assert.equal(ids[0], "run-4");
+    assert.equal(ids[5], "wait-19");
+    assert.equal(ids[AI_OVERVIEW_LIST_LIMIT - 1], "wait-1");
+  });
+});
+
+// ──────────────────────────── the live line ─────────────────────────────
+
+type FeedEvent = Pick<RepositoryWorkSessionEvent, "kind" | "summary" | "detailJson">;
+
+function feedEvent(over: Partial<FeedEvent> = {}): FeedEvent {
+  return { kind: "text", summary: "", detailJson: "", ...over };
+}
+
+describe("activitySummary", () => {
+  test("the newest readable line wins", () => {
+    assert.equal(
+      activitySummary([
+        feedEvent({ kind: "tool_use", summary: "Read server/app.ts" }),
+        feedEvent({ kind: "tool_result", summary: "Exit 1" }),
+      ]),
+      "Exit 1",
+    );
+    assert.equal(
+      activitySummary([feedEvent({ kind: "tool_use", summary: "  Ran npm test  " })]),
+      "Ran npm test",
+    );
+  });
+
+  test("a steps event is never the line", () => {
+    assert.equal(
+      activitySummary([
+        feedEvent({ kind: "tool_result", summary: "Exit 1" }),
+        feedEvent({ kind: "steps", summary: "1 of 3 steps done" }),
+      ]),
+      "Exit 1",
+    );
+  });
+
+  test("narration stands in when there is no tool line, flattened and clipped", () => {
+    assert.equal(
+      activitySummary([
+        feedEvent({
+          kind: "text",
+          detailJson: JSON.stringify({ text: "  Let me\n\tcheck   the tests.  " }),
+        }),
+      ]),
+      "Let me check the tests.",
+    );
+
+    const line = activitySummary([
+      feedEvent({ kind: "text", detailJson: JSON.stringify({ text: "w".repeat(200) }) }),
+    ]);
+    assert.equal(line, `${"w".repeat(159)}…`);
+    assert.equal(line.length, 160);
+  });
+
+  test("unreadable narration falls through to an older line rather than showing nothing", () => {
+    assert.equal(
+      activitySummary([
+        feedEvent({ kind: "tool_use", summary: "Read server/app.ts" }),
+        feedEvent({ kind: "text", detailJson: "{not json" }),
+      ]),
+      "Read server/app.ts",
+    );
+  });
+
+  test("nothing readable is an empty line, never a crash", () => {
+    assert.equal(activitySummary([]), "");
+    assert.equal(activitySummary([feedEvent({ kind: "text", detailJson: "{not json" })]), "");
+    assert.equal(activitySummary([feedEvent({ kind: "text", detailJson: "" })]), "");
+    assert.equal(
+      activitySummary([feedEvent({ kind: "text", detailJson: JSON.stringify({ text: 42 }) })]),
+      "",
+    );
+    assert.equal(
+      activitySummary([feedEvent({ kind: "text", detailJson: JSON.stringify(["hello"]) })]),
+      "",
+    );
+    // Only narration gets the fallback: a tool event with no summary says nothing.
+    assert.equal(
+      activitySummary([
+        feedEvent({ kind: "tool_result", detailJson: JSON.stringify({ text: "hidden" }) }),
+      ]),
+      "",
+    );
+  });
+});
+
+describe("stepProgress", () => {
+  test("counts what is done and names the first step in flight", () => {
+    assert.deepEqual(
+      stepProgress(
+        JSON.stringify({
+          steps: [
+            { text: "Read the router", status: "completed" },
+            { text: "Add the route", status: "in_progress" },
+            { text: "Write a test", status: "pending" },
+            { text: "Ship it", status: "in_progress" },
+          ],
+        }),
+      ),
+      { done: 1, total: 4, current: "Add the route" },
+    );
+  });
+
+  test("a plan with nothing usable in it is no progress rather than 0 of 0", () => {
+    assert.equal(stepProgress(""), null);
+    assert.equal(stepProgress("{"), null);
+    assert.equal(stepProgress(JSON.stringify({ steps: "soon" })), null);
+    assert.equal(stepProgress(JSON.stringify([{ text: "x", status: "pending" }])), null);
+    assert.equal(stepProgress(JSON.stringify({ steps: [] })), null);
+    assert.equal(stepProgress(JSON.stringify({})), null);
+    assert.equal(stepProgress("null"), null);
+  });
+
+  test("an entry the employee malformed is dropped, not counted as pending", () => {
+    assert.deepEqual(
+      stepProgress(
+        JSON.stringify({
+          steps: [
+            { text: "Real", status: "completed" },
+            { text: "Bad status", status: "cancelled" },
+            { text: 7, status: "pending" },
+            { status: "pending" },
+            null,
+            "Write a test",
+            ["Write a test", "pending"],
+          ],
+        }),
+      ),
+      { done: 1, total: 1, current: null },
+    );
+  });
+
+  test("a blank step in flight is no step rather than an empty line", () => {
+    assert.deepEqual(
+      stepProgress(JSON.stringify({ steps: [{ text: "   ", status: "in_progress" }] })),
+      { done: 0, total: 1, current: null },
+    );
+  });
+});
+
+// ───────────────────────── against a database ───────────────────────────
+
+type HydratedSession = RepositoryWorkSession & {
+  employee: { id: string; name: string; slug: string; avatarKey: string | null } | null;
+};
+
+describe("repositoryAiOverview", () => {
+  let company: Company;
+  let repository: Repository;
+  let elsewhere: Repository;
+  let ada: AIEmployee;
+  let bo: AIEmployee;
+
+  async function makeRepository(name: string, slug: string): Promise<Repository> {
+    return insert(Repository, {
+      companyId: company.id,
+      name,
+      slug,
+      description: "",
+      origin: "local",
+      kind: "code",
+      gitUrl: "",
+      defaultBranch: "main",
+      authMode: "none",
+      committerName: "Genosyn",
+      committerEmail: "repositories@genosyn.local",
+      lastSyncStatus: "unknown",
+      lastSyncError: "",
+    });
+  }
+
+  async function session(
+    over: Partial<RepositoryWorkSession> = {},
+  ): Promise<RepositoryWorkSession> {
+    return insert(RepositoryWorkSession, {
+      companyId: company.id,
+      repositoryId: repository.id,
+      employeeId: ada.id,
+      instruction: "Update the deployment guide",
+      status: "ready",
+      ...over,
+    });
+  }
+
+  /**
+   * A turn on a session. Real sessions always have one, and the digest reads
+   * the activity of the newest one rather than of the session as a whole, so a
+   * fixture that skipped it would be testing a state that cannot occur.
+   */
+  async function turn(sessionId: string, ordinal: number): Promise<RepositoryWorkSessionTurn> {
+    return insert(RepositoryWorkSessionTurn, {
+      companyId: company.id,
+      sessionId,
+      ordinal,
+      instruction: `Instruction ${ordinal}`,
+      reply: "",
+      status: "running",
+      error: "",
+    });
+  }
+
+  async function event(
+    turnRow: RepositoryWorkSessionTurn,
+    ordinal: number,
+    over: Partial<RepositoryWorkSessionEvent> = {},
+  ): Promise<RepositoryWorkSessionEvent> {
+    return insert(RepositoryWorkSessionEvent, {
+      companyId: company.id,
+      repositoryId: repository.id,
+      sessionId: turnRow.sessionId,
+      turnId: turnRow.id,
+      ordinal,
+      kind: "tool_use",
+      summary: "",
+      detailJson: "",
+      ...over,
+    });
+  }
+
+  beforeEach(async () => {
+    await resetTestDb();
+    company = await insert(Company, { name: "Acme", slug: "acme", ownerId: testId("user") });
+    repository = await makeRepository("Strategy", "strategy");
+    elsewhere = await makeRepository("Runbooks", "runbooks");
+    ada = await insert(AIEmployee, {
+      companyId: company.id,
+      name: "Ada",
+      slug: "ada",
+      role: "Engineer",
+      soulBody: "",
+    });
+    bo = await insert(AIEmployee, {
+      companyId: company.id,
+      name: "Bo",
+      slug: "bo",
+      role: "Writer",
+      soulBody: "",
+      avatarKey: "bo.png",
+    });
+  });
+
+  test("lists the sessions in display order, each carrying the employee it was given to", async () => {
+    const done = await session({
+      status: "published",
+      employeeId: bo.id,
+      updatedAt: at("2026-01-05T00:00:00.000Z"),
+    });
+    const waiting = await session({ status: "ready", updatedAt: at("2026-01-04T00:00:00.000Z") });
+    const live = await session({
+      status: "running",
+      employeeId: bo.id,
+      updatedAt: at("2026-01-03T00:00:00.000Z"),
+    });
+    const filed = await session({
+      status: "ready",
+      updatedAt: at("2026-01-06T00:00:00.000Z"),
+      archivedAt: at("2026-01-06T00:00:00.000Z"),
+    });
+
+    const overview = await repositoryAiOverview(repository);
+    const sessions = overview.sessions as HydratedSession[];
+
+    assert.deepEqual(
+      sessions.map((row) => row.id),
+      [live.id, waiting.id, done.id],
+    );
+    assert.equal(
+      sessions.some((row) => row.id === filed.id),
+      false,
+    );
+    assert.deepEqual(sessions[0].employee, {
+      id: bo.id,
+      name: "Bo",
+      slug: "bo",
+      avatarKey: "bo.png",
+    });
+    assert.equal(sessions[1].employee?.name, "Ada");
+    assert.equal(sessions[2].employee?.id, bo.id);
+    // The listed rows carry the instruction only as a title fallback, clipped.
+    assert.equal(sessions[0].instruction, "Update the deployment guide");
+    assert.equal("reply" in sessions[0], false);
+    assert.equal("error" in sessions[0], false);
+
+    assert.deepEqual(overview.counts, {
+      total: 4,
+      running: 1,
+      attention: 1,
+      completed: 1,
+      archived: 1,
+    });
+    assert.equal(overview.capped, false);
+    // The archived session still counts as the last thing that moved here.
+    assert.equal(overview.lastActiveAt, "2026-01-06T00:00:00.000Z");
+  });
+
+  test("a running session gets its newest line, its plan, and a tool-call count", async () => {
+    const live = await session({ status: "running", updatedAt: at("2026-01-07T00:00:00.000Z") });
+    const first = await turn(live.id, 1);
+
+    // The plan lands early and is then buried by more events than the tail the
+    // summary reads, which is the case a naive "look at the last N events"
+    // implementation gets wrong.
+    await event(first, 1, {
+      kind: "steps",
+      summary: "1 of 3 steps done",
+      detailJson: JSON.stringify({
+        steps: [
+          { text: "Read the guide", status: "completed" },
+          { text: "Rewrite the rollback section", status: "in_progress" },
+          { text: "Commit", status: "pending" },
+        ],
+      }),
+    });
+    for (let i = 0; i < 44; i += 1) {
+      await event(first, 2 + i, { kind: "tool_use", summary: `Read page-${i}.md` });
+    }
+    const newest = at("2026-01-07T11:22:33.000Z");
+    await event(first, 46, {
+      kind: "tool_result",
+      summary: "Exit 0",
+      createdAt: newest,
+    });
+
+    const overview = await repositoryAiOverview(repository);
+
+    assert.equal(overview.activity.length, 1);
+    const entry = overview.activity[0];
+    assert.equal(entry.sessionId, live.id);
+    assert.equal(entry.summary, "Exit 0");
+    assert.deepEqual(entry.steps, {
+      done: 1,
+      total: 3,
+      current: "Rewrite the rollback section",
+    });
+    assert.equal(entry.toolCalls, 44);
+    assert.equal(entry.at, newest.toISOString());
+  });
+
+  test("the live line is the turn in flight, never the one before it", async () => {
+    // Ordinals run on across turns and events are never deleted, so a
+    // session-wide read answers the second instruction with the first one's
+    // finished plan and counts tool calls the reader already watched happen.
+    const live = await session({ status: "running", updatedAt: at("2026-01-08T00:00:00.000Z") });
+    const first = await turn(live.id, 1);
+    await event(first, 1, {
+      kind: "steps",
+      detailJson: JSON.stringify({
+        steps: [
+          { text: "Read the guide", status: "completed" },
+          { text: "Commit", status: "completed" },
+        ],
+      }),
+    });
+    await event(first, 2, { kind: "tool_use", summary: "Read guide.md" });
+    await event(first, 3, { kind: "tool_result", summary: "Exit 0" });
+
+    const second = await turn(live.id, 2);
+
+    const started = await repositoryAiOverview(repository);
+    assert.equal(started.activity.length, 1);
+    // Nothing has happened on this turn yet, and the page says so rather than
+    // reporting the previous turn's finished plan as this turn's progress.
+    assert.equal(started.activity[0].summary, "");
+    assert.equal(started.activity[0].steps, null);
+    assert.equal(started.activity[0].toolCalls, 0);
+
+    await event(second, 4, { kind: "tool_use", summary: "Read rollback.md" });
+    const going = await repositoryAiOverview(repository);
+    assert.equal(going.activity[0].summary, "Read rollback.md");
+    assert.equal(going.activity[0].toolCalls, 1);
+  });
+
+  test("a session nobody is working on gets no live line", async () => {
+    const waiting = await session({ status: "ready" });
+    await event(await turn(waiting.id, 1), 1, { kind: "tool_result", summary: "Exit 0" });
+    await session({ status: "published" });
+
+    const overview = await repositoryAiOverview(repository);
+
+    assert.equal(overview.sessions.length, 2);
+    assert.deepEqual(overview.activity, []);
+  });
+
+  test("a repository nobody has worked in answers with zeroes rather than throwing", async () => {
+    const overview = await repositoryAiOverview(repository);
+
+    assert.deepEqual(overview.counts, {
+      total: 0,
+      running: 0,
+      attention: 0,
+      completed: 0,
+      archived: 0,
+    });
+    assert.deepEqual(overview.landed, {
+      sessions: 0,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+    });
+    assert.deepEqual(overview.totals, { turns: 0, discarded: 0 });
+    assert.equal(overview.lastActiveAt, null);
+    assert.deepEqual(overview.employees, []);
+    assert.deepEqual(overview.sessions, []);
+    assert.deepEqual(overview.activity, []);
+    assert.equal(overview.capped, false);
+  });
+
+  test("work done in another repository is not counted in this one", async () => {
+    await session({
+      status: "published",
+      turnCount: 2,
+      filesChanged: 3,
+      insertions: 30,
+      deletions: 3,
+      updatedAt: at("2026-01-08T00:00:00.000Z"),
+    });
+    const stranger = await insert(RepositoryWorkSession, {
+      companyId: company.id,
+      repositoryId: elsewhere.id,
+      employeeId: bo.id,
+      instruction: "Rewrite the on-call runbook",
+      status: "published",
+      turnCount: 7,
+      filesChanged: 99,
+      insertions: 990,
+      deletions: 99,
+      updatedAt: at("2026-02-09T00:00:00.000Z"),
+    });
+
+    const overview = await repositoryAiOverview(repository);
+
+    assert.equal(overview.counts.total, 1);
+    assert.deepEqual(overview.landed, {
+      sessions: 1,
+      filesChanged: 3,
+      insertions: 30,
+      deletions: 3,
+    });
+    assert.deepEqual(overview.totals, { turns: 2, discarded: 0 });
+    assert.equal(overview.lastActiveAt, "2026-01-08T00:00:00.000Z");
+    assert.deepEqual(
+      overview.employees.map((row) => row.employeeId),
+      [ada.id],
+    );
+    assert.equal(
+      overview.sessions.some((row) => row.id === stranger.id),
+      false,
+    );
+
+    const other = await repositoryAiOverview(elsewhere);
+    assert.equal(other.counts.total, 1);
+    assert.deepEqual(
+      other.sessions.map((row) => row.id),
+      [stranger.id],
+    );
+  });
+});

--- a/App/server/services/repositoryAiOverview.ts
+++ b/App/server/services/repositoryAiOverview.ts
@@ -1,0 +1,542 @@
+import { In } from "typeorm";
+import { AppDataSource } from "../db/datasource.js";
+import { AIEmployee } from "../db/entities/AIEmployee.js";
+import type { Repository } from "../db/entities/Repository.js";
+import {
+  RepositoryWorkSession,
+  type RepositoryWorkSessionStatus,
+} from "../db/entities/RepositoryWorkSession.js";
+import { RepositoryWorkSessionEvent } from "../db/entities/RepositoryWorkSessionEvent.js";
+import { RepositoryWorkSessionTurn } from "../db/entities/RepositoryWorkSessionTurn.js";
+
+/**
+ * What AI Employees have actually done in one Repository.
+ *
+ * The Repository Overview page used to answer "what is this repository" —
+ * default branch, sign-in mode, command mode, a README. Every one of those is
+ * a setting somebody chose once, and a page made of them tells a returning
+ * reader nothing about the only thing that changes here on its own: the work.
+ * This module is the other answer. It reads the rows the server wrote while
+ * employees worked — sessions, their turns, and the activity events of a turn
+ * in flight — and digests them into the few numbers and sentences a person
+ * wants at a glance.
+ *
+ * Two rules shape it.
+ *
+ * **The list is slim and the counts are not.** A repository can hold hundreds
+ * of sessions, each carrying a 20 KB instruction and a report. Shipping them
+ * all to draw four numbers would be absurd, so the tallies are computed from a
+ * projection with no prose in it, and only the two dozen sessions the page
+ * actually lists come back whole.
+ *
+ * **A cap is never silent.** {@link RepositoryAiOverview.capped} says when the
+ * tallies stopped counting, because a number that quietly means "the first
+ * 2,000" is worse than one that says so.
+ *
+ * Everything below is either a pure function over rows or a thin query that
+ * feeds one, which is what makes the wording and the arithmetic testable
+ * without a repository on disk.
+ */
+
+/** Sessions whose tallies are counted. Beyond this the answer says it stopped. */
+export const AI_OVERVIEW_STAT_LIMIT = 2_000;
+
+/** Sessions the page lists at once. The rest are one click away on AI work. */
+export const AI_OVERVIEW_LIST_LIMIT = 24;
+
+/** Finished sessions kept in that list — the tail is history, not a queue. */
+export const AI_OVERVIEW_RECENT_LIMIT = 6;
+
+/** Activity events read back to describe a turn in flight. */
+const ACTIVITY_TAIL = 40;
+
+/**
+ * Characters of the opening instruction carried on a listed session.
+ *
+ * The list uses it for one thing — the title of a session nobody renamed — and
+ * an instruction may be twenty thousand characters. This endpoint is re-read on
+ * every activity event of a running turn, so shipping the whole brief two dozen
+ * times over would put megabytes on the wire to draw a line of text.
+ */
+const TITLE_FALLBACK_CHARS = 200;
+
+/**
+ * The columns the tallies need. No `instruction`, no `reply`, no `error` —
+ * the arithmetic never reads prose, and leaving it out is what lets the limit
+ * above be two thousand rather than twenty.
+ */
+export type RepositoryAiSessionStat = {
+  id: string;
+  employeeId: string;
+  status: RepositoryWorkSessionStatus;
+  archivedAt: Date | string | null;
+  turnCount: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  /** A `Date` from TypeORM; a string is tolerated because drivers differ. */
+  updatedAt: Date | string;
+};
+
+/**
+ * How many sessions sit in each state.
+ *
+ * `running`, `attention` and `completed` partition the sessions that are *not*
+ * archived, and `archived` is the rest — so the four add up to `total` exactly
+ * once. Filing a session away is a statement about a list rather than about
+ * the work, which is why it takes the row out of the queues instead of
+ * inventing a fifth outcome for it.
+ */
+export type RepositoryAiCounts = {
+  /** Every session ever opened here, archived ones included. */
+  total: number;
+  /** Turns in flight right now. */
+  running: number;
+  /** Finished, not filed away, and waiting on a human. */
+  attention: number;
+  /** Accepted or thrown away — the decision has been made. */
+  completed: number;
+  /** Filed out of the inbox. Not a state of the work, a state of the list. */
+  archived: number;
+};
+
+/**
+ * What AI work has actually put into this repository.
+ *
+ * Only `published` sessions count. A branch a Member never accepted changed
+ * nothing here, and counting it would turn this into a measure of how much the
+ * employees typed rather than how much of it was any good.
+ */
+export type RepositoryAiLanded = {
+  sessions: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+};
+
+/** One employee's tally in this repository, keyed for the client to join. */
+export type RepositoryAiEmployeeWork = {
+  employeeId: string;
+  sessions: number;
+  landed: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  lastActiveAt: string | null;
+};
+
+/** Where a turn in flight has got to, as the overview shows it. */
+export type RepositoryAiStepProgress = {
+  done: number;
+  total: number;
+  /** The step being worked on, when the employee marked one. */
+  current: string | null;
+};
+
+/** The live line for one running session. */
+export type RepositoryAiActivity = {
+  sessionId: string;
+  /** The newest thing worth reading: "Ran npm test → Exit 1", "Read src/app.ts". */
+  summary: string;
+  at: string | null;
+  steps: RepositoryAiStepProgress | null;
+  /** Tool calls the turn in flight has made. */
+  toolCalls: number;
+};
+
+/**
+ * A session as the overview lists it.
+ *
+ * Deliberately not the whole row. The page needs a name, a state, a diffstat
+ * and a link; it never shows the employee's report, the failure text, or the
+ * brief in full — and those three are the only large fields on the entity.
+ * `instruction` survives, clipped, because a session nobody renamed is titled
+ * from it.
+ */
+export type RepositoryAiSessionRow = {
+  id: string;
+  employeeId: string;
+  status: RepositoryWorkSessionStatus;
+  title: string;
+  /** The opening instruction, clipped to {@link TITLE_FALLBACK_CHARS}. */
+  instruction: string;
+  branch: string | null;
+  turnCount: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  publishedBranch: string | null;
+  pullRequestUrl: string | null;
+  pullRequestNumber: number | null;
+  finishedAt: Date | null;
+  archivedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  employee: { id: string; name: string; slug: string; avatarKey: string | null } | null;
+};
+
+export type RepositoryAiOverview = {
+  counts: RepositoryAiCounts;
+  landed: RepositoryAiLanded;
+  /** Instructions given across every session, and the work thrown away. */
+  totals: { turns: number; discarded: number };
+  /** The most recent moment any session here moved. */
+  lastActiveAt: string | null;
+  employees: RepositoryAiEmployeeWork[];
+  /** True when the tallies stopped at {@link AI_OVERVIEW_STAT_LIMIT}. */
+  capped: boolean;
+  /** The sessions the page lists, already in display order. */
+  sessions: RepositoryAiSessionRow[];
+  activity: RepositoryAiActivity[];
+};
+
+/**
+ * Which of the three overview groups a status belongs to.
+ *
+ * Deliberately the same split the AI work inbox uses: `running` is live,
+ * `published` / `discarded` are decided, and everything else — including
+ * `empty`, which is a finished answer of "nothing to change" — is a session
+ * whose next move belongs to a human.
+ */
+export function aiOverviewGroup(
+  status: RepositoryWorkSessionStatus,
+): "running" | "attention" | "completed" {
+  if (status === "running") return "running";
+  if (status === "published" || status === "discarded") return "completed";
+  return "attention";
+}
+
+/** Whether a session has been filed out of the inbox. */
+function archived(row: { archivedAt: Date | string | null }): boolean {
+  return row.archivedAt !== null && row.archivedAt !== undefined;
+}
+
+/**
+ * The tallies, from the projection alone.
+ *
+ * The three queue counts skip archived rows for the reason the inbox does:
+ * archiving is a Member saying "this wants nothing from me", and a queue that
+ * counts them is a queue nobody can empty. `total`, `landed` and the
+ * per-employee tallies count everything, because filing a session away does
+ * not un-write the commits it landed.
+ */
+export function summarizeRepositoryAiWork(rows: readonly RepositoryAiSessionStat[]): {
+  counts: RepositoryAiCounts;
+  landed: RepositoryAiLanded;
+  totals: { turns: number; discarded: number };
+  lastActiveAt: string | null;
+  employees: RepositoryAiEmployeeWork[];
+} {
+  const counts: RepositoryAiCounts = {
+    total: rows.length,
+    running: 0,
+    attention: 0,
+    completed: 0,
+    archived: 0,
+  };
+  const landed: RepositoryAiLanded = { sessions: 0, filesChanged: 0, insertions: 0, deletions: 0 };
+  const totals = { turns: 0, discarded: 0 };
+  const byEmployee = new Map<string, RepositoryAiEmployeeWork>();
+  let lastActive: number | null = null;
+
+  for (const row of rows) {
+    const group = aiOverviewGroup(row.status);
+    if (archived(row)) counts.archived += 1;
+    else counts[group] += 1;
+
+    totals.turns += row.turnCount;
+    if (row.status === "discarded") totals.discarded += 1;
+
+    const employee = byEmployee.get(row.employeeId) ?? {
+      employeeId: row.employeeId,
+      sessions: 0,
+      landed: 0,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      lastActiveAt: null,
+    };
+    employee.sessions += 1;
+
+    if (row.status === "published") {
+      landed.sessions += 1;
+      landed.filesChanged += row.filesChanged;
+      landed.insertions += row.insertions;
+      landed.deletions += row.deletions;
+      employee.landed += 1;
+      employee.filesChanged += row.filesChanged;
+      employee.insertions += row.insertions;
+      employee.deletions += row.deletions;
+    }
+
+    const at = time(row.updatedAt);
+    if (at > 0) {
+      if (lastActive === null || at > lastActive) lastActive = at;
+      const employeeAt = employee.lastActiveAt ? Date.parse(employee.lastActiveAt) : null;
+      if (employeeAt === null || at > employeeAt) {
+        employee.lastActiveAt = new Date(at).toISOString();
+      }
+    }
+    byEmployee.set(row.employeeId, employee);
+  }
+
+  // Busiest first, and a stable tie-break so two employees with the same tally
+  // do not swap places between two reads of the same page.
+  const employees = [...byEmployee.values()].sort(
+    (a, b) =>
+      b.landed - a.landed ||
+      b.sessions - a.sessions ||
+      time(b.lastActiveAt ?? 0) - time(a.lastActiveAt ?? 0) ||
+      a.employeeId.localeCompare(b.employeeId),
+  );
+
+  return {
+    counts,
+    landed,
+    totals,
+    lastActiveAt: lastActive === null ? null : new Date(lastActive).toISOString(),
+    employees,
+  };
+}
+
+/**
+ * Which sessions the page lists, in the order it lists them.
+ *
+ * Live work first, then whatever is waiting on a human, then a short tail of
+ * finished work so the page still says something on a repository where
+ * everything has been decided. Archived sessions are never listed: they were
+ * filed away precisely so they would stop appearing in a queue.
+ */
+export function pickOverviewSessionIds(rows: readonly RepositoryAiSessionStat[]): string[] {
+  const newestFirst = [...rows]
+    .filter((row) => !archived(row))
+    .sort((a, b) => time(b.updatedAt) - time(a.updatedAt));
+  const running = newestFirst.filter((row) => aiOverviewGroup(row.status) === "running");
+  const attention = newestFirst.filter((row) => aiOverviewGroup(row.status) === "attention");
+  const completed = newestFirst
+    .filter((row) => aiOverviewGroup(row.status) === "completed")
+    .slice(0, AI_OVERVIEW_RECENT_LIMIT);
+  return [...running, ...attention, ...completed].slice(0, AI_OVERVIEW_LIST_LIMIT).map((r) => r.id);
+}
+
+/** A comparable instant, or 0 for anything a driver handed back unparseable. */
+function time(value: Date | string | number): number {
+  const at =
+    value instanceof Date ? value.getTime() : typeof value === "number" ? value : Date.parse(value);
+  return Number.isFinite(at) ? at : 0;
+}
+
+/**
+ * The one line a running session gets, from the tail of its activity feed.
+ *
+ * Newest first, and the first event that says something a person can read
+ * wins. Narration is used only when there is no tool line to show, because
+ * "Ran npm test → Exit 1" is a fact and "Now I will check the tests" is an
+ * intention. A `steps` event is never the line: its progress is reported
+ * separately and its summary would say the same thing twice.
+ */
+export function activitySummary(
+  events: ReadonlyArray<Pick<RepositoryWorkSessionEvent, "kind" | "summary" | "detailJson">>,
+): string {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event.kind === "steps") continue;
+    const summary = event.summary.trim();
+    if (summary) return summary;
+    if (event.kind === "text") {
+      const text = textOf(event.detailJson);
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+function textOf(detailJson: string): string {
+  if (!detailJson) return "";
+  try {
+    const parsed = JSON.parse(detailJson) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
+    const text = (parsed as { text?: unknown }).text;
+    if (typeof text !== "string") return "";
+    const flat = text.replace(/\s+/g, " ").trim();
+    return flat.length > 160 ? `${flat.slice(0, 159).trimEnd()}…` : flat;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * The employee's own plan, as progress.
+ *
+ * The step list is the employee's, so it is read defensively: anything that is
+ * not `{ text, status }` is dropped rather than trusted, and a list with no
+ * usable entries is no progress at all rather than "0 of 0".
+ */
+export function stepProgress(detailJson: string): RepositoryAiStepProgress | null {
+  if (!detailJson) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detailJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const steps = (parsed as { steps?: unknown }).steps;
+  if (!Array.isArray(steps)) return null;
+  let done = 0;
+  let total = 0;
+  let current: string | null = null;
+  for (const step of steps) {
+    if (!step || typeof step !== "object" || Array.isArray(step)) continue;
+    const { text, status } = step as { text?: unknown; status?: unknown };
+    if (typeof text !== "string" || typeof status !== "string") continue;
+    if (status !== "pending" && status !== "in_progress" && status !== "completed") continue;
+    total += 1;
+    if (status === "completed") done += 1;
+    if (status === "in_progress" && current === null) current = text.trim() || null;
+  }
+  return total === 0 ? null : { done, total, current };
+}
+
+/** Narrow a session to what the list draws, with the employee it was given to. */
+async function toListRows(
+  companyId: string,
+  sessions: RepositoryWorkSession[],
+): Promise<RepositoryAiSessionRow[]> {
+  if (sessions.length === 0) return [];
+  const employees = await AppDataSource.getRepository(AIEmployee).find({
+    where: { companyId, id: In([...new Set(sessions.map((s) => s.employeeId))]) },
+  });
+  const byId = new Map(employees.map((e) => [e.id, e]));
+  return sessions.map((session) => {
+    const employee = byId.get(session.employeeId);
+    return {
+      id: session.id,
+      employeeId: session.employeeId,
+      status: session.status,
+      title: session.title,
+      instruction: clip(session.instruction, TITLE_FALLBACK_CHARS),
+      branch: session.branch,
+      turnCount: session.turnCount,
+      filesChanged: session.filesChanged,
+      insertions: session.insertions,
+      deletions: session.deletions,
+      publishedBranch: session.publishedBranch,
+      pullRequestUrl: session.pullRequestUrl,
+      pullRequestNumber: session.pullRequestNumber,
+      finishedAt: session.finishedAt,
+      archivedAt: session.archivedAt,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      employee: employee
+        ? {
+            id: employee.id,
+            name: employee.name,
+            slug: employee.slug,
+            avatarKey: employee.avatarKey ?? null,
+          }
+        : null,
+    };
+  });
+}
+
+/** Cut a string to a length the wire can afford, marking that it was cut. */
+export function clip(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max - 1).trimEnd()}…` : flat;
+}
+
+/**
+ * The live line for each running session.
+ *
+ * Everything here is scoped to the **turn in flight**, not to the session.
+ * Events are never deleted and their ordinals run on across turns, so a
+ * session-wide read would answer the second instruction with the first one's
+ * finished plan — "Step 5 of 5" over a turn that has only just started — and
+ * count tool calls the reader already watched happen. The turn is found first
+ * and everything else is asked about it.
+ *
+ * Three small reads per running session; a session listed as running always
+ * gets an entry, so a missing line is only ever "nothing has happened yet".
+ */
+async function readActivity(sessionIds: string[]): Promise<RepositoryAiActivity[]> {
+  const events = AppDataSource.getRepository(RepositoryWorkSessionEvent);
+  const turns = AppDataSource.getRepository(RepositoryWorkSessionTurn);
+  return Promise.all(
+    sessionIds.map(async (sessionId) => {
+      const turn = await turns.findOne({
+        where: { sessionId },
+        order: { ordinal: "DESC" },
+        select: { id: true, ordinal: true },
+      });
+      if (!turn) return { sessionId, summary: "", at: null, steps: null, toolCalls: 0 };
+      const [tail, steps, toolCalls] = await Promise.all([
+        events.find({
+          where: { turnId: turn.id },
+          order: { ordinal: "DESC" },
+          take: ACTIVITY_TAIL,
+        }),
+        events.findOne({
+          where: { turnId: turn.id, kind: "steps" },
+          order: { ordinal: "DESC" },
+        }),
+        events.count({ where: { turnId: turn.id, kind: "tool_use" } }),
+      ]);
+      const ascending = [...tail].reverse();
+      const newest = ascending.length > 0 ? ascending[ascending.length - 1] : null;
+      return {
+        sessionId,
+        summary: activitySummary(ascending),
+        at: newest ? new Date(newest.createdAt).toISOString() : null,
+        steps: steps ? stepProgress(steps.detailJson) : null,
+        toolCalls,
+      };
+    }),
+  );
+}
+
+/**
+ * Everything the Repository Overview needs to talk about AI work.
+ *
+ * One projection read for the arithmetic, one full read for the two dozen
+ * sessions the page lists, and a live line per running session. Nothing here
+ * touches the checkout on disk — the route mounts it with `workspace: false`
+ * for that reason, so an unreachable remote never hides the answer.
+ */
+export async function repositoryAiOverview(repo: Repository): Promise<RepositoryAiOverview> {
+  const sessionRepo = AppDataSource.getRepository(RepositoryWorkSession);
+  const stats: RepositoryAiSessionStat[] = await sessionRepo.find({
+    where: { repositoryId: repo.id },
+    select: {
+      id: true,
+      employeeId: true,
+      status: true,
+      archivedAt: true,
+      turnCount: true,
+      filesChanged: true,
+      insertions: true,
+      deletions: true,
+      updatedAt: true,
+    },
+    order: { updatedAt: "DESC" },
+    take: AI_OVERVIEW_STAT_LIMIT + 1,
+  });
+
+  const capped = stats.length > AI_OVERVIEW_STAT_LIMIT;
+  const counted = capped ? stats.slice(0, AI_OVERVIEW_STAT_LIMIT) : stats;
+  const summary = summarizeRepositoryAiWork(counted);
+
+  const ids = pickOverviewSessionIds(counted);
+  const rows = ids.length ? await sessionRepo.find({ where: { id: In(ids) } }) : [];
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const ordered = ids
+    .map((id) => byId.get(id))
+    .filter((row): row is RepositoryWorkSession => !!row);
+  const sessions = await toListRows(repo.companyId, ordered);
+
+  const activity = await readActivity(
+    ordered.filter((row) => row.status === "running").map((row) => row.id),
+  );
+
+  return { ...summary, capped, sessions, activity };
+}

--- a/App/tsconfig.json
+++ b/App/tsconfig.json
@@ -3,6 +3,13 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    // `tsx` reads this project — the tests and `npm run dev` both run through it —
+    // and the app compiles JSX with the automatic runtime everywhere else
+    // (tsconfig.client.json, Vite, and `react/react-in-jsx-scope: off` in
+    // ESLint). Leaving it unset here made tsx emit classic `React.createElement`
+    // calls, so a component that legitimately does not import React — Spinner —
+    // threw the moment a test rendered it.
+    "jsx": "react-jsx",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/Home/client/docs/pages/Repositories.tsx
+++ b/Home/client/docs/pages/Repositories.tsx
@@ -126,13 +126,56 @@ export function Repositories() {
         and it is written to the audit log.
       </P>
 
+      <H2 id="overview">The Overview: what the AI has been doing</H2>
+      <P>
+        Opening a repository lands on its <Strong>Overview</Strong>, and the subject of that page is
+        the work rather than the settings. It opens with one sentence about the state of AI work
+        here — who is working right now, how many sessions are waiting for you to decide, or that
+        nothing has run yet — and the button that starts the next one.
+      </P>
+      <P>
+        Under it are four numbers: what is running, what is waiting for you, how many sessions you
+        have accepted out of everything ever asked for, and the lines those accepted sessions
+        actually put into the repository. Only accepted work counts toward the last two. A branch
+        nobody merged changed nothing here, and counting it would measure how much the employees
+        typed rather than how much of it was any good.
+      </P>
+      <P>Then the sessions themselves, in three bands that hide when they are empty.</P>
+      <UL>
+        <LI>
+          <Strong>Working now.</Strong> Each running session with the line its employee is on this
+          second — <em>Ran npm test → Exit 1</em> — its progress through its own step list, and how
+          many tool calls it has made. It updates live, without a reload.
+        </LI>
+        <LI>
+          <Strong>Needs you.</Strong> What has come back. Each row says what to do about it —{" "}
+          <em>Read the diff and decide</em>, <em>The last turn failed — ask again</em> — rather than
+          naming a status, and opens in <Strong>AI work</Strong>.
+        </LI>
+        <LI>
+          <Strong>Recently decided.</Strong> A short tail of the work you accepted or threw away, so
+          a repository where everything has been settled still says something.
+        </LI>
+      </UL>
+      <P>
+        <Strong>Who works here</Strong> closes the page: the AI Employees you granted access, each
+        with what it has actually done in this repository rather than only the fact that it may. A
+        repository nobody has been granted says so, and links to the page that fixes it.
+      </P>
+      <P>
+        The repository&apos;s own settings — default branch, sign-in, what an employee may run, and
+        the connection check for a remote — are still here, one disclosure down under{" "}
+        <Strong>Repository details</Strong>. A <Code>README</Code> at the root is rendered above
+        them.
+      </P>
+
       <H2 id="files">Browse and edit files</H2>
       <P>
-        Opening a repository shows the working tree of a checkout Genosyn keeps on the server. The
-        tree is read from disk rather than from git, so a file you just created appears before you
-        have committed it. Symlinks and the <Code>.git</Code> directory are never listed, one
-        directory shows at most 2,000 entries, and <Code>.gitignore</Code> is respected — ignored
-        entries are hidden, with a toggle that brings them back dimmed.
+        The <Strong>Files</Strong> page shows the working tree of a checkout Genosyn keeps on the
+        server. The tree is read from disk rather than from git, so a file you just created appears
+        before you have committed it. Symlinks and the <Code>.git</Code> directory are never listed,
+        one directory shows at most 2,000 entries, and <Code>.gitignore</Code> is respected —
+        ignored entries are hidden, with a toggle that brings them back dimmed.
       </P>
       <P>
         Open a file to edit it in place, with syntax highlighting. You can create, rename, move, and
@@ -183,7 +226,9 @@ export function Repositories() {
         session has its own URL, so you can send a colleague straight to the work you want them to
         review. Rename a session from its header when the instruction it was opened with stops
         describing it, and <Strong>archive</Strong> one you are finished with. On a narrow window
-        the inbox becomes a compact switcher above the open session.
+        the inbox becomes a compact switcher above the open session. For the short version — what is
+        running, what is waiting for you, and what has been accepted — the{" "}
+        <DocLink to="#overview">Overview</DocLink> summarises the same sessions.
       </P>
 
       <H3 id="quick-start">Start with a useful brief</H3>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4713,6 +4713,69 @@ scoping, and the redaction are M61's and are untouched.
 
 ---
 
+### M65 — The repository, as AI work ✅
+
+Opening a Repository showed you its default branch, its sign-in mode, its
+command mode, a count of grants, and a three-step explanation of a workflow you
+had used forty times. Every one of those is a setting somebody chose once.
+Nothing on that page moved between visits — which, on a product whose whole
+premise is that AI employees do the work, made the first screen of a repository
+the least informative one in the section, and the one place where "what has the
+AI actually been doing here" went unanswered.
+
+The subject is the work now, and the settings are one disclosure down.
+
+- [x] **One digest, and the server computes it.** `GET
+      /repositories/:slug/ai-overview` (`services/repositoryAiOverview.ts`)
+      answers the AI-work half of the page in one read: the counts, what AI
+      work has been *accepted* into the repository, the per-employee tallies,
+      the two dozen sessions worth listing, and a live line for each turn in
+      flight. Both reads are projections rather than rows — the tallies drop
+      every prose column, so counting two thousand sessions costs less than
+      shipping twenty, and the list keeps only what it draws, because a
+      response re-read on every tool call must not carry two dozen
+      twenty-thousand-character briefs. It is mounted `workspace: false` —
+      this answers a question *about* a repository, and an unreachable remote
+      must not be able to hide the answer behind a clone error.
+- [x] **Only accepted work counts as landed.** A branch nobody merged changed
+      nothing here. Counting it would have turned the headline number into a
+      measure of how much the employees typed rather than how much of it was any
+      good, which is the same distinction M58 drew between a Run that returned
+      and a Run that was graded.
+- [x] **A running session says what it is doing.** The overview reads the tail
+      of the activity feed, the newest `steps` event wherever it is, and the
+      tool-call count, and prints *Ran npm test → Exit 1 · Step 4 of 7 · 38 tool
+      calls* — live, on the same `resource.changed` frames the session page
+      uses. A row that only said "Working" would be a spinner with extra steps.
+      All three are scoped to the **turn in flight**, never to the session:
+      ordinals run on across turns and events are never deleted, so a
+      session-wide read would answer the second instruction with the first
+      one's finished plan.
+- [x] **Rows say what to do, not what state they are in.** "Read the diff and
+      decide", "Nothing changed — ask for another pass", "The last turn failed —
+      ask again". A status names the work; an overview exists to name the next
+      move, and the reader is the one who has to make it. A session already
+      decided has no next move, so its line says where the work went —
+      *Merged into main* — rather than repeating the chip beside it.
+- [x] **Bands hide when empty, and the counts stay honest.** The three bands
+      follow decision 12 — an empty queue is not news — and the four tallies
+      partition the sessions exactly once, with archived rows out of the queues
+      and still inside the lifetime totals. A cap is stated rather than implied,
+      because a number that quietly means "the first two thousand" is worse than
+      one that says so.
+- [x] **The grant is not the work.** "Who works here" lists each granted
+      employee beside what it has actually done in this repository. The old
+      page could print "4 employees" on a repository no employee had ever
+      touched.
+
+Deliberately **not** in this milestone. A second session inbox — the bands are a
+glance and every row opens **AI work**, which stays the place work is done. Any
+change to what a work session *is*: M63 owns the runtime, the events, and the
+review surface, and none of it was touched. And commit history, which is
+`History`'s subject and would only have been a worse copy of it here.
+
+---
+
 ## V2+ wild ideas
 
 - **Marketplace** of Soul personas + skill packs (M17 above is the seed)


### PR DESCRIPTION
**M65 — The repository, as AI work** (`ROADMAP.md`)

Opening a Repository answered *what is this repository*: the default branch, the sign-in mode, the command mode, a grant count, and a three-step explainer of a workflow the reader had used forty times. Every one of those is a setting somebody chose once, so nothing on the page moved between visits — which, on a product whose premise is that AI employees do the work, made the first screen of a repository the least informative one in the section.

The subject is the work now. The settings are one disclosure down, under **Repository details**.

## What the page shows

- **One sentence and the button that starts the next session.** *"Ada is working here now. 2 other sessions are waiting for you."* — or, on a repository nobody has been granted, the sentence that says so rather than a zero.
- **Four tallies**: what is running, what is waiting for you, how many sessions have been *accepted* out of everything ever asked for, and the lines those accepted sessions actually put into the repository. Only accepted work counts as landed — a branch nobody merged changed nothing here.
- **Three bands that hide when empty.** *Working now* shows each running session with the line its employee is on this second (*Ran npm test → Exit 1*), its step progress and its tool-call count, live on the same `resource.changed` frames the session page uses. *Needs you* says what to do about each row rather than naming a status. *Recently decided* says where the work went.
- **Who works here**: each granted employee beside what it has actually done in this repository. The old page could print "4 employees" on a repository no employee had ever touched.

## How it is built

- `GET /api/companies/:cid/repositories/:slug/ai-overview` → `App/server/services/repositoryAiOverview.ts`. Mounted `workspace: false` — this answers a question *about* a repository, so an unreachable remote must not hide the answer behind a clone error.
- Both server reads are projections. The tallies drop every prose column (counting 2,000 sessions costs less than shipping 20); the list keeps only what it draws, because a response re-read on every tool call must not carry two dozen 20,000-character briefs.
- The live line, the step progress and the tool-call count are scoped to the **turn in flight**, never to the session: ordinals run on across turns and events are never deleted, so a session-wide read would answer the second instruction with the first one's finished plan.
- Wording, grouping and destinations are pure functions in `App/client/components/repositories/aiOverview.ts`, following the `lib/workTimeline.ts` precedent — client tests here have no DOM, so the part a reader depends on has to be reachable without React.
- `App/tsconfig.json` gains `"jsx": "react-jsx"`. That file is what `tsx` reads, and the app compiles JSX with the automatic runtime everywhere else (`tsconfig.client.json`, Vite, `react/react-in-jsx-scope: off` in ESLint). Leaving it unset made `tsx` emit classic `React.createElement`, so a component that legitimately does not import React — `ui/Spinner` — threw the moment a test rendered it.

## Tests

136 new cases across four files: the wording and grouping (`aiOverview.test.ts`), the components rendered through `renderToStaticMarkup` (`AiWorkOverview.test.ts`), the digest as arithmetic and against a real database (`repositoryAiOverview.test.ts`), and the HTTP contract including that the route does not materialize a checkout (`repositoryAiOverviewRoutes.test.ts`).

Six defects were found by an adversarial review pass and fixed before this PR: a stale digest overwriting the current repository's, a failed grants read rendered as the definite claim that no employee has access, a failed digest read rendered as a definite claim about the repository's state, an employee running two sessions named twice ("Ada and Ada"), the live line read across the whole session rather than the turn in flight, and the response carrying full session rows.

## Manual test steps

Driven against a real server (seeded company, two AI employees, one local repository, six work sessions including a running one with an activity feed):

- Overview renders the headline, the four tallies, all three bands and the roster; the running row shows *Ran npm test → Exit 1 · Step 4 of 5 · 3 tool calls*.
- Decided rows read *Merged into main* / *Its branch was thrown away* rather than repeating their own chip.
- `Repository details` opens to the branch, sign-in, command mode and the connection check.
- README still renders above the details.

`npm run lint`, `npm run typecheck` and `npm run build` pass in both `App/` and `Home/`; all 741 client tests pass locally. Docs updated at `Home/client/docs/pages/Repositories.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j9KZQtcNLSWLnZLnkc9gb
