### PR TITLE
Enable proactive work by default

### DIFF
--- a/App/client/pages/Proactive.tsx
+++ b/App/client/pages/Proactive.tsx
@@ -21,6 +21,7 @@ export default function Proactive({ company }: { company: Company }) {
   const [error, setError] = React.useState<string | null>(null);
   const [selected, setSelected] = React.useState<ProactiveRecipe | null>(null);
   const [busy, setBusy] = React.useState<string | null>(null);
+  const [savingDefaults, setSavingDefaults] = React.useState(false);
   const requestSequence = React.useRef(0);
   const admin = company.role === "owner" || company.role === "admin";
   const refresh = React.useCallback(async () => {
@@ -59,18 +60,36 @@ export default function Proactive({ company }: { company: Company }) {
     }
   }
 
+  async function toggleAutomaticSetup() {
+    if (!overview || !admin || savingDefaults) return;
+    const enabled = !overview.automaticSetup;
+    setSavingDefaults(true);
+    setError(null);
+    try {
+      await api.patch(`/api/companies/${company.id}/proactive/defaults`, { enabled });
+      setOverview((current) => current && { ...current, automaticSetup: enabled });
+      await refresh();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSavingDefaults(false);
+    }
+  }
+
   return (
     <div className="page-shell space-y-8 p-4 sm:p-8">
       <div>
         <TopBar title="Proactive" />
         <p className="mt-2 text-sm text-slate-500">
-          Give your AI Employees standing responsibility, then follow the work they finish.
+          Your AI Employees take responsibility for incoming requests and work that needs
+          follow-through.
         </p>
       </div>
       <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-5 text-sm text-indigo-950 dark:border-indigo-900 dark:bg-indigo-950/30 dark:text-indigo-100">
-        Start with one workflow and an AI Employee who knows your business. Review the instructions,
-        connect the required resources, and enable it. The Soul guides their judgement; Grants and
-        company Policies control what they can do.
+        Proactive work is on by default. Genosyn assigns ready work as AI Employees get a connected
+        AI Model and the required resources and Grants, with one automatic assignment for each
+        responsibility. The Soul guides their judgement; Grants and company Policies control what
+        they can do.
         <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 font-medium">
           <Link to={`/c/${company.slug}/employees`}>
             AI Employees <span aria-hidden="true">→</span>
@@ -98,14 +117,56 @@ export default function Proactive({ company }: { company: Company }) {
       )}
       {overview && (
         <>
+          <section
+            aria-labelledby="automatic-setup-title"
+            className="rounded-xl border border-slate-200 p-5 dark:border-slate-800"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <h2 id="automatic-setup-title" className="text-base font-semibold">
+                Automatic setup
+              </h2>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="text-sm font-medium" aria-hidden="true">
+                  {savingDefaults ? "Saving…" : overview.automaticSetup ? "On" : "Off"}
+                </span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-label="Automatic setup"
+                  aria-describedby="automatic-setup-description"
+                  aria-checked={overview.automaticSetup}
+                  disabled={!admin || savingDefaults}
+                  onClick={() => void toggleAutomaticSetup()}
+                  className={`h-6 w-11 shrink-0 rounded-full p-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 ${overview.automaticSetup ? "bg-indigo-600" : "bg-slate-200 dark:bg-slate-700"}`}
+                >
+                  <span
+                    className={`block h-5 w-5 rounded-full bg-white transition-transform ${overview.automaticSetup ? "translate-x-5" : ""}`}
+                  />
+                </button>
+              </div>
+            </div>
+            <p id="automatic-setup-description" className="mt-1 text-sm leading-6 text-slate-500">
+              {overview.automaticSetup
+                ? "On: ready responsibilities are assigned automatically, even before you visit this page."
+                : "Off: Genosyn will not make new automatic assignments. You can still customize work below."}{" "}
+              Turning this off only affects future assignments. Existing work keeps running; use
+              Pause on each responsibility to stop future starts.
+            </p>
+          </section>
           <section aria-labelledby="active-work-title" className="space-y-3">
             <h2 id="active-work-title" className="text-base font-semibold">
               Your standing work
             </h2>
             {overview.installations.length === 0 ? (
               <EmptyState
-                title="Nothing enabled yet"
-                description="Choose a starter below. Enabling it creates an email rule or a Routine you can inspect, edit, and pause."
+                title={
+                  overview.automaticSetup ? "Waiting for ready AI Employees" : "No standing work"
+                }
+                description={
+                  overview.automaticSetup
+                    ? "Connect an AI Model and grant the resources an AI Employee needs. Ready responsibilities will appear here automatically. You can review requirements and customize work below."
+                    : "Turn on Automatic setup to assign ready responsibilities, or customize work below."
+                }
               />
             ) : (
               <div className="divide-y divide-slate-200 rounded-xl border border-slate-200 dark:divide-slate-800 dark:border-slate-800">
@@ -160,7 +221,8 @@ export default function Proactive({ company }: { company: Company }) {
           </section>
           {!admin && (
             <p className="text-sm text-slate-500">
-              An owner or admin can enable and change standing work.
+              An owner or admin can change Automatic setup, customize work, and pause
+              responsibilities.
             </p>
           )}
           {(["email", "routine"] as const).map((kind) => (
@@ -206,7 +268,7 @@ export default function Proactive({ company }: { company: Company }) {
                           disabled={!admin}
                           onClick={() => setSelected(recipe)}
                         >
-                          Set up <ArrowRight size={14} />
+                          Customize <ArrowRight size={14} />
                         </Button>
                       </div>
                     </article>
@@ -299,7 +361,7 @@ function Setup({
             disabled={saving || needs.length > 0 || !instruction.trim() || Boolean(already)}
           >
             <Sparkles size={16} />
-            {saving ? "Enabling…" : "Enable workflow"}
+            {saving ? "Assigning…" : "Assign work"}
           </Button>
         </>
       }
@@ -367,13 +429,13 @@ function Setup({
           />
         </label>
         <p className="text-xs text-slate-500">
-          Only enable work you want this AI Employee to own. Existing Grants are checked here; setup
-          never adds access. Scheduled starters draft customer communication and preserve source
-          restrictions.
+          Choose who owns this responsibility and how they work. Existing Grants are checked here;
+          setup never adds access. Scheduled starters draft customer communication and preserve
+          source restrictions.
         </p>
         {already && (
           <p className="text-sm text-indigo-600">
-            This starter is already installed for this AI Employee and mailbox.{" "}
+            This responsibility is already assigned to this AI Employee and mailbox.{" "}
             <Link className="underline" to={already.href}>
               Review existing work
             </Link>
@@ -382,7 +444,7 @@ function Setup({
         )}
         {needs.length > 0 && (
           <div className="rounded-lg bg-slate-50 p-3 text-sm dark:bg-slate-900">
-            <p className="font-medium">Before enabling</p>
+            <p className="font-medium">Before assigning</p>
             <ul className="mt-2 list-disc space-y-1 pl-5">
               {needs.map((need) => (
                 <li key={need}>{need}</li>

--- a/App/scripts/proactiveHarness.tsx
+++ b/App/scripts/proactiveHarness.tsx
@@ -15,11 +15,12 @@ function Location() {
     </output>
   );
 }
+const role = new URLSearchParams(location.search).get("role");
 const company = {
   id: "company",
   slug: "company",
   name: "Example company",
-  role: new URLSearchParams(location.search).get("role") === "member" ? "member" : "owner",
+  role: role === "member" || role === "admin" ? role : "owner",
 } as Company;
 createRoot(document.getElementById("root")!).render(
   <MemoryRouter initialEntries={["/c/company/proactive"]}>

--- a/App/scripts/test-proactive.ts
+++ b/App/scripts/test-proactive.ts
@@ -56,10 +56,14 @@ const installs: Array<{
   instruction: string;
 }> = [];
 const toggles: Array<{ id: string; enabled: boolean }> = [];
+const defaultToggles: boolean[] = [];
 let overview: ProactiveOverview;
 let failLoad = false;
 let failInstall = false;
 let failToggle = false;
+let failDefaults = false;
+let holdDefaults = false;
+let releaseDefaults: (() => void) | undefined;
 let holdInstall = false;
 let releaseInstall: (() => void) | undefined;
 let loads = 0;
@@ -109,6 +113,21 @@ await context.route("**/api/**", async (route) => {
     overview.installations.push(row);
     return route.fulfill({ status: 201, json: row });
   }
+  if (pathname === "/api/companies/company/proactive/defaults" && request.method() === "PATCH") {
+    const { enabled } = request.postDataJSON() as { enabled: boolean };
+    defaultToggles.push(enabled);
+    if (holdDefaults)
+      await new Promise<void>((resolve) => {
+        releaseDefaults = resolve;
+      });
+    if (failDefaults)
+      return route.fulfill({
+        status: 503,
+        json: { error: "Automatic setup could not be saved. Try again." },
+      });
+    overview.automaticSetup = enabled;
+    return route.fulfill({ json: { automaticSetup: enabled } });
+  }
   if (pathname.startsWith("/api/companies/company/proactive/") && request.method() === "PATCH") {
     const id = pathname.split("/").at(-1)!;
     const { enabled } = request.postDataJSON() as { enabled: boolean };
@@ -129,13 +148,19 @@ await context.route("**/api/**", async (route) => {
 function reset() {
   installs.length = 0;
   toggles.length = 0;
+  defaultToggles.length = 0;
   sockets.length = 0;
   failLoad = false;
   failInstall = false;
   failToggle = false;
+  failDefaults = false;
+  holdDefaults = false;
+  releaseDefaults = undefined;
   holdInstall = false;
   releaseInstall = undefined;
   overview = {
+    automaticSetup: true,
+    defaultAssignments: {},
     recipes: structuredClone(PROACTIVE_RECIPES),
     installations: [],
     mailboxes: [
@@ -145,6 +170,7 @@ function reset() {
         status: "active",
         analysisEnabled: true,
         analysisReady: true,
+        analysisEmployeeId: "ada",
       },
       {
         id: "paused",
@@ -228,7 +254,7 @@ async function setup(page: Page, id = "quote-requests") {
   await page
     .locator("article")
     .filter({ has: page.getByRole("heading", { name: recipe.name, exact: true }) })
-    .getByRole("button", { name: "Set up", exact: true })
+    .getByRole("button", { name: "Customize", exact: true })
     .click();
   await page.getByRole("dialog", { name: recipe.name, exact: true }).waitFor();
 }
@@ -241,7 +267,7 @@ async function ready(page: Page, employee = "Ada") {
   await choose(page, "Mailbox", "support@example.com");
 }
 function enable(page: Page) {
-  return page.getByRole("button", { name: /^Enable / });
+  return page.getByRole("button", { name: "Assign work", exact: true });
 }
 async function submit(page: Page) {
   await enable(page).click();
@@ -268,13 +294,119 @@ async function check(name: string, run: () => Promise<void>) {
     throw error;
   } finally {
     releaseInstall?.();
+    releaseDefaults?.();
     for (const page of context.pages()) await page.close();
   }
 }
 try {
+  await check(
+    "automatic setup is on by default and existing assignments need no first visit setup",
+    async () => {
+      overview.installations.push(
+        {
+          id: "existing-quote",
+          recipeId: "quote-requests",
+          employeeId: "ada",
+          accountId: "mailbox",
+          name: "Customer quote responsibility",
+          enabled: true,
+          kind: "email",
+          delivery: "draft",
+          href: "/c/company/mail/settings/rules",
+        },
+        {
+          id: "existing-followthrough",
+          recipeId: "work-followthrough",
+          employeeId: "grace",
+          accountId: null,
+          name: "Customized follow-through",
+          enabled: false,
+          kind: "routine",
+          delivery: "draft",
+          href: "/c/company/routines/followthrough",
+        },
+      );
+      overview.defaultAssignments = { "opaque-mailbox-scope": "existing-quote" };
+      const page = await open();
+      const automatic = page.getByRole("switch", { name: "Automatic setup", exact: true });
+      await automatic.waitFor();
+      assert.equal(await automatic.getAttribute("aria-checked"), "true");
+      assert.equal(await automatic.isEnabled(), true);
+      await page.getByText(/Proactive work is on by default/).waitFor();
+      await page
+        .getByRole("link", { name: "Customer quote responsibility", exact: true })
+        .waitFor();
+      await page.getByRole("link", { name: "Customized follow-through", exact: true }).waitFor();
+      assert.equal(await page.getByRole("button", { name: "Pause", exact: true }).count(), 1);
+      assert.equal(await page.getByRole("button", { name: "Resume", exact: true }).count(), 1);
+      assert.equal(await page.getByText("Nothing enabled yet", { exact: true }).count(), 0);
+      assert.deepEqual(installs, [], "Opening the page never installs work in the browser");
+      assert.deepEqual(defaultToggles, []);
+      const originalRows = structuredClone(overview.installations);
+      await automatic.click();
+      await page.getByText(/Off: Genosyn will not make new automatic assignments/).waitFor();
+      assert.equal(await automatic.getAttribute("aria-checked"), "false");
+      assert.deepEqual(
+        overview.installations,
+        originalRows,
+        "Turning defaults off preserves enabled and paused work",
+      );
+      await page.getByText(/Existing work keeps running/).waitFor();
+      await automatic.click();
+      await page.getByText(/On: ready responsibilities are assigned automatically/).waitFor();
+      assert.equal(await automatic.getAttribute("aria-checked"), "true");
+      assert.deepEqual(defaultToggles, [false, true]);
+      assert.deepEqual(toggles, [], "Defaults never call an individual Pause or Resume");
+    },
+  );
+  await check("automatic setup save errors preserve the setting and support retry", async () => {
+    const page = await open("admin");
+    const automatic = page.getByRole("switch", { name: "Automatic setup", exact: true });
+    await automatic.waitFor();
+    failDefaults = true;
+    await automatic.click();
+    await page
+      .getByRole("alert")
+      .filter({ hasText: "Automatic setup could not be saved" })
+      .waitFor();
+    assert.equal(await automatic.getAttribute("aria-checked"), "true");
+    assert.equal(await automatic.isEnabled(), true);
+    assert.equal(await page.locator("article").count(), PROACTIVE_RECIPES.length);
+    failDefaults = false;
+    await automatic.click();
+    await page.getByText(/Off: Genosyn will not make new automatic assignments/).waitFor();
+    assert.equal(await page.getByRole("alert").count(), 0);
+    await page.getByText("No standing work", { exact: true }).waitFor();
+    await setup(page);
+    await ready(page);
+    assert.equal(
+      await enable(page).isEnabled(),
+      true,
+      "Manual assignment remains available with defaults off",
+    );
+    assert.deepEqual(defaultToggles, [false, false]);
+  });
+  await check("automatic setup pending save prevents duplicate changes", async () => {
+    const page = await open();
+    const automatic = page.getByRole("switch", { name: "Automatic setup", exact: true });
+    await automatic.waitFor();
+    holdDefaults = true;
+    const sent = page.waitForRequest(
+      (request) => request.method() === "PATCH" && request.url().endsWith("/proactive/defaults"),
+    );
+    await automatic.click();
+    await sent;
+    await page.getByText("Saving…", { exact: true }).waitFor();
+    assert.equal(await automatic.isDisabled(), true);
+    assert.equal(await automatic.getAttribute("aria-checked"), "true");
+    assert.deepEqual(defaultToggles, [false]);
+    releaseDefaults?.();
+    await page.getByText(/Off: Genosyn will not make new automatic assignments/).waitFor();
+    assert.equal(await automatic.isEnabled(), true);
+  });
   await check("catalogue and navigation display real starter instructions", async () => {
     const page = await open();
-    await page.getByText("Nothing enabled yet", { exact: true }).waitFor();
+    await page.getByText("Waiting for ready AI Employees", { exact: true }).waitFor();
     assert.equal(await page.locator("article").count(), PROACTIVE_RECIPES.length);
     assert.equal(
       await page.getByRole("link", { name: /AI Employees/ }).getAttribute("href"),
@@ -373,7 +505,7 @@ try {
       });
       await setup(page);
       await ready(page);
-      await page.getByText(/This starter is already installed/).waitFor();
+      await page.getByText(/This responsibility is already assigned/).waitFor();
       assert.equal(await enable(page).isDisabled(), true);
       assert.equal(installs.length, 1);
     },
@@ -431,7 +563,7 @@ try {
     await enable(page).click();
     await sent;
     assert.equal(
-      await page.getByRole("button", { name: "Enabling…", exact: true }).isDisabled(),
+      await page.getByRole("button", { name: "Assigning…", exact: true }).isDisabled(),
       true,
     );
     assert.equal(
@@ -457,7 +589,7 @@ try {
     assert.equal(await page.getByRole("button", { name: "Pause", exact: true }).isEnabled(), true);
     assert.equal(overview.installations[0].enabled, true);
   });
-  await check("ordinary Members can inspect but cannot enable or pause standing work", async () => {
+  await check("automatic setup and standing work are read-only for ordinary Members", async () => {
     overview.installations.push({
       id: "existing",
       recipeId: "quote-requests",
@@ -471,15 +603,24 @@ try {
     });
     const page = await open("member");
     await page
-      .getByText("An owner or admin can enable and change standing work.", { exact: true })
+      .getByText(
+        "An owner or admin can change Automatic setup, customize work, and pause responsibilities.",
+        { exact: true },
+      )
       .waitFor();
-    for (const button of await page.getByRole("button", { name: "Set up", exact: true }).all())
+    const automatic = page.getByRole("switch", { name: "Automatic setup", exact: true });
+    assert.equal(await automatic.getAttribute("aria-checked"), "true");
+    assert.equal(await automatic.isDisabled(), true);
+    for (const button of await page.getByRole("button", { name: "Customize", exact: true }).all())
       assert.equal(await button.isDisabled(), true);
     assert.equal(await page.getByRole("button", { name: /^(Pause|Resume)$/ }).count(), 0);
     assert.equal(
       await page.getByRole("link", { name: "Review work", exact: true }).isVisible(),
       true,
     );
+    assert.deepEqual(defaultToggles, []);
+    assert.deepEqual(toggles, []);
+    assert.deepEqual(installs, []);
   });
   await check(
     "scheduled starters omit send options and allow a mailbox-free follow-through",
@@ -501,7 +642,7 @@ try {
     "live changes refresh standing work and mobile setup remains within the screen",
     async () => {
       const page = await open();
-      await page.getByText("Nothing enabled yet", { exact: true }).waitFor();
+      await page.getByText("Waiting for ready AI Employees", { exact: true }).waitFor();
       const initialLoads = loads;
       overview.installations.push({
         id: "live",
@@ -540,6 +681,7 @@ try {
   console.log(`${checks} Proactive browser regression groups passed.`);
 } finally {
   releaseInstall?.();
+  releaseDefaults?.();
   await browser.close();
   await server.close();
 }

--- a/App/server/db/entities/Company.ts
+++ b/App/server/db/entities/Company.ts
@@ -30,6 +30,20 @@ export class Company {
   @Column({ type: "boolean", default: false })
   requireTwoFactor!: boolean;
 
+  /** Automatically assign ready Proactive starters unless an admin switches this off. */
+  @Column({ type: "boolean", default: true })
+  proactiveAutoSetup!: boolean;
+
+  /**
+   * System-owned initialization and assignment tombstones, encoded as
+   * { version: 1, assignments: Record<string, string> }. Starter instructions
+   * remain on their native MailRule and Routine rows; this records which
+   * responsibilities have already been assigned so customization, pauses,
+   * and deletions are not overwritten by later automatic setup.
+   */
+  @Column({ type: "text", default: "" })
+  proactiveDefaultsJson!: string;
+
   @CreateDateColumn()
   createdAt!: Date;
 }

--- a/App/server/db/migrations/1788870048873-CompanyProactiveDefaults.ts
+++ b/App/server/db/migrations/1788870048873-CompanyProactiveDefaults.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CompanyProactiveDefaults1788870048873 implements MigrationInterface {
+    name = 'CompanyProactiveDefaults1788870048873'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "temporary_companies" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar NOT NULL, "slug" varchar NOT NULL, "ownerId" varchar NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "requireTwoFactor" boolean NOT NULL DEFAULT (0), "mission" text NOT NULL DEFAULT (''), "vision" text NOT NULL DEFAULT (''), "proactiveAutoSetup" boolean NOT NULL DEFAULT (1), "proactiveDefaultsJson" text NOT NULL DEFAULT (''), CONSTRAINT "UQ_b28b07d25e4324eee577de5496d" UNIQUE ("slug"))`);
+        await queryRunner.query(`INSERT INTO "temporary_companies"("id", "name", "slug", "ownerId", "createdAt", "requireTwoFactor", "mission", "vision") SELECT "id", "name", "slug", "ownerId", "createdAt", "requireTwoFactor", "mission", "vision" FROM "companies"`);
+        await queryRunner.query(`DROP TABLE "companies"`);
+        await queryRunner.query(`ALTER TABLE "temporary_companies" RENAME TO "companies"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "companies" RENAME TO "temporary_companies"`);
+        await queryRunner.query(`CREATE TABLE "companies" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar NOT NULL, "slug" varchar NOT NULL, "ownerId" varchar NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "requireTwoFactor" boolean NOT NULL DEFAULT (0), "mission" text NOT NULL DEFAULT (''), "vision" text NOT NULL DEFAULT (''), CONSTRAINT "UQ_b28b07d25e4324eee577de5496d" UNIQUE ("slug"))`);
+        await queryRunner.query(`INSERT INTO "companies"("id", "name", "slug", "ownerId", "createdAt", "requireTwoFactor", "mission", "vision") SELECT "id", "name", "slug", "ownerId", "createdAt", "requireTwoFactor", "mission", "vision" FROM "temporary_companies"`);
+        await queryRunner.query(`DROP TABLE "temporary_companies"`);
+    }
+
+}

--- a/App/server/db/migrations/postgres/1788870145153-CompanyProactiveDefaults.ts
+++ b/App/server/db/migrations/postgres/1788870145153-CompanyProactiveDefaults.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CompanyProactiveDefaults1788870145153 implements MigrationInterface {
+    name = 'CompanyProactiveDefaults1788870145153'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "companies" ADD "proactiveAutoSetup" boolean NOT NULL DEFAULT true`);
+        await queryRunner.query(`ALTER TABLE "companies" ADD "proactiveDefaultsJson" text NOT NULL DEFAULT ''`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "companies" DROP COLUMN "proactiveDefaultsJson"`);
+        await queryRunner.query(`ALTER TABLE "companies" DROP COLUMN "proactiveAutoSetup"`);
+    }
+
+}

--- a/App/server/index.ts
+++ b/App/server/index.ts
@@ -38,6 +38,7 @@ import { skillsRouter } from "./routes/skills.js";
 import { toolCatalogueRouter } from "./routes/toolCatalogue.js";
 import { routinesRouter } from "./routes/routines.js";
 import { proactiveRouter } from "./routes/proactive.js";
+import { bootProactiveDefaults } from "./services/proactive/defaults.js";
 import { routineAssistantRouter } from "./routes/routineAssistant.js";
 import { routineFoldersRouter } from "./routes/routineFolders.js";
 import { goalsRouter } from "./routes/goals.js";
@@ -181,6 +182,7 @@ async function main() {
   // can still reveal it, before dropping the dead Connection. Runs after the
   // key ring is bound and validated, which is why it is not a migration.
   await backfillRetiredIntegrationsIntoVault();
+  await bootProactiveDefaults();
   await bootCron();
   // M54: Routine event Triggers subscribe to the live-sync flush. Registered
   // here rather than imported by resourceEvents so the low-level module stays

--- a/App/server/routes/proactive.test.ts
+++ b/App/server/routes/proactive.test.ts
@@ -157,6 +157,9 @@ test("overview is scoped and exposes readiness without model credentials or Soul
   assert.equal(view.employees[0].modelReady, true);
   assert.equal(view.employees[0].mailGrants.length, 1);
   assert.equal(view.mailboxes[0].analysisReady, true);
+  assert.equal(view.mailboxes[0].analysisEmployeeId, employee.id);
+  assert.equal(view.automaticSetup, true);
+  assert.deepEqual(view.defaultAssignments, {});
   assert.doesNotMatch(JSON.stringify(view), /do-not-serialize|soulBody|configJson/);
   assert.ok(!JSON.stringify(view).includes(other.id));
 });
@@ -165,6 +168,39 @@ test("authentication and company membership are required", async () => {
   assert.equal((await request()).status, 401);
   actingUserId = user.id;
   assert.equal((await request("GET", undefined, "", randomUUID())).status, 403);
+});
+
+test("automatic setup is an admin-only company setting with strict validation", async () => {
+  assert.equal((await request("PATCH", { enabled: false }, "/defaults")).status, 200);
+  assert.equal((await request()).body.automaticSetup, false);
+  assert.equal(
+    (await request("PATCH", { enabled: true, defaultAssignments: {} }, "/defaults")).status,
+    400,
+  );
+  assert.equal((await request("PATCH", { enabled: "true" }, "/defaults")).status, 400);
+  assert.equal((await request("PATCH", { enabled: true }, "/defaults", randomUUID())).status, 403);
+  await AppDataSource.getRepository(Membership).update(
+    { companyId: company.id, userId: user.id },
+    { role: "member" },
+  );
+  assert.equal((await request("PATCH", { enabled: true }, "/defaults")).status, 403);
+  assert.equal((await request()).body.automaticSetup, false);
+});
+
+test("turning automatic setup off preserves existing work and its individual pause state", async () => {
+  const installed = await request("POST", input());
+  assert.equal((await request("PATCH", { enabled: false }, `/${installed.body.id}`)).status, 200);
+  assert.equal((await request("PATCH", { enabled: false }, "/defaults")).status, 200);
+  assert.equal((await request("PATCH", { enabled: true }, "/defaults")).status, 200);
+  const view = (await request()).body as ProactiveOverview;
+  assert.equal(view.installations.length, 1);
+  assert.equal(view.installations[0].enabled, false);
+  assert.equal(view.automaticSetup, true);
+  const events = await AppDataSource.getRepository(AuditEvent).findBy({
+    action: "proactive.automatic_setup",
+  });
+  assert.equal(events.length, 2);
+  assert.ok(events.every((event) => event.actorUserId === user.id && event.actorKind === "user"));
 });
 test("ordinary Members may inspect but cannot enable or pause standing work", async () => {
   const enabled = await request("POST", input());

--- a/App/server/routes/proactive.ts
+++ b/App/server/routes/proactive.ts
@@ -11,6 +11,7 @@ import {
   getProactiveOverview,
   installProactiveStarter,
   toggleProactiveStarter,
+  setProactiveAutomaticSetup,
   ProactiveSetupError,
 } from "../services/proactive/setup.js";
 import { PlanLimitError } from "../services/entitlements.js";
@@ -57,6 +58,21 @@ proactiveRouter.post(
       if (error instanceof PlanLimitError) return res.status(402).json({ error: error.message });
       throw error;
     }
+  },
+);
+proactiveRouter.patch(
+  "/proactive/defaults",
+  requireBrowserSession,
+  requireCompanyRoleForMutations("admin"),
+  validateParams(companyParams),
+  validateBody(z.object({ enabled: z.boolean() }).strict()),
+  async (req, res) => {
+    await setProactiveAutomaticSetup(
+      (req.params as Record<string, string>).cid,
+      req.userId!,
+      req.body.enabled,
+    );
+    res.json({ ok: true });
   },
 );
 proactiveRouter.patch(

--- a/App/server/services/mail/automationQueue.ts
+++ b/App/server/services/mail/automationQueue.ts
@@ -9,6 +9,7 @@ import { withSchedulerLease } from "../schedulerLeases.js";
 import { analyzeInboundMessage } from "./analysis.js";
 import { hasBlockedSender } from "./blockedSenders.js";
 import { runRulesForNewMessage } from "./rules.js";
+import { reconcileProactiveDefaults } from "../proactive/defaults.js";
 
 const DISCOVERY_INTERVAL_MS = 5_000;
 const ACCOUNT_LEASE_MS = 12 * 60 * 60 * 1_000;
@@ -35,16 +36,44 @@ type MailAutomationRunOptions = {
   now?: () => Date;
   /** Test seam for holding or counting side effects without starting a real Pipeline. */
   runEffects?: MailAutomationEffectRunner;
+  /** Narrow seams for verifying ordinary processing around default setup failures. */
+  defaultEffects?: MailDefaultEffectsDependencies;
 };
 
-const runDefaultEffects: MailAutomationEffectRunner = async (
-  account,
-  message,
-  assertRunnable,
-  beforeEffect,
-) => {
+type MailDefaultEffectsDependencies = {
+  reconcileDefaults?: typeof reconcileProactiveDefaults;
+  analyzeInbound?: typeof analyzeInboundMessage;
+  applyRules?: typeof runRulesForNewMessage;
+  dispatchReceived?: typeof dispatchEmailReceived;
+};
+
+export async function runDefaultMailEffects(
+  account: MailAccount,
+  message: MailMessage,
+  assertRunnable: () => Promise<void>,
+  beforeEffect: () => Promise<void>,
+  dependencies: MailDefaultEffectsDependencies = {},
+): Promise<void> {
+  // This queue contains new inbound mail only; setup never replays imported
+  // history. Install ready defaults before this first message is classified.
+  await assertRunnable();
+  try {
+    await (dependencies.reconcileDefaults ?? reconcileProactiveDefaults)(account.companyId);
+  } catch (error) {
+    // Automatic setup is repairable bookkeeping. Its failure must not turn
+    // the unique inbound delivery into a failed, unreplayable message or stop
+    // the mailbox's existing analysis, rules and Pipelines. The sweep retries setup.
+    // eslint-disable-next-line no-console
+    console.warn(`[proactive] inbox setup will retry for company ${account.companyId}:`, error);
+  }
+  await assertRunnable();
   if (await hasBlockedSender(account, message)) {
-    await runRulesForNewMessage(account, message.id, assertRunnable, beforeEffect);
+    await (dependencies.applyRules ?? runRulesForNewMessage)(
+      account,
+      message.id,
+      assertRunnable,
+      beforeEffect,
+    );
     return;
   }
   // AI triage goes first, and is deliberately NOT fenced by `beforeEffect`.
@@ -60,7 +89,7 @@ const runDefaultEffects: MailAutomationEffectRunner = async (
   // Going first also means the buttons a human wants are ready before a rule's
   // handover or a Pipeline that may run for hours.
   await assertRunnable();
-  await analyzeInboundMessage(account, message).catch((error) => {
+  await (dependencies.analyzeInbound ?? analyzeInboundMessage)(account, message).catch((error) => {
     // Triage is an enrichment. A mailbox whose model is down still gets its
     // rules and its Pipelines; the analysis row already recorded the failure.
     // eslint-disable-next-line no-console
@@ -68,12 +97,20 @@ const runDefaultEffects: MailAutomationEffectRunner = async (
   });
 
   await assertRunnable();
-  await runRulesForNewMessage(account, message.id, assertRunnable, beforeEffect);
+  await (dependencies.applyRules ?? runRulesForNewMessage)(
+    account,
+    message.id,
+    assertRunnable,
+    beforeEffect,
+  );
   await assertRunnable();
   if (!(await hasBlockedSender(account, message))) {
-    await dispatchEmailReceived(message.id, { failOnRejected: true, beforeEffect });
+    await (dependencies.dispatchReceived ?? dispatchEmailReceived)(message.id, {
+      failOnRejected: true,
+      beforeEffect,
+    });
   }
-};
+}
 
 function errorMessage(error: unknown): string {
   return (error instanceof Error ? error.message : String(error)).slice(0, 4_000);
@@ -171,12 +208,10 @@ async function processOne(
             accountId,
           });
           if (!message) throw new Error("Inbound message no longer exists");
-          await (options.runEffects ?? runDefaultEffects)(
-            account,
-            message,
-            assertRunnable,
-            beforeEffect,
-          );
+          const effects: MailAutomationEffectRunner =
+            options.runEffects ??
+            ((...args) => runDefaultMailEffects(...args, options.defaultEffects));
+          await effects(account, message, assertRunnable, beforeEffect);
           await assertRunnable();
           await finish(event.id, "succeeded");
         } catch (error) {

--- a/App/server/services/proactive/defaultAssignments.test.ts
+++ b/App/server/services/proactive/defaultAssignments.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { after, before, beforeEach, test } from "node:test";
+import type { EntityManager } from "typeorm";
+import { AppDataSource } from "../../db/datasource.js";
+import { Company } from "../../db/entities/Company.js";
+import { AIEmployee } from "../../db/entities/AIEmployee.js";
+import { AIModel } from "../../db/entities/AIModel.js";
+import { MailAccount } from "../../db/entities/MailAccount.js";
+import { MailRule } from "../../db/entities/MailRule.js";
+import { Routine } from "../../db/entities/Routine.js";
+import { AuditEvent } from "../../db/entities/AuditEvent.js";
+import { EmployeeMailAccountGrant } from "../../db/entities/EmployeeMailAccountGrant.js";
+import { EmployeeFinanceGrant } from "../../db/entities/EmployeeFinanceGrant.js";
+import { initTestDb, resetTestDb, closeTestDb, insert } from "../../test/dbHarness.js";
+import { initializeProactiveDefaults, readProactiveDefaults } from "./defaultsState.js";
+import { proactiveScope } from "./scopes.js";
+import { proactiveId, installProactiveStarter, setProactiveAutomaticSetup } from "./setup.js";
+
+let company: Company;
+let employee: AIEmployee;
+let account: MailAccount;
+before(initTestDb);
+after(closeTestDb);
+beforeEach(async () => {
+  await resetTestDb();
+  company = await insert(Company, { name: "Automatic", slug: randomUUID(), ownerId: randomUUID() });
+  account = await insert(MailAccount, {
+    companyId: company.id,
+    connectionId: randomUUID(),
+    address: "quotes@example.test",
+  });
+  employee = await worker();
+});
+async function worker() {
+  const row = await insert(AIEmployee, {
+    companyId: company.id,
+    name: "Commercial",
+    slug: randomUUID(),
+    role: "Sales",
+  });
+  await insert(AIModel, {
+    employeeId: row.id,
+    provider: "openai",
+    model: "fixture",
+    isActive: true,
+    authMode: "apikey",
+    configJson: JSON.stringify({ apiKeyEncrypted: "fixture-only" }),
+  });
+  await insert(EmployeeMailAccountGrant, {
+    employeeId: row.id,
+    accountId: account.id,
+    accessLevel: "send",
+  });
+  await insert(EmployeeFinanceGrant, {
+    companyId: company.id,
+    employeeId: row.id,
+    accessLevel: "invoice",
+  });
+  return row;
+}
+function input(employeeId = employee.id, recipeId = "quote-requests") {
+  return {
+    recipeId,
+    employeeId,
+    accountId: account.id,
+    delivery: "draft" as const,
+    instruction: "Prepare accurate work from the actual request and keep its Workstream.",
+  };
+}
+async function savedState() {
+  const saved = await AppDataSource.getRepository(Company).findOneByOrFail({ id: company.id });
+  return readProactiveDefaults(saved.proactiveDefaultsJson);
+}
+
+test("new companies are on by default and automatic work has a system actor and draft ceiling", async () => {
+  assert.equal(company.proactiveAutoSetup, true);
+  const installed = await installProactiveStarter(company.id, null, input(), { automatic: true });
+  const rule = await AppDataSource.getRepository(MailRule).findOneByOrFail({ id: installed.id });
+  assert.equal(rule.enabled, true);
+  assert.equal(rule.createdByUserId, null);
+  assert.equal(JSON.parse(rule.actionsJson)[0].mode, "work");
+  assert.equal(
+    (await savedState()).assignments[proactiveScope("quote-requests", account.id, employee.id)],
+    rule.id,
+  );
+  const audit = await AppDataSource.getRepository(AuditEvent).findOneByOrFail({
+    targetId: rule.id,
+  });
+  assert.equal(audit.actorKind, "system");
+  assert.equal(audit.actorUserId, null);
+  assert.equal(JSON.parse(audit.metadataJson).automatic, true);
+  await assert.rejects(
+    installProactiveStarter(
+      company.id,
+      null,
+      { ...input(), delivery: "soul" },
+      { automatic: true },
+    ),
+    /prepares drafts/,
+  );
+});
+
+test("simultaneous workers claim one mailbox responsibility atomically", async () => {
+  const other = await worker();
+  const results = await Promise.allSettled([
+    installProactiveStarter(company.id, null, input(), { automatic: true }),
+    installProactiveStarter(company.id, null, input(other.id), { automatic: true }),
+  ]);
+  assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(await AppDataSource.getRepository(MailRule).count(), 1);
+  assert.equal(
+    await AppDataSource.getRepository(AuditEvent).countBy({ action: "proactive.enable" }),
+    1,
+  );
+  assert.equal(Object.keys((await savedState()).assignments).length, 1);
+});
+
+for (const scenario of [
+  {
+    name: "AI Model is disconnected",
+    revoke: () => AppDataSource.getRepository(AIModel).delete({ employeeId: employee.id }),
+    message: /Connect an active AI Model/,
+  },
+  {
+    name: "mailbox Grant is revoked",
+    revoke: () =>
+      AppDataSource.getRepository(EmployeeMailAccountGrant).delete({
+        employeeId: employee.id,
+        accountId: account.id,
+      }),
+    message: /Grant Draft access/,
+  },
+]) {
+  test(`automatic setup leaves no reservation when its ${scenario.name} after preflight`, async (t) => {
+    const transaction = AppDataSource.transaction.bind(AppDataSource);
+    // Initial readiness uses the actual database. Revoke at the transaction
+    // boundary to simulate an assignment queued behind another writer.
+    const intercepted = t.mock.method(
+      AppDataSource,
+      "transaction",
+      async (work: (manager: EntityManager) => Promise<unknown>) => {
+        intercepted.mock.restore();
+        await scenario.revoke();
+        return transaction(work);
+      },
+    );
+
+    await assert.rejects(
+      installProactiveStarter(company.id, null, input(), { automatic: true }),
+      scenario.message,
+    );
+    assert.equal(intercepted.mock.callCount(), 1, "initial readiness passed before revocation");
+    assert.equal(await AppDataSource.getRepository(MailRule).count(), 0);
+    assert.equal(await AppDataSource.getRepository(Routine).count(), 0);
+    assert.equal(
+      await AppDataSource.getRepository(AuditEvent).countBy({ action: "proactive.enable" }),
+      0,
+    );
+    assert.deepEqual((await savedState()).assignments, {});
+  });
+}
+
+test("deletion is durable across reconciliation and a Member can deliberately assign it again", async () => {
+  const installed = await installProactiveStarter(company.id, null, input(), { automatic: true });
+  await AppDataSource.getRepository(MailRule).delete(installed.id);
+  await initializeProactiveDefaults(company.id);
+  await assert.rejects(
+    installProactiveStarter(company.id, null, input(), { automatic: true }),
+    /already assigned or removed/,
+  );
+  assert.equal(await AppDataSource.getRepository(MailRule).count(), 0);
+  await installProactiveStarter(company.id, company.ownerId, input());
+  assert.equal(await AppDataSource.getRepository(MailRule).count(), 1);
+});
+
+test("automatic company opt-out cannot alter an existing paused or customized installation", async () => {
+  const installed = await installProactiveStarter(company.id, company.ownerId, input());
+  await AppDataSource.getRepository(MailRule).update(installed.id, {
+    enabled: false,
+    name: "My reviewed rule",
+  });
+  await setProactiveAutomaticSetup(company.id, company.ownerId, false);
+  await assert.rejects(
+    installProactiveStarter(company.id, null, input(employee.id, "newsletter-cleanup"), {
+      automatic: true,
+    }),
+    /is off/,
+  );
+  await setProactiveAutomaticSetup(company.id, company.ownerId, true);
+  const saved = await AppDataSource.getRepository(MailRule).findOneByOrFail({ id: installed.id });
+  assert.equal(saved.enabled, false);
+  assert.equal(saved.name, "My reviewed rule");
+  assert.equal(Object.keys((await savedState()).assignments).length, 1);
+});
+
+test("upgrade adopts previously deleted installations once and no longer depends on audit retention", async () => {
+  const deletedId = proactiveId(company.id, employee.id, "quote-requests", account.id);
+  await insert(AuditEvent, {
+    companyId: company.id,
+    action: "proactive.enable",
+    targetId: deletedId,
+    metadataJson: JSON.stringify({
+      recipeId: "quote-requests",
+      employeeId: employee.id,
+      accountId: account.id,
+    }),
+  });
+  await initializeProactiveDefaults(company.id);
+  await AppDataSource.getRepository(AuditEvent).clear();
+  await initializeProactiveDefaults(company.id);
+  assert.equal(
+    (await savedState()).assignments[proactiveScope("quote-requests", account.id, employee.id)],
+    deletedId,
+  );
+  await assert.rejects(
+    installProactiveStarter(company.id, null, input(), { automatic: true }),
+    /already assigned or removed/,
+  );
+});
+
+test("native category handovers reserve responsibility even when paused and differently named", async () => {
+  const rule = await insert(MailRule, {
+    companyId: company.id,
+    accountId: account.id,
+    name: "Our quote process",
+    enabled: false,
+    conditionsJson: JSON.stringify({ category: "quote_request", from: "preferred.example" }),
+    actionsJson: JSON.stringify([
+      { type: "handToEmployee", employeeId: employee.id, mode: "draft", instruction: "Custom" },
+    ]),
+  });
+  await initializeProactiveDefaults(company.id);
+  assert.equal(
+    (await savedState()).assignments[proactiveScope("quote-requests", account.id, employee.id)],
+    rule.id,
+  );
+  await assert.rejects(
+    installProactiveStarter(company.id, null, input(), { automatic: true }),
+    /already assigned or removed/,
+  );
+});
+
+test("company responsibilities reserve one owner across mailboxes and retain scheduled delivery limits", async () => {
+  const installed = await installProactiveStarter(
+    company.id,
+    null,
+    input(employee.id, "overdue-invoices"),
+    { automatic: true },
+  );
+  const otherMailbox = await insert(MailAccount, {
+    companyId: company.id,
+    connectionId: randomUUID(),
+    address: "billing@example.test",
+  });
+  await insert(EmployeeMailAccountGrant, {
+    employeeId: employee.id,
+    accountId: otherMailbox.id,
+    accessLevel: "send",
+  });
+  await assert.rejects(
+    installProactiveStarter(
+      company.id,
+      null,
+      { ...input(employee.id, "overdue-invoices"), accountId: otherMailbox.id },
+      { automatic: true },
+    ),
+    /already assigned or removed/,
+  );
+  const routine = await AppDataSource.getRepository(Routine).findOneByOrFail({ id: installed.id });
+  assert.equal(routine.mailDeliveryMode, "draft");
+  assert.equal(await AppDataSource.getRepository(Routine).count(), 1);
+});
+
+test("mailbox-scoped native Routines are adopted even without an audit receipt", async () => {
+  const id = proactiveId(company.id, employee.id, "customer-commitments", account.id);
+  await insert(Routine, {
+    id,
+    employeeId: employee.id,
+    name: "Existing commitments",
+    slug: `proactive-customer-commitments-${id.slice(0, 8)}`,
+    cronExpr: "0 */4 * * *",
+    body: "Custom",
+    mailDeliveryMode: "draft",
+    enabled: false,
+  });
+  await initializeProactiveDefaults(company.id);
+  assert.equal(
+    (await savedState()).assignments[
+      proactiveScope("customer-commitments", account.id, employee.id)
+    ],
+    id,
+  );
+});
+
+test("invalid saved state fails closed and remains intact", async () => {
+  await AppDataSource.getRepository(Company).update(company.id, {
+    proactiveDefaultsJson: "invalid",
+  });
+  await assert.rejects(initializeProactiveDefaults(company.id), /could not read/);
+  await assert.rejects(
+    installProactiveStarter(company.id, null, input(), { automatic: true }),
+    /could not read/,
+  );
+  assert.equal(
+    (await AppDataSource.getRepository(Company).findOneByOrFail({ id: company.id }))
+      .proactiveDefaultsJson,
+    "invalid",
+  );
+  assert.equal(await AppDataSource.getRepository(MailRule).count(), 0);
+});
+
+test("unrelated company receipts and unknown recipes cannot reserve this company's work", async () => {
+  await insert(AuditEvent, {
+    companyId: randomUUID(),
+    action: "proactive.enable",
+    targetId: randomUUID(),
+    metadataJson: JSON.stringify({
+      recipeId: "quote-requests",
+      employeeId: employee.id,
+      accountId: account.id,
+    }),
+  });
+  await insert(AuditEvent, {
+    companyId: company.id,
+    action: "proactive.enable",
+    targetId: randomUUID(),
+    metadataJson: JSON.stringify({
+      recipeId: "unknown",
+      employeeId: employee.id,
+      accountId: account.id,
+    }),
+  });
+  await initializeProactiveDefaults(company.id);
+  assert.deepEqual((await savedState()).assignments, {});
+});

--- a/App/server/services/proactive/defaults.test.ts
+++ b/App/server/services/proactive/defaults.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ProactiveInstallation, ProactiveOverview } from "../../../shared/proactive.js";
+import { PlanLimitError } from "../entitlements.js";
+import type { workBlocked } from "../standdowns.js";
+import { PROACTIVE_RECIPES } from "./catalogue.js";
+import { planProactiveDefaults, reconcileProactiveDefaults } from "./defaults.js";
+import { proactiveScope } from "./scopes.js";
+import {
+  ProactiveSetupError,
+  type installProactiveStarter,
+  type ProactiveSetupInput,
+} from "./setup.js";
+
+type Overview = ProactiveOverview & {
+  automaticSetup: boolean;
+  defaultAssignments: Record<string, string>;
+};
+function fixture(): Overview {
+  return {
+    automaticSetup: true,
+    defaultAssignments: {},
+    recipes: structuredClone(PROACTIVE_RECIPES),
+    installations: [],
+    mailboxes: [
+      {
+        id: "mail-a",
+        address: "a@example.com",
+        status: "active",
+        analysisEnabled: true,
+        analysisReady: true,
+        analysisEmployeeId: "employee-b",
+      },
+      {
+        id: "mail-b",
+        address: "b@example.com",
+        status: "active",
+        analysisEnabled: true,
+        analysisReady: true,
+      },
+    ],
+    employees: ["employee-b", "employee-a"].map((id) => ({
+      id,
+      name: id,
+      slug: id,
+      modelReady: true,
+      financeAccess: "invoice",
+      revenueAccess: "write",
+      repositoryWrite: true,
+      calendarRead: true,
+      mailGrants: ["mail-a", "mail-b"].map((accountId) => ({ accountId, accessLevel: "send" })),
+    })),
+  };
+}
+function installation(input: ProactiveSetupInput, enabled = true): ProactiveInstallation {
+  return {
+    id: `installed-${input.recipeId}-${input.accountId ?? input.employeeId}`,
+    recipeId: input.recipeId,
+    employeeId: input.employeeId,
+    accountId: input.accountId ?? null,
+    name: "Reviewed native work",
+    enabled,
+    kind: PROACTIVE_RECIPES.find((recipe) => recipe.id === input.recipeId)!.kind,
+    delivery: "draft",
+    href: "/native-work",
+  };
+}
+const unblocked: typeof workBlocked = () => ({ blocked: false });
+
+test("scope ownership prevents worker changes and extra mailboxes duplicating company work", () => {
+  assert.equal(
+    proactiveScope("quote-requests", "mail", "a"),
+    proactiveScope("quote-requests", "mail", "b"),
+  );
+  assert.notEqual(
+    proactiveScope("quote-requests", "mail-a", "a"),
+    proactiveScope("quote-requests", "mail-b", "a"),
+  );
+  assert.equal(
+    proactiveScope("overdue-invoices", "mail-a", "a"),
+    proactiveScope("overdue-invoices", "mail-b", "b"),
+  );
+  assert.notEqual(
+    proactiveScope("work-followthrough", null, "a"),
+    proactiveScope("work-followthrough", null, "b"),
+  );
+});
+
+test("default-on planning selects one ready worker per scope and prioritizes their follow-through", () => {
+  const plan = planProactiveDefaults(fixture());
+  assert.equal(plan.filter((input) => input.recipeId === "quote-requests").length, 2);
+  assert.equal(
+    plan.find((input) => input.recipeId === "quote-requests" && input.accountId === "mail-a")
+      ?.employeeId,
+    "employee-b",
+  );
+  assert.equal(
+    plan.find((input) => input.recipeId === "quote-requests" && input.accountId === "mail-b")
+      ?.employeeId,
+    "employee-a",
+  );
+  for (const recipeId of [
+    "overdue-invoices",
+    "stalled-deals",
+    "meeting-followups",
+    "discover-improvements",
+  ]) {
+    assert.equal(plan.filter((input) => input.recipeId === recipeId).length, 1, recipeId);
+  }
+  assert.equal(plan.filter((input) => input.recipeId === "customer-commitments").length, 2);
+  assert.deepEqual(
+    plan.slice(0, 2).map((input) => input.recipeId),
+    ["work-followthrough", "work-followthrough"],
+  );
+  assert.ok(plan.every((input) => input.delivery === "draft"));
+});
+
+test("reserved deleted scopes and paused or customized native rows are never recreated", () => {
+  const overview = fixture();
+  overview.defaultAssignments[proactiveScope("quote-requests", "mail-a", "former-employee")] =
+    "deleted-rule";
+  overview.installations.push(
+    installation(
+      {
+        recipeId: "spam-cleanup",
+        employeeId: "employee-b",
+        accountId: "mail-b",
+        delivery: "draft",
+        instruction: "Custom human instruction",
+      },
+      false,
+    ),
+  );
+  const plan = planProactiveDefaults(overview);
+  assert.ok(
+    !plan.some((input) => input.recipeId === "quote-requests" && input.accountId === "mail-a"),
+  );
+  assert.ok(
+    !plan.some((input) => input.recipeId === "spam-cleanup" && input.accountId === "mail-b"),
+  );
+});
+
+test("unavailable analysis, disabled setup and stood-down employees never become ready by assumption", () => {
+  const overview = fixture();
+  overview.automaticSetup = false;
+  assert.deepEqual(planProactiveDefaults(overview), []);
+  overview.automaticSetup = true;
+  overview.mailboxes[0].analysisEnabled = false;
+  overview.mailboxes[1].analysisReady = false;
+  const plan = planProactiveDefaults(overview, new Set(["employee-a"]));
+  assert.ok(
+    !plan.some(
+      (input) => PROACTIVE_RECIPES.find((recipe) => recipe.id === input.recipeId)?.kind === "email",
+    ),
+  );
+  assert.ok(plan.every((input) => input.employeeId === "employee-b"));
+  assert.deepEqual(planProactiveDefaults(overview, new Set(["employee-a", "employee-b"])), []);
+});
+
+test("the pinned reader preference never overrides missing business Grants", () => {
+  const overview = fixture();
+  overview.employees[0].financeAccess = "read";
+  const plan = planProactiveDefaults(overview);
+  assert.equal(
+    plan.find((input) => input.recipeId === "quote-requests" && input.accountId === "mail-a")
+      ?.employeeId,
+    "employee-a",
+  );
+});
+
+test("concurrent company reconciliation coalesces and always uses automatic system installation", async () => {
+  const overview = fixture();
+  let release!: () => void;
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let initialized = 0;
+  const installed: ProactiveSetupInput[] = [];
+  const dependencies = {
+    initialize: async () => {
+      initialized++;
+      await barrier;
+    },
+    overview: async () => overview,
+    blocked: unblocked,
+    install: (async (companyId, userId, input, options) => {
+      assert.equal(companyId, "coalesced");
+      assert.equal(userId, null);
+      assert.deepEqual(options, { automatic: true });
+      installed.push(input);
+      return installation(input);
+    }) as typeof installProactiveStarter,
+  };
+  const first = reconcileProactiveDefaults("coalesced", dependencies);
+  const second = reconcileProactiveDefaults("coalesced", dependencies);
+  assert.equal(first, second);
+  release();
+  await Promise.all([first, second]);
+  assert.equal(initialized, 1);
+  assert.equal(installed.length, planProactiveDefaults(overview).length);
+});
+
+test("late readiness is retried, expected capacity/setup gaps stay pending, unexpected failures remain visible", async () => {
+  const overview = fixture();
+  overview.employees.forEach((employee) => {
+    employee.modelReady = false;
+  });
+  let calls = 0;
+  let unexpected = false;
+  const dependencies = {
+    initialize: async () => {},
+    overview: async () => overview,
+    blocked: unblocked,
+    install: (async (_companyId, _userId, input) => {
+      calls++;
+      if (unexpected) throw new Error("Database unavailable");
+      if (input.recipeId === "work-followthrough") throw new PlanLimitError("No capacity");
+      if (input.recipeId === "quote-requests") throw new ProactiveSetupError("Grant changed");
+      return installation(input);
+    }) as typeof installProactiveStarter,
+  };
+  await reconcileProactiveDefaults("late-ready", dependencies);
+  assert.equal(calls, 0);
+  overview.employees[0].modelReady = true;
+  await reconcileProactiveDefaults("late-ready", dependencies);
+  assert.ok(calls > 2);
+  unexpected = true;
+  await assert.rejects(
+    reconcileProactiveDefaults("late-ready", dependencies),
+    /Database unavailable/,
+  );
+});
+
+test("a company Standdown prevents initialization and a newly placed stop fences later installs", async () => {
+  const overview = fixture();
+  let stopped = true;
+  let initialized = 0;
+  let installed = 0;
+  const blocked: typeof workBlocked = () =>
+    stopped
+      ? { blocked: true, scope: "company", reason: "Paused", standdownId: "stop" }
+      : { blocked: false };
+  const dependencies = {
+    initialize: async () => {
+      initialized++;
+    },
+    overview: async () => overview,
+    blocked,
+    install: (async (_companyId, _userId, input) => {
+      installed++;
+      stopped = true;
+      return installation(input);
+    }) as typeof installProactiveStarter,
+  };
+  await reconcileProactiveDefaults("stopped", dependencies);
+  assert.equal(initialized, 0);
+  stopped = false;
+  await reconcileProactiveDefaults("stopped", dependencies);
+  assert.equal(installed, 1);
+});

--- a/App/server/services/proactive/defaults.ts
+++ b/App/server/services/proactive/defaults.ts
@@ -1,0 +1,222 @@
+import { MoreThan } from "typeorm";
+import { AppDataSource } from "../../db/datasource.js";
+import { Company } from "../../db/entities/Company.js";
+import {
+  proactiveReadiness,
+  type ProactiveOverview,
+  type ProactiveEmployee,
+  type ProactiveMailbox,
+  type ProactiveRecipe,
+} from "../../../shared/proactive.js";
+import { PlanLimitError } from "../entitlements.js";
+import { withSchedulerLease } from "../schedulerLeases.js";
+import { workBlocked } from "../standdowns.js";
+import { initializeProactiveDefaults } from "./defaultsState.js";
+import {
+  getProactiveOverview,
+  installProactiveStarter,
+  ProactiveSetupError,
+  type ProactiveSetupInput,
+} from "./setup.js";
+import { proactiveScope, proactiveScopeKind } from "./scopes.js";
+
+type DefaultsOverview = ProactiveOverview & {
+  automaticSetup: boolean;
+  defaultAssignments: Record<string, string>;
+};
+
+/** Pure ownership planner: an existing reservation includes paused, customized, and deleted work. */
+export function planProactiveDefaults(
+  overview: DefaultsOverview,
+  blockedEmployeeIds: ReadonlySet<string> = new Set(),
+): ProactiveSetupInput[] {
+  if (!overview.automaticSetup) return [];
+  const occupied = new Set(Object.keys(overview.defaultAssignments));
+  for (const row of overview.installations) {
+    occupied.add(proactiveScope(row.recipeId, row.accountId, row.employeeId));
+  }
+  const employees = [...overview.employees]
+    .filter((employee) => !blockedEmployeeIds.has(employee.id))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const mailboxes = [...overview.mailboxes].sort((left, right) => left.id.localeCompare(right.id));
+  const plan: ProactiveSetupInput[] = [];
+  const assignedEmployees = new Set(
+    overview.installations
+      .filter((row) => row.enabled && row.recipeId !== "work-followthrough")
+      .map((row) => row.employeeId),
+  );
+  const choose = (recipe: ProactiveRecipe, mailbox?: ProactiveMailbox) => {
+    const preferred = (
+      mailbox as (ProactiveMailbox & { analysisEmployeeId?: string | null }) | undefined
+    )?.analysisEmployeeId;
+    return [...employees]
+      .sort((left, right) => Number(right.id === preferred) - Number(left.id === preferred))
+      .find((employee) => proactiveReadiness(recipe, employee, mailbox, "draft").length === 0);
+  };
+  const add = (
+    recipe: ProactiveRecipe,
+    employee: ProactiveEmployee,
+    mailbox?: ProactiveMailbox,
+  ) => {
+    const accountId = mailbox?.id ?? null;
+    const scope = proactiveScope(recipe.id, accountId, employee.id);
+    if (occupied.has(scope)) return;
+    occupied.add(scope);
+    assignedEmployees.add(employee.id);
+    plan.push({
+      recipeId: recipe.id,
+      employeeId: employee.id,
+      accountId,
+      delivery: "draft",
+      instruction: recipe.brief,
+    });
+  };
+  // Select owners before adding follow-through, so even the first ready inbox
+  // worker gets a continuation Routine before optional scheduled work uses capacity.
+  for (const recipe of overview.recipes) {
+    const kind = proactiveScopeKind(recipe.id);
+    if (kind === "employee") continue;
+    if (kind === "mailbox") {
+      for (const mailbox of mailboxes) {
+        const employee = choose(recipe, mailbox);
+        if (employee) add(recipe, employee, mailbox);
+      }
+    } else if (recipe.requirements.includes("mail")) {
+      for (const mailbox of mailboxes) {
+        const employee = choose(recipe, mailbox);
+        if (employee) {
+          add(recipe, employee, mailbox);
+          break;
+        }
+      }
+    } else {
+      const employee = choose(recipe);
+      if (employee) add(recipe, employee);
+    }
+  }
+  const followthrough = overview.recipes.find((recipe) => recipe.id === "work-followthrough");
+  if (followthrough) {
+    for (const employee of employees) {
+      if (
+        assignedEmployees.has(employee.id) &&
+        proactiveReadiness(followthrough, employee, undefined).length === 0
+      ) {
+        add(followthrough, employee);
+      }
+    }
+  }
+  return plan.sort((left, right) => {
+    const priority = (input: ProactiveSetupInput) =>
+      input.recipeId === "work-followthrough"
+        ? 0
+        : overview.recipes.find((recipe) => recipe.id === input.recipeId)?.kind === "email"
+          ? 1
+          : 2;
+    return priority(left) - priority(right);
+  });
+}
+
+type DefaultsDependencies = {
+  initialize: (companyId: string) => Promise<unknown>;
+  overview: (companyId: string) => Promise<DefaultsOverview>;
+  install: typeof installProactiveStarter;
+  blocked: typeof workBlocked;
+};
+const defaultsDependencies: DefaultsDependencies = {
+  initialize: initializeProactiveDefaults,
+  overview: getProactiveOverview,
+  install: installProactiveStarter,
+  blocked: workBlocked,
+};
+
+const companyRuns = new Map<string, Promise<void>>();
+
+/** Initialization and native installation claims are durable; this coalesces local arrivals. */
+export function reconcileProactiveDefaults(
+  companyId: string,
+  dependencies: DefaultsDependencies = defaultsDependencies,
+): Promise<void> {
+  const active = companyRuns.get(companyId);
+  if (active) return active;
+  const run = (async () => {
+    if (dependencies.blocked(companyId).blocked) return;
+    await dependencies.initialize(companyId);
+    const overview = await dependencies.overview(companyId);
+    const blocked = new Set(
+      overview.employees
+        .filter((employee) => dependencies.blocked(companyId, { employeeId: employee.id }).blocked)
+        .map((employee) => employee.id),
+    );
+    for (const input of planProactiveDefaults(overview, blocked)) {
+      if (dependencies.blocked(companyId, { employeeId: input.employeeId }).blocked) continue;
+      try {
+        await dependencies.install(companyId, null, input, { automatic: true });
+      } catch (error) {
+        // Missing live prerequisites, a paused scope, or plan capacity are
+        // pending setup, not incidents. A later reconciliation can try again.
+        if (!(error instanceof ProactiveSetupError) && !(error instanceof PlanLimitError))
+          throw error;
+      }
+    }
+  })().finally(() => {
+    if (companyRuns.get(companyId) === run) companyRuns.delete(companyId);
+  });
+  companyRuns.set(companyId, run);
+  return run;
+}
+
+const DISCOVERY_INTERVAL_MS = 60_000;
+const COMPANY_PAGE_SIZE = 50;
+let discoveryTimer: NodeJS.Timeout | null = null;
+let discovering = false;
+
+/** Repair sweep also covers new companies/mailboxes and writes made on other replicas. */
+export async function sweepProactiveDefaults(): Promise<void> {
+  if (discovering) return;
+  discovering = true;
+  try {
+    await withSchedulerLease("proactive-defaults", 60_000, async (lease) => {
+      let cursor: string | undefined;
+      for (;;) {
+        const companies = await AppDataSource.getRepository(Company).find({
+          where: { proactiveAutoSetup: true, ...(cursor ? { id: MoreThan(cursor) } : {}) },
+          select: { id: true },
+          order: { id: "ASC" },
+          take: COMPANY_PAGE_SIZE,
+        });
+        for (const company of companies) {
+          if (!lease.isHeld()) return;
+          try {
+            await reconcileProactiveDefaults(company.id);
+          } catch (error) {
+            // One unavailable company must not prevent other ready companies starting.
+            // eslint-disable-next-line no-console
+            console.error(`[proactive] automatic setup failed for company ${company.id}:`, error);
+          }
+        }
+        if (companies.length < COMPANY_PAGE_SIZE) return;
+        cursor = companies.at(-1)!.id;
+      }
+    });
+  } finally {
+    discovering = false;
+  }
+}
+
+export async function bootProactiveDefaults(): Promise<void> {
+  stopProactiveDefaults();
+  await sweepProactiveDefaults();
+  discoveryTimer = setInterval(() => {
+    void sweepProactiveDefaults().catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error("[proactive] automatic setup sweep failed:", error);
+    });
+  }, DISCOVERY_INTERVAL_MS);
+  discoveryTimer.unref();
+}
+
+/** Stop discovery before a test database closes or a lifecycle restarts it. */
+export function stopProactiveDefaults(): void {
+  if (discoveryTimer) clearInterval(discoveryTimer);
+  discoveryTimer = null;
+}

--- a/App/server/services/proactive/defaultsIntegration.test.ts
+++ b/App/server/services/proactive/defaultsIntegration.test.ts
@@ -1,0 +1,371 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { after, before, beforeEach, test } from "node:test";
+import { AppDataSource } from "../../db/datasource.js";
+import { AIEmployee } from "../../db/entities/AIEmployee.js";
+import { AIModel } from "../../db/entities/AIModel.js";
+import { CalendarAccount } from "../../db/entities/CalendarAccount.js";
+import { Company } from "../../db/entities/Company.js";
+import { EmployeeCalendarGrant } from "../../db/entities/EmployeeCalendarGrant.js";
+import { EmployeeFinanceGrant } from "../../db/entities/EmployeeFinanceGrant.js";
+import { EmployeeMailAccountGrant } from "../../db/entities/EmployeeMailAccountGrant.js";
+import { EmployeeRepositoryGrant } from "../../db/entities/EmployeeRepositoryGrant.js";
+import { EmployeeRevenueGrant } from "../../db/entities/EmployeeRevenueGrant.js";
+import { MailAccount } from "../../db/entities/MailAccount.js";
+import { MailInboundAutomation } from "../../db/entities/MailInboundAutomation.js";
+import { MailMessage } from "../../db/entities/MailMessage.js";
+import { MailRule } from "../../db/entities/MailRule.js";
+import { MailThread } from "../../db/entities/MailThread.js";
+import { Repository } from "../../db/entities/Repository.js";
+import { Routine } from "../../db/entities/Routine.js";
+import { RoutineTrigger } from "../../db/entities/RoutineTrigger.js";
+import { Run } from "../../db/entities/Run.js";
+import { Standdown } from "../../db/entities/Standdown.js";
+import { closeTestDb, initTestDb, insert, resetTestDb } from "../../test/dbHarness.js";
+import { enqueueInboundAutomation, waitForMailAutomation } from "../mail/automationQueue.js";
+import { refreshStanddowns } from "../standdowns.js";
+import {
+  bootProactiveDefaults,
+  reconcileProactiveDefaults,
+  stopProactiveDefaults,
+  sweepProactiveDefaults,
+} from "./defaults.js";
+import { getProactiveOverview } from "./setup.js";
+import { proactiveScope } from "./scopes.js";
+
+before(initTestDb);
+beforeEach(async () => {
+  stopProactiveDefaults();
+  await resetTestDb();
+  await refreshStanddowns();
+});
+after(async () => {
+  stopProactiveDefaults();
+  await closeTestDb();
+});
+
+async function company() {
+  return insert(Company, { name: "Default work", slug: randomUUID(), ownerId: randomUUID() });
+}
+
+async function worker(companyId: string, account?: MailAccount, businessGrants = true) {
+  const employee = await insert(AIEmployee, {
+    companyId,
+    name: "Customer operations",
+    slug: randomUUID(),
+    role: "Customer operations",
+  });
+  await insert(AIModel, {
+    employeeId: employee.id,
+    provider: "openai",
+    model: "fixture",
+    authMode: "apikey",
+    isActive: true,
+    configJson: JSON.stringify({ apiKeyEncrypted: "fixture-only-no-network" }),
+  });
+  if (account)
+    await insert(EmployeeMailAccountGrant, {
+      employeeId: employee.id,
+      accountId: account.id,
+      accessLevel: "send",
+    });
+  if (businessGrants) {
+    await insert(EmployeeFinanceGrant, {
+      companyId,
+      employeeId: employee.id,
+      accessLevel: "invoice",
+    });
+    await insert(EmployeeRevenueGrant, {
+      companyId,
+      employeeId: employee.id,
+      accessLevel: "write",
+    });
+    const repository = await insert(Repository, {
+      companyId,
+      name: "Product",
+      slug: randomUUID(),
+      origin: "local",
+      gitUrl: "",
+    });
+    await insert(EmployeeRepositoryGrant, {
+      employeeId: employee.id,
+      repositoryId: repository.id,
+      accessLevel: "write",
+    });
+    const calendar = await insert(CalendarAccount, { companyId, connectionId: randomUUID() });
+    await insert(EmployeeCalendarGrant, {
+      employeeId: employee.id,
+      accountId: calendar.id,
+      accessLevel: "read",
+    });
+  }
+  return employee;
+}
+
+async function readyCompany() {
+  const row = await company();
+  const account = await insert(MailAccount, {
+    companyId: row.id,
+    connectionId: randomUUID(),
+    address: "requests@example.test",
+    status: "active",
+    aiAnalysisEnabled: true,
+  });
+  const employee = await worker(row.id, account);
+  return { company: row, account, employee };
+}
+
+async function message(account: MailAccount) {
+  const thread = await insert(MailThread, {
+    companyId: account.companyId,
+    accountId: account.id,
+    gmailThreadId: randomUUID(),
+  });
+  return insert(MailMessage, {
+    companyId: account.companyId,
+    accountId: account.id,
+    threadId: thread.id,
+    gmailThreadId: thread.gmailThreadId,
+    gmailMessageId: randomUUID(),
+    fromEmail: "customer@example.test",
+    toEmails: account.address,
+    subject: "Please quote for our order",
+  });
+}
+
+async function assertNativeDefaults(companyId: string) {
+  const overview = await getProactiveOverview(companyId);
+  assert.equal(overview.automaticSetup, true);
+  assert.equal(overview.installations.length, 11);
+  assert.equal(Object.keys(overview.defaultAssignments).length, 11);
+  const rules = await AppDataSource.getRepository(MailRule).findBy({ companyId });
+  assert.equal(rules.length, 5);
+  for (const rule of rules) {
+    assert.equal(rule.enabled, true);
+    assert.equal(rule.createdByUserId, null);
+    assert.equal(JSON.parse(rule.actionsJson)[0].mode, "work");
+  }
+  const routines = await AppDataSource.getRepository(Routine).findBy({
+    employeeId: overview.employees[0].id,
+  });
+  assert.equal(routines.length, 6);
+  for (const routine of routines) {
+    assert.equal(routine.enabled, true);
+    assert.equal(routine.mailDeliveryMode, "draft");
+    assert.ok(routine.nextRunAt instanceof Date);
+  }
+  assert.equal(await AppDataSource.getRepository(RoutineTrigger).countBy({ companyId }), 4);
+  assert.equal(await AppDataSource.getRepository(Run).count(), 0);
+  return overview;
+}
+
+test("boot activates existing ready companies and later discovery activates newly created companies", async () => {
+  const existing = await readyCompany();
+  assert.equal(existing.company.proactiveAutoSetup, true);
+  await bootProactiveDefaults();
+  stopProactiveDefaults();
+  const first = await assertNativeDefaults(existing.company.id);
+  const later = await readyCompany();
+  await sweepProactiveDefaults();
+  await assertNativeDefaults(later.company.id);
+  assert.deepEqual(
+    (await getProactiveOverview(existing.company.id)).defaultAssignments,
+    first.defaultAssignments,
+  );
+});
+
+test("multiple eligible employees get one stable owner for each company and mailbox responsibility", async () => {
+  const fixture = await readyCompany();
+  const preferred = await worker(fixture.company.id, fixture.account);
+  await AppDataSource.getRepository(MailAccount).update(fixture.account.id, {
+    aiAnalysisEmployeeId: preferred.id,
+  });
+  await Promise.all([
+    reconcileProactiveDefaults(fixture.company.id),
+    reconcileProactiveDefaults(fixture.company.id),
+  ]);
+  const overview = await getProactiveOverview(fixture.company.id);
+  for (const recipe of overview.recipes.filter((row) => row.id !== "work-followthrough")) {
+    const installed = overview.installations.filter((row) => row.recipeId === recipe.id);
+    assert.equal(installed.length, 1, recipe.id);
+    if (recipe.requirements.includes("mail")) assert.equal(installed[0].employeeId, preferred.id);
+  }
+  await AppDataSource.getRepository(MailAccount).update(fixture.account.id, {
+    aiAnalysisEmployeeId: fixture.employee.id,
+  });
+  await reconcileProactiveDefaults(fixture.company.id);
+  assert.deepEqual(
+    (await getProactiveOverview(fixture.company.id)).defaultAssignments,
+    overview.defaultAssignments,
+  );
+});
+
+test("later Grants become ready automatically without replacing existing assignments", async () => {
+  const row = await company();
+  const employee = await worker(row.id, undefined, false);
+  await reconcileProactiveDefaults(row.id);
+  const initial = await getProactiveOverview(row.id);
+  assert.deepEqual(initial.installations.map((entry) => entry.recipeId).sort(), [
+    "discover-improvements",
+    "work-followthrough",
+  ]);
+  const account = await insert(MailAccount, {
+    companyId: row.id,
+    connectionId: randomUUID(),
+    address: "new@example.test",
+    aiAnalysisEnabled: true,
+  });
+  await insert(EmployeeMailAccountGrant, {
+    employeeId: employee.id,
+    accountId: account.id,
+    accessLevel: "draft",
+  });
+  await sweepProactiveDefaults();
+  assert.equal(
+    (await getProactiveOverview(row.id)).installations.some(
+      (entry) => entry.recipeId === "quote-requests",
+    ),
+    false,
+  );
+  await insert(EmployeeFinanceGrant, {
+    companyId: row.id,
+    employeeId: employee.id,
+    accessLevel: "invoice",
+  });
+  await sweepProactiveDefaults();
+  const ready = await getProactiveOverview(row.id);
+  assert.ok(ready.installations.some((entry) => entry.recipeId === "quote-requests"));
+  for (const [scope, id] of Object.entries(initial.defaultAssignments))
+    assert.equal(ready.defaultAssignments[scope], id);
+});
+
+test("reconciliation preserves paused custom work and deleted defaults across later sweeps", async () => {
+  const fixture = await readyCompany();
+  await reconcileProactiveDefaults(fixture.company.id);
+  const initial = await getProactiveOverview(fixture.company.id);
+  const quote = initial.installations.find((row) => row.recipeId === "quote-requests")!;
+  const spam = initial.installations.find((row) => row.recipeId === "spam-cleanup")!;
+  const overdue = initial.installations.find((row) => row.recipeId === "overdue-invoices")!;
+  await AppDataSource.getRepository(MailRule).update(quote.id, {
+    enabled: false,
+    name: "Our reviewed quote process",
+  });
+  await AppDataSource.getRepository(MailRule).delete(spam.id);
+  await AppDataSource.getRepository(Routine).delete(overdue.id);
+  await sweepProactiveDefaults();
+  await reconcileProactiveDefaults(fixture.company.id);
+  const saved = await AppDataSource.getRepository(MailRule).findOneByOrFail({ id: quote.id });
+  assert.equal(saved.enabled, false);
+  assert.equal(saved.name, "Our reviewed quote process");
+  assert.equal(await AppDataSource.getRepository(MailRule).existsBy({ id: spam.id }), false);
+  assert.equal(await AppDataSource.getRepository(Routine).existsBy({ id: overdue.id }), false);
+  assert.deepEqual(
+    (await getProactiveOverview(fixture.company.id)).defaultAssignments,
+    initial.defaultAssignments,
+  );
+});
+
+test("Standdowns and company automatic-setup opt-out stay pending until released", async () => {
+  const fixture = await readyCompany();
+  const standdown = await insert(Standdown, {
+    companyId: fixture.company.id,
+    scope: "company",
+    placedAt: new Date(),
+  });
+  await refreshStanddowns();
+  await sweepProactiveDefaults();
+  assert.equal((await getProactiveOverview(fixture.company.id)).installations.length, 0);
+  await AppDataSource.getRepository(Standdown).update(standdown.id, { liftedAt: new Date() });
+  await refreshStanddowns();
+  await AppDataSource.getRepository(Company).update(fixture.company.id, {
+    proactiveAutoSetup: false,
+  });
+  await sweepProactiveDefaults();
+  assert.equal((await getProactiveOverview(fixture.company.id)).installations.length, 0);
+  await AppDataSource.getRepository(Company).update(fixture.company.id, {
+    proactiveAutoSetup: true,
+  });
+  await sweepProactiveDefaults();
+  await assertNativeDefaults(fixture.company.id);
+});
+
+test("the first incoming message installs defaults before ordinary processing without replaying history", async () => {
+  const fixture = await readyCompany();
+  const historical = await message(fixture.account);
+  const incoming = await message(fixture.account);
+  const calls: string[] = [];
+  const options = {
+    defaultEffects: {
+      analyzeInbound: async (_account: MailAccount, current: MailMessage) => {
+        assert.equal(
+          await AppDataSource.getRepository(MailRule).countBy({ companyId: fixture.company.id }),
+          5,
+        );
+        assert.equal(current.id, incoming.id);
+        calls.push("analysis");
+        return null;
+      },
+      applyRules: async () => {
+        calls.push("rules");
+      },
+      dispatchReceived: async () => {
+        calls.push("pipelines");
+      },
+    },
+  };
+  await enqueueInboundAutomation(incoming, options);
+  await waitForMailAutomation(fixture.account.id);
+  await enqueueInboundAutomation(incoming, options);
+  await waitForMailAutomation(fixture.account.id);
+  assert.deepEqual(calls, ["analysis", "rules", "pipelines"]);
+  const deliveries = await AppDataSource.getRepository(MailInboundAutomation).find();
+  assert.equal(deliveries.length, 1);
+  assert.equal(deliveries[0].messageId, incoming.id);
+  assert.equal(deliveries[0].status, "succeeded");
+  assert.equal(
+    await AppDataSource.getRepository(MailMessage).existsBy({ id: historical.id }),
+    true,
+  );
+  await assertNativeDefaults(fixture.company.id);
+});
+
+test("a temporary setup failure retains incoming mail and existing automation while a later sweep repairs defaults", async (context) => {
+  const fixture = await readyCompany();
+  const incoming = await message(fixture.account);
+  const warning = context.mock.method(console, "warn", () => {});
+  const calls: string[] = [];
+  await enqueueInboundAutomation(incoming, {
+    defaultEffects: {
+      reconcileDefaults: async () => {
+        throw new Error("Temporary setup storage failure");
+      },
+      analyzeInbound: async () => {
+        calls.push("analysis");
+        return null;
+      },
+      applyRules: async () => {
+        calls.push("rules");
+      },
+      dispatchReceived: async () => {
+        calls.push("pipelines");
+      },
+    },
+  });
+  await waitForMailAutomation(fixture.account.id);
+  assert.equal(warning.mock.callCount(), 1);
+  assert.deepEqual(calls, ["analysis", "rules", "pipelines"]);
+  const delivery = await AppDataSource.getRepository(MailInboundAutomation).findOneByOrFail({
+    messageId: incoming.id,
+  });
+  assert.equal(delivery.status, "succeeded");
+  assert.equal(await AppDataSource.getRepository(MailMessage).existsBy({ id: incoming.id }), true);
+  assert.equal(await AppDataSource.getRepository(MailRule).count(), 0);
+  await sweepProactiveDefaults();
+  const overview = await assertNativeDefaults(fixture.company.id);
+  assert.ok(
+    overview.defaultAssignments[
+      proactiveScope("quote-requests", fixture.account.id, fixture.employee.id)
+    ],
+  );
+  assert.deepEqual(calls, ["analysis", "rules", "pipelines"]);
+});

--- a/App/server/services/proactive/defaultsState.ts
+++ b/App/server/services/proactive/defaultsState.ts
@@ -1,0 +1,135 @@
+import { In, type EntityManager } from "typeorm";
+import { z } from "zod";
+import { AppDataSource } from "../../db/datasource.js";
+import { withSerializedTransaction } from "../../db/transactions.js";
+import { Company } from "../../db/entities/Company.js";
+import { AIEmployee } from "../../db/entities/AIEmployee.js";
+import { AuditEvent } from "../../db/entities/AuditEvent.js";
+import { MailRule } from "../../db/entities/MailRule.js";
+import { MailAccount } from "../../db/entities/MailAccount.js";
+import { Routine } from "../../db/entities/Routine.js";
+import { parseActions, parseConditions } from "../mail/rules.js";
+import { PROACTIVE_RECIPES } from "./catalogue.js";
+import { proactiveScope } from "./scopes.js";
+import { proactiveId } from "./ids.js";
+
+const stateSchema = z
+  .object({
+    version: z.literal(1),
+    assignments: z.record(z.string().uuid()),
+  })
+  .strict();
+export type ProactiveDefaultsState = z.infer<typeof stateSchema>;
+
+/** Reservations only. Instructions, scheduling, enabled state and authority
+ * remain on the native rows. Keeping a reservation after deletion respects
+ * the Member's choice instead of recreating their work on the next sweep. */
+export function readProactiveDefaults(raw: string): ProactiveDefaultsState {
+  if (!raw) return { version: 1, assignments: {} };
+  try {
+    return stateSchema.parse(JSON.parse(raw));
+  } catch {
+    throw new Error("Automatic setup could not read its saved assignments.");
+  }
+}
+
+export async function lockProactiveCompany(
+  manager: EntityManager,
+  companyId: string,
+): Promise<Company> {
+  return manager.getRepository(Company).findOneOrFail({
+    where: { id: companyId },
+    ...(AppDataSource.options.type === "postgres"
+      ? { lock: { mode: "pessimistic_write" as const } }
+      : {}),
+  });
+}
+
+/** Called inside the same company transaction as installing work. It also
+ * adopts recognizable native edits made between reconciliation passes. */
+export async function collectProactiveDefaults(
+  manager: EntityManager,
+  company: Company,
+): Promise<ProactiveDefaultsState> {
+  const state = readProactiveDefaults(company.proactiveDefaultsJson);
+  const reserve = (recipeId: string, employeeId: string, accountId: string | null, id: string) => {
+    const scope = proactiveScope(recipeId, accountId, employeeId);
+    state.assignments[scope] ??= id;
+  };
+
+  // Upgrade bridge only: preserve installations removed before reservations
+  // existed. Subsequent passes use the durable state, never audit retention.
+  if (!company.proactiveDefaultsJson) {
+    const receipts = await manager.getRepository(AuditEvent).find({
+      where: { companyId: company.id, action: "proactive.enable" },
+      order: { createdAt: "ASC", id: "ASC" },
+    });
+    const receiptSchema = z.object({
+      recipeId: z.string(),
+      employeeId: z.string().uuid(),
+      accountId: z.string().uuid().nullable(),
+    });
+    for (const receipt of receipts) {
+      if (!receipt.targetId || !z.string().uuid().safeParse(receipt.targetId).success) continue;
+      try {
+        const metadata = receiptSchema.parse(JSON.parse(receipt.metadataJson));
+        const recipe = PROACTIVE_RECIPES.find((entry) => entry.id === metadata.recipeId);
+        if (!recipe || recipe.requirements.includes("mail") !== Boolean(metadata.accountId))
+          continue;
+        reserve(recipe.id, metadata.employeeId, metadata.accountId, receipt.targetId);
+      } catch {
+        // Older/unrelated receipts are not an assignment record.
+      }
+    }
+  }
+
+  const rules = await manager.getRepository(MailRule).find({
+    where: { companyId: company.id },
+    order: { createdAt: "ASC", id: "ASC" },
+  });
+  for (const rule of rules) {
+    const recipe = PROACTIVE_RECIPES.find(
+      (entry) =>
+        entry.kind === "email" && entry.category === parseConditions(rule.conditionsJson).category,
+    );
+    const action = parseActions(rule.actionsJson).find((entry) => entry.type === "handToEmployee");
+    if (recipe && action?.type === "handToEmployee")
+      reserve(recipe.id, action.employeeId, rule.accountId, rule.id);
+  }
+  const employees = await manager.getRepository(AIEmployee).findBy({ companyId: company.id });
+  const accounts = await manager.getRepository(MailAccount).findBy({ companyId: company.id });
+  const routines = employees.length
+    ? await manager
+        .getRepository(Routine)
+        .findBy({ employeeId: In(employees.map((entry) => entry.id)) })
+    : [];
+  for (const routine of routines) {
+    const recipe = PROACTIVE_RECIPES.find(
+      (entry) => entry.kind === "routine" && routine.slug.startsWith(`proactive-${entry.id}-`),
+    );
+    // Company/employee responsibilities do not need their original mailbox
+    // to reserve their scope. Mailbox-scoped receipts were adopted above.
+    if (!recipe) continue;
+    if (recipe.id !== "customer-commitments")
+      reserve(recipe.id, routine.employeeId, null, routine.id);
+    else {
+      const account = accounts.find(
+        (entry) => proactiveId(company.id, routine.employeeId, recipe.id, entry.id) === routine.id,
+      );
+      if (account) reserve(recipe.id, routine.employeeId, account.id, routine.id);
+    }
+  }
+  return state;
+}
+
+export async function initializeProactiveDefaults(companyId: string): Promise<void> {
+  await withSerializedTransaction(async (manager) => {
+    const company = await lockProactiveCompany(manager, companyId);
+    const state = await collectProactiveDefaults(manager, company);
+    const json = JSON.stringify(state);
+    if (json !== company.proactiveDefaultsJson)
+      await manager
+        .getRepository(Company)
+        .update({ id: companyId }, { proactiveDefaultsJson: json });
+  });
+}

--- a/App/server/services/proactive/ids.ts
+++ b/App/server/services/proactive/ids.ts
@@ -1,0 +1,14 @@
+import { createHash } from "node:crypto";
+
+/** The native identity stays stable across retries and automatic setup. */
+export function proactiveId(
+  companyId: string,
+  employeeId: string,
+  recipeId: string,
+  accountId: string | null,
+): string {
+  const hex = createHash("sha1")
+    .update(JSON.stringify(["genosyn-proactive-v1", companyId, employeeId, recipeId, accountId]))
+    .digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-a${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}

--- a/App/server/services/proactive/scopes.ts
+++ b/App/server/services/proactive/scopes.ts
@@ -1,0 +1,29 @@
+/** Business ownership is stable when employees change; follow-through alone is per employee. */
+export function proactiveScopeKind(recipeId: string): "mailbox" | "company" | "employee" {
+  if (recipeId === "work-followthrough") return "employee";
+  if (
+    [
+      "quote-requests",
+      "customer-code-issues",
+      "new-sales-enquiries",
+      "spam-cleanup",
+      "newsletter-cleanup",
+      "customer-commitments",
+    ].includes(recipeId)
+  )
+    return "mailbox";
+  return "company";
+}
+
+export function proactiveScope(
+  recipeId: string,
+  accountId: string | null,
+  employeeId: string,
+): string {
+  const kind = proactiveScopeKind(recipeId);
+  return JSON.stringify([
+    recipeId,
+    kind,
+    kind === "mailbox" ? accountId : kind === "employee" ? employeeId : null,
+  ]);
+}

--- a/App/server/services/proactive/setup.ts
+++ b/App/server/services/proactive/setup.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { In } from "typeorm";
 import { AppDataSource } from "../../db/datasource.js";
 import { withSerializedTransaction } from "../../db/transactions.js";
@@ -19,13 +18,23 @@ import { RoutineTrigger } from "../../db/entities/RoutineTrigger.js";
 import { effectiveActiveId } from "../models.js";
 import { isModelConnected } from "../providers.js";
 import { recordAudit } from "../audit.js";
-import { assertRoutineCapacity } from "../entitlements.js";
+import { assertRoutineCapacity, PlanLimitError } from "../entitlements.js";
 import { nextRunFor } from "../cron.js";
 import { emitResourceChange } from "../resourceEvents.js";
 import { broadcastToCompany } from "../realtime.js";
 import { parseActions, parseConditions } from "../mail/rules.js";
 import { resolveAnalysisReader } from "../mail/analysis.js";
 import { PROACTIVE_RECIPES, PROACTIVE_WORK_GUIDANCE } from "./catalogue.js";
+import { proactiveId } from "./ids.js";
+import { proactiveScope } from "./scopes.js";
+import {
+  collectProactiveDefaults,
+  initializeProactiveDefaults,
+  lockProactiveCompany,
+  readProactiveDefaults,
+} from "./defaultsState.js";
+import { workBlocked } from "../standdowns.js";
+export { proactiveId } from "./ids.js";
 import {
   proactiveReadiness,
   type ProactiveInstallation,
@@ -40,20 +49,6 @@ export class ProactiveSetupError extends Error {
   ) {
     super(message);
   }
-}
-
-/** Native rows remain the source of truth. A stable primary key makes retries
- * and concurrent installs converge without a second automation registry. */
-export function proactiveId(
-  companyId: string,
-  employeeId: string,
-  recipeId: string,
-  accountId: string | null,
-): string {
-  const hex = createHash("sha1")
-    .update(JSON.stringify(["genosyn-proactive-v1", companyId, employeeId, recipeId, accountId]))
-    .digest("hex");
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-a${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
 }
 
 export async function getProactiveOverview(companyId: string): Promise<ProactiveOverview> {
@@ -91,13 +86,17 @@ export async function getProactiveOverview(companyId: string): Promise<Proactive
   // Use the same resolver as incoming mail: its pinned employee may differ
   // from the worker selected for this starter, and must retain a live Grant.
   const mailboxes = await Promise.all(
-    accounts.map(async (account) => ({
-      id: account.id,
-      address: account.address,
-      status: account.status,
-      analysisEnabled: account.aiAnalysisEnabled,
-      analysisReady: account.aiAnalysisEnabled && Boolean(await resolveAnalysisReader(account)),
-    })),
+    accounts.map(async (account) => {
+      const reader = account.aiAnalysisEnabled ? await resolveAnalysisReader(account) : null;
+      return {
+        id: account.id,
+        address: account.address,
+        status: account.status,
+        analysisEnabled: account.aiAnalysisEnabled,
+        analysisReady: Boolean(reader),
+        analysisEmployeeId: reader?.employee.id ?? null,
+      };
+    }),
   );
   const employees = roster.map((employee) => {
     const brains = models.filter((model) => model.employeeId === employee.id);
@@ -192,6 +191,8 @@ export async function getProactiveOverview(companyId: string): Promise<Proactive
     });
   }
   return {
+    automaticSetup: company.proactiveAutoSetup,
+    defaultAssignments: readProactiveDefaults(company.proactiveDefaultsJson).assignments,
     recipes: PROACTIVE_RECIPES.map((recipe) => ({
       ...recipe,
       brief: `${recipe.brief}\n\n${PROACTIVE_WORK_GUIDANCE}`,
@@ -230,32 +231,73 @@ function validateSetup(overview: ProactiveOverview, input: ProactiveSetupInput):
 
 export async function installProactiveStarter(
   companyId: string,
-  userId: string,
+  userId: string | null,
   input: ProactiveSetupInput,
+  options: { automatic?: boolean } = {},
 ): Promise<ProactiveInstallation> {
+  if (options.automatic && input.delivery !== "draft")
+    throw new ProactiveSetupError("Automatic setup prepares drafts.");
   const overview = await getProactiveOverview(companyId);
   const recipe = validateSetup(overview, input);
   const accountId = input.accountId ?? null;
   const id = proactiveId(companyId, input.employeeId, recipe.id, accountId);
   const existing = overview.installations.find((entry) => entry.id === id);
   // Retried requests never change the instruction or re-enable paused work.
-  if (existing) return existing;
+  if (existing) {
+    await initializeProactiveDefaults(companyId);
+    return existing;
+  }
   if (!input.instruction.trim() || input.instruction.length > 20_000)
     throw new ProactiveSetupError("Provide instructions of 1–20,000 characters.");
   const mailbox = overview.mailboxes.find((account) => account.id === accountId);
   const body = `${input.instruction.trim()}${mailbox ? `\n\nAssigned mailbox: ${JSON.stringify({ accountId: mailbox.id, address: mailbox.address })}. Use this mailbox only for this starter.` : ""}`;
   try {
     const created = await withSerializedTransaction(async (manager) => {
-      if (AppDataSource.options.type === "postgres")
+      const company = await lockProactiveCompany(manager, companyId);
+      const defaults = await collectProactiveDefaults(manager, company);
+      const scope = proactiveScope(recipe.id, accountId, input.employeeId);
+      const defaultsJson = JSON.stringify(defaults);
+      if (company.proactiveDefaultsJson !== defaultsJson)
         await manager
           .getRepository(Company)
-          .findOneOrFail({ where: { id: companyId }, lock: { mode: "pessimistic_write" } });
+          .update({ id: companyId }, { proactiveDefaultsJson: defaultsJson });
+      if (options.automatic) {
+        if (!company.proactiveAutoSetup)
+          return new ProactiveSetupError("Automatic setup is off.", 409);
+        if (workBlocked(companyId, { employeeId: input.employeeId }).blocked)
+          return new ProactiveSetupError("This AI Employee is under a Standdown.", 409);
+        if (defaults.assignments[scope])
+          return new ProactiveSetupError(
+            "This responsibility was already assigned or removed.",
+            409,
+          );
+        // Readiness may have changed while this assignment waited for another
+        // company write. Do not reserve an unusable owner permanently.
+        try {
+          validateSetup(await getProactiveOverview(companyId), input);
+        } catch (error) {
+          if (error instanceof ProactiveSetupError) return error;
+          throw error;
+        }
+      }
       const occupied =
         recipe.kind === "email"
           ? await manager.getRepository(MailRule).existsBy({ id })
           : await manager.getRepository(Routine).existsBy({ id });
-      if (occupied) return false;
-      if (recipe.kind === "routine") await assertRoutineCapacity(companyId);
+      if (occupied) {
+        await manager
+          .getRepository(Company)
+          .update({ id: companyId }, { proactiveDefaultsJson: JSON.stringify(defaults) });
+        return false;
+      }
+      if (recipe.kind === "routine") {
+        try {
+          await assertRoutineCapacity(companyId);
+        } catch (error) {
+          if (error instanceof PlanLimitError) return error;
+          throw error;
+        }
+      }
       if (recipe.kind === "email") {
         await manager.getRepository(MailRule).insert({
           id,
@@ -297,8 +339,16 @@ export async function installProactiveStarter(
             minIntervalSec: 3600,
           });
       }
+      defaults.assignments[scope] = id;
+      await manager
+        .getRepository(Company)
+        .update({ id: companyId }, { proactiveDefaultsJson: JSON.stringify(defaults) });
       return true;
     });
+    // Expected contention commits the adopted ownership markers. Rolling
+    // back a declined assignment could also discard concurrent audit writes
+    // on SQLite's shared connection.
+    if (created instanceof Error) throw created;
     if (!created) {
       const installed = (await getProactiveOverview(companyId)).installations.find(
         (entry) => entry.id === id,
@@ -322,6 +372,9 @@ export async function installProactiveStarter(
   await recordAudit({
     companyId,
     actorUserId: userId,
+    ...(options.automatic
+      ? { actorKind: "system" as const, actorUserId: null, runId: null, conversationId: null }
+      : {}),
     action: "proactive.enable",
     targetType: recipe.kind === "email" ? "mail_rule" : "routine",
     targetId: id,
@@ -331,10 +384,40 @@ export async function installProactiveStarter(
       employeeId: input.employeeId,
       accountId,
       delivery: input.delivery,
+      ...(options.automatic ? { automatic: true } : {}),
     },
   });
   changed(companyId, recipe.kind, accountId);
   return (await getProactiveOverview(companyId)).installations.find((entry) => entry.id === id)!;
+}
+
+/** This controls future automatic assignments. Existing native work keeps
+ * its own Pause/Resume state and is never rewritten by the company switch. */
+export async function setProactiveAutomaticSetup(
+  companyId: string,
+  userId: string,
+  enabled: boolean,
+): Promise<void> {
+  await withSerializedTransaction(async (manager) => {
+    const company = await lockProactiveCompany(manager, companyId);
+    const defaults = await collectProactiveDefaults(manager, company);
+    await manager.getRepository(Company).update(
+      { id: companyId },
+      {
+        proactiveAutoSetup: enabled,
+        proactiveDefaultsJson: JSON.stringify(defaults),
+      },
+    );
+  });
+  await recordAudit({
+    companyId,
+    actorUserId: userId,
+    action: "proactive.automatic_setup",
+    targetType: "company",
+    targetId: companyId,
+    metadata: { enabled },
+  });
+  emitResourceChange(companyId, "routine");
 }
 
 export async function toggleProactiveStarter(

--- a/App/shared/proactive.ts
+++ b/App/shared/proactive.ts
@@ -36,6 +36,7 @@ export type ProactiveMailbox = {
   status: string;
   analysisEnabled: boolean;
   analysisReady: boolean;
+  analysisEmployeeId?: string | null;
 };
 export type ProactiveInstallation = {
   id: string;
@@ -50,6 +51,8 @@ export type ProactiveInstallation = {
   configurationIssue?: string;
 };
 export type ProactiveOverview = {
+  automaticSetup: boolean;
+  defaultAssignments: Record<string, string>;
   recipes: ProactiveRecipe[];
   employees: ProactiveEmployee[];
   mailboxes: ProactiveMailbox[];

--- a/Home/client/docs/pages/Email.tsx
+++ b/Home/client/docs/pages/Email.tsx
@@ -459,8 +459,14 @@ export function Email() {
         employee&apos;s Grants. Progress and results appear on the thread and on the{" "}
         <Strong>AI handovers</Strong> page, and Genosyn notifies you when the handover finishes.
         Paused mailboxes and active Standdowns defer queued work; removed Grants or changed rules
-        are checked again before it starts. For ready-made email starters, open{" "}
-        <DocLink to="/docs/reactivity">Proactive</DocLink> in the company navigation.
+        are checked again before it starts. Ready email responsibilities are assigned automatically
+        by default as AI Employees gain a connected AI Model and the required Grants, once the
+        mailbox and its AI analysis reader are ready. This covers quote requests, customer code
+        issues, sales enquiries, confirmed spam, and unwanted newsletters. Open{" "}
+        <DocLink to="/docs/reactivity">Proactive</DocLink> to review or customize those assignments.
+        Turning <Strong>Automatic setup</Strong> off only stops future automatic assignments;
+        existing work keeps running until you pause it individually. Historical mail is never
+        replayed by setup, and automatically assigned email work prepares drafts by default.
         If preparation needs missing information, the employee can raise a Decision for a Member.
         The answer is saved for the approved standing Routine or a Member to continue; answering
         does not start a separate session that could send around the draft restriction.

--- a/Home/client/docs/pages/Reactivity.tsx
+++ b/Home/client/docs/pages/Reactivity.tsx
@@ -8,8 +8,9 @@ export function Reactivity() {
         title="Proactive work"
         lead={
           <>
-            A cron answers <em>when</em>. This page covers the four features that answer everything
-            cron can&apos;t: <Strong>Triggers</Strong> fire a{" "}
+            Proactive work is on by default. Genosyn assigns ready responsibilities to your
+            AI Employees as their AI Models, resources, and Grants become available.
+            <Strong> Triggers</Strong> fire a{" "}
             <DocLink to="/docs/routines">Routine</DocLink> the moment something changes,{" "}
             <Strong>Wakeups</Strong> let an employee check back later, <Strong>Workstreams</Strong>
             {" "}
@@ -19,13 +20,27 @@ export function Reactivity() {
         }
       />
 
-      <H2 id="start">Start in Proactive</H2>
+      <H2 id="start">Review your proactive work</H2>
       <P>
-        Open <Strong>Proactive</Strong> from the company navigation. Choose a starter, pick an
-        AI Employee and (where needed) a mailbox, review its instructions, then select
-        <Strong> Enable workflow</Strong>. The setup form lists missing Grants or a disconnected
-        AI Model. It never grants access for you. Owners and admins can enable, pause, and resume
-        standing work; every Member can see what is configured.
+        Open <Strong>Proactive</Strong> from the company navigation to see your standing work.
+        <Strong> Automatic setup</Strong> starts <Strong>On</Strong> for both new and existing
+        companies. Genosyn assigns ready responsibilities in the background, without a first visit
+        or setup click. Each responsibility gets one automatic assignment; it does not go to every
+        eligible employee. Assignment never adds Grants, and work waits until an AI Employee has a
+        connected AI Model and the required resource access.
+      </P>
+      <P>
+        Owners and admins can turn <Strong>Automatic setup</Strong> off to stop future automatic
+        assignments. Existing work keeps running: use its individual <Strong>Pause</Strong> control
+        to stop future starts. Automatic setup preserves customized and paused work, and does not
+        recreate work you deliberately deleted. Every Member can see the setting and standing work.
+      </P>
+      <P>
+        Use <Strong>Review work</Strong> to edit an existing rule or Routine. To assign work manually,
+        select <Strong>Customize</Strong> on a responsibility, choose an AI Employee and (where
+        needed) a mailbox, review its instructions, then select <Strong>Assign work</Strong>.
+        The form lists missing Grants or a disconnected AI Model. Manual customization remains
+        available when Automatic setup is off.
       </P>
       <P>
         Email starters also need a working AI analysis reader in <Strong>Email → Settings</Strong>.
@@ -76,15 +91,16 @@ export function Reactivity() {
         Repository publication needs the employee&apos;s Write Grant plus an explicitly granted,
         pinned GitHub or Forgejo Connection. The employee can open a PR only from its own completed
         session branch; it cannot merge or publish the default branch. Repositories using a private
-        token or SSH credential still need Member publication. Enable <Strong>Follow through on
-        open work</Strong> for the same employee to revisit saved sessions and finish the next
-        authorized step. See <DocLink to="/docs/repositories">Repositories</DocLink>.
+        token or SSH credential still need Member publication. <Strong>Follow through on
+        open work</Strong> lets the same employee revisit saved sessions and finish the next
+        authorized step; check its assignment under Your standing work. See
+        <DocLink to="/docs/repositories"> Repositories</DocLink>.
       </P>
       <P>
         Under <Strong>Your standing work</Strong>, use <Strong>Review work</Strong> to open the
         underlying rule or Routine and its history. <Strong>Pause</Strong> stops future starts;
         use a <DocLink to="/docs/standdowns">Standdown</DocLink> when work already in progress
-        must stop. Enabling the same starter for the same employee and mailbox twice reuses its
+        must stop. Assigning the same starter for the same employee and mailbox twice reuses its
         existing configuration, including a paused state.
       </P>
 


### PR DESCRIPTION
Proactive work previously required a Member to assign each starter before anything happened. It now starts enabled for new and existing companies, assigns ready responsibilities at startup and as AI Models and Grants become available, and prepares the first new inbound email without waiting for a visit to Proactive.

Each mailbox or company responsibility gets one automatic owner. Assignments use the existing email rules and Routines with draft delivery, retain existing instructions and authority, and preserve paused or deleted work. The Automatic setup switch stops future assignments; existing responsibilities retain their own Pause controls. Setup never adds Grants or replays historical email.

The change includes generated SQLite and Postgres migrations, durable assignment ownership, periodic discovery, first-message setup recovery, an updated Proactive page, and matching Email and Proactive documentation. No dependencies were added.

Validation:

- 67 focused server tests passed across assignment ownership, boot/discovery, later readiness, concurrency, model disconnection or Grant revocation while waiting to assign, deletion, opt-out, Standdowns, first-message recovery, email queue behavior, and API authorization.
- 15 browser test groups passed, including default-on display, switching Automatic setup, manual customization, permissions, error handling, live updates, and mobile layout. The final mobile layout adjustment was rerun and inspected.
- Generated migrations were applied, reverted, and reapplied against isolated SQLite and Postgres databases; existing/new company defaults, saved settings, and zero schema drift were verified.
- App and Home lint, typecheck, and production builds passed.
- Signup/login/logout, company creation/switching/invitation, employee/Soul/Skill/Routine/model setup, and password reset were browser-tested during the parent Proactive change in PR #27.

CI passed all 8,208 App tests (zero failures/skips), all 61 browser regression groups, fresh-database startup, App/Home lint and typechecks, CLI tests, and all four Linux image builds. The two legacy Cloudflare Workers Builds checks still fail in the stale account documented in RELEASING.md; the repository's release site workflow remains the deployment authority.
