### PR TITLE
fix: show active work and queue follow-ups in Ask AI

### DIFF
--- a/App/client/App.tsx
+++ b/App/client/App.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "./components/ui/Spinner";
 import { DialogProvider } from "./components/ui/Dialog";
 import { ThemeProvider } from "./components/Theme";
 import { ChatSessionsProvider } from "./lib/chatSessions";
+import { clearAssistantChatSessions } from "@/lib/assistantChatSessions";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import Forgot from "./pages/Forgot";
@@ -223,9 +224,12 @@ export default function App() {
   const location = useLocation();
   const isPublicSigning = location.pathname.startsWith("/sign/");
   const [auth, setAuth] = React.useState<AuthState>({ status: "loading" });
+  const authenticatedMemberRef = React.useRef<string | null>(null);
 
   const refreshAuthenticatedState = React.useCallback(async () => {
     const me = await api.get<Me>("/api/auth/me");
+    if (authenticatedMemberRef.current !== me.id) clearAssistantChatSessions();
+    authenticatedMemberRef.current = me.id;
     const companies = await api.get<Company[]>("/api/companies");
     setAuth({ status: "ready", me, companies });
   }, []);
@@ -234,6 +238,8 @@ export default function App() {
     try {
       await refreshAuthenticatedState();
     } catch {
+      clearAssistantChatSessions();
+      authenticatedMemberRef.current = null;
       setAuth({ status: "anon" });
     }
   }, [refreshAuthenticatedState]);

--- a/App/client/components/AppShell.tsx
+++ b/App/client/components/AppShell.tsx
@@ -15,6 +15,7 @@ import {
   Sun,
 } from "lucide-react";
 import { api, Company, Me } from "../lib/api";
+import { clearAssistantChatSessions } from "@/lib/assistantChatSessions";
 import { createCompanyAndSwitch } from "../lib/companySwitch";
 import { SECTION_BY_KEY, SectionItem, activeSection } from "../lib/sections";
 import { productIntegrationScope, type ProductIntegrationKey } from "../lib/productIntegrations";
@@ -166,6 +167,7 @@ function TopNav({
 
   async function performLogout() {
     await api.post("/api/auth/logout");
+    clearAssistantChatSessions();
     await onAuthChanged();
     navigate("/login");
   }

--- a/App/client/components/chat/AssistantMessageQueue.tsx
+++ b/App/client/components/chat/AssistantMessageQueue.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Clock, Loader2, Paperclip, Play, X } from "lucide-react";
+import type { AssistantQueuedMessage } from "@/lib/assistantChatSessions";
+import { FormError } from "@/components/ui/FormError";
+
+/** Stays beside the input even when the Member scrolls away from the reply. */
+export function AssistantWorkStatus({
+  name,
+  startedAt,
+  reconnecting,
+}: {
+  name: string;
+  startedAt?: string;
+  reconnecting: boolean;
+}) {
+  const [now, setNow] = React.useState(Date.now);
+  React.useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, []);
+  const seconds = startedAt ? Math.max(0, Math.floor((now - Date.parse(startedAt)) / 1_000)) : 0;
+  const elapsed = seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+
+  return (
+    <div
+      role="status"
+      className="mb-2 flex items-start gap-2.5 rounded-xl border border-indigo-200 bg-indigo-50 px-3 py-2.5 dark:border-indigo-500/30 dark:bg-indigo-500/10"
+    >
+      <Loader2
+        size={16}
+        aria-hidden="true"
+        className="mt-0.5 shrink-0 motion-safe:animate-spin text-indigo-600 dark:text-indigo-300"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2 text-xs font-medium text-indigo-900 dark:text-indigo-100">
+          <span>{reconnecting ? "Reconnecting to the reply…" : `${name} is working`}</span>
+          {Number.isFinite(seconds) && seconds > 0 && (
+            <span
+              aria-hidden="true"
+              className="shrink-0 font-normal tabular-nums text-indigo-600 dark:text-indigo-300"
+            >
+              {elapsed}
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-[11px] leading-relaxed text-indigo-700 dark:text-indigo-200">
+          {reconnecting
+            ? "Checking the reply’s status. Your follow-ups will wait."
+            : "You can add a follow-up. It will send after this reply."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function AssistantMessageQueue({
+  messages,
+  paused,
+  onRemove,
+  onResume,
+}: {
+  messages: AssistantQueuedMessage[];
+  paused: string | null;
+  onRemove: (id: string) => void;
+  onResume: () => void;
+}) {
+  if (messages.length === 0 && !paused) return null;
+  return (
+    <section
+      aria-label="Queued messages"
+      className="mb-2 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900"
+    >
+      <div className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-slate-600 dark:text-slate-300">
+        <Clock size={13} aria-hidden="true" />
+        <span>{messages.length} queued</span>
+        {!paused && (
+          <span className="ml-auto text-[11px] font-normal text-slate-500">Sent in order</span>
+        )}
+      </div>
+      {messages.length > 0 && (
+        <ol className="max-h-36 overflow-y-auto border-t border-slate-200 dark:border-slate-700">
+          {messages.map((item, index) => (
+            <li
+              key={item.id}
+              className="flex items-start gap-2 border-b border-slate-200 px-3 py-2 last:border-b-0 dark:border-slate-700"
+            >
+              <span className="pt-0.5 text-[11px] tabular-nums text-slate-400">{index + 1}</span>
+              <div className="min-w-0 flex-1 text-xs text-slate-700 dark:text-slate-200">
+                {item.message && (
+                  <p className="line-clamp-2 break-words whitespace-pre-wrap">{item.message}</p>
+                )}
+                {item.attachments.map((file) => (
+                  <div
+                    key={file.id}
+                    className="mt-0.5 flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400"
+                  >
+                    <Paperclip size={11} className="shrink-0" aria-hidden="true" />
+                    <span className="truncate">{file.filename}</span>
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => onRemove(item.id)}
+                aria-label={`Remove queued message ${index + 1}`}
+                title="Remove queued message"
+                className="shrink-0 rounded p-1 text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+              >
+                <X size={13} />
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+      {paused && (
+        <div className="border-t border-slate-200 px-3 py-2 dark:border-slate-700">
+          <FormError message={paused} />
+          {messages.length > 0 && (
+            <button
+              type="button"
+              onClick={onResume}
+              className="mt-1 flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 dark:text-indigo-300 dark:hover:bg-indigo-500/20"
+            >
+              <Play size={12} aria-hidden="true" /> Resume queue
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/App/client/lib/assistantChatSessions.test.ts
+++ b/App/client/lib/assistantChatSessions.test.ts
@@ -1,0 +1,430 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  AssistantChatSession,
+  type AssistantChatAdapter,
+  type AssistantChatMessage,
+  type AssistantQueuedMessage,
+} from "./assistantChatSessions.js";
+
+type Message = AssistantChatMessage;
+type RosterEntry = { id: string };
+type OnEvent = (event: string, data: unknown) => void;
+
+function message(
+  id: string,
+  role: Message["role"],
+  content: string,
+  status: Message["status"] = null,
+): Message {
+  return {
+    id,
+    role,
+    content,
+    status,
+    employeeId: role === "assistant" ? "employee" : null,
+    attachments: [],
+  };
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) assert.fail("Session did not reach the expected state");
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
+function harness() {
+  const rows: Message[] = [];
+  const calls: {
+    item: AssistantQueuedMessage;
+    emit: OnEvent;
+    finish: () => void;
+    fail: (error: Error) => void;
+    signal: AbortSignal;
+  }[] = [];
+  let loadError = false;
+  let loads = 0;
+  let clears = 0;
+  const adapter: AssistantChatAdapter<Message, RosterEntry> = {
+    load: async () => {
+      loads += 1;
+      if (loadError) throw new Error("Offline");
+      return {
+        messages: rows.map((row) => ({ ...row })),
+        roster: [{ id: "employee" }],
+        modelId: "model-default",
+      };
+    },
+    send: (item, emit, signal) =>
+      new Promise<void>((finish, fail) => {
+        calls.push({ item, emit, finish, fail, signal });
+      }),
+    clear: async () => {
+      rows.length = 0;
+      clears += 1;
+    },
+    createUserMessage: (item) => ({
+      ...message(`temp-${item.id}`, "user", item.message),
+      attachments: item.attachments,
+    }),
+    initialTarget: () => ({ id: "employee", name: "Jamie", slug: "jamie" }),
+  };
+  const session = new AssistantChatSession(adapter, 4);
+  function accept(index: number) {
+    const call = calls[index];
+    const user = {
+      ...message(`user-${index}`, "user", call.item.message),
+      attachments: call.item.attachments,
+    };
+    const working = message(`assistant-${index}`, "assistant", "", "working");
+    rows.push(user, working);
+    call.emit("user", user);
+    call.emit("working", working);
+  }
+  function finish(index: number, status: Message["status"] = "ok", emit = true) {
+    const final = message(`assistant-${index}`, "assistant", "Finished", status);
+    const rowIndex = rows.findIndex((row) => row.id === final.id);
+    if (rowIndex === -1) rows.push(final);
+    else rows[rowIndex] = final;
+    if (emit) calls[index].emit("assistant", final);
+    calls[index].finish();
+  }
+  return {
+    rows,
+    calls,
+    adapter,
+    session,
+    accept,
+    finish,
+    setOffline: (value: boolean) => {
+      loadError = value;
+    },
+    loads: () => loads,
+    clears: () => clears,
+  };
+}
+
+describe("assistant panel follow-up sessions", () => {
+  test("serializes fast submissions and snapshots attachments, employee, model and focused draft", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    const attachment = {
+      id: "attachment",
+      filename: "form.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 15,
+      isImage: false,
+    };
+    const input = {
+      message: "Second",
+      attachments: [attachment],
+      employeeId: "jamie",
+      modelId: "model-chosen",
+      focusedMessageId: "draft-chosen",
+    };
+    h.session.send(input);
+    input.modelId = "changed-model";
+    attachment.filename = "changed.pdf";
+    input.attachments.length = 0;
+    await until(() => h.calls.length === 1);
+    assert.equal(h.session.getSnapshot().queuedMessages.length, 1);
+    h.accept(0);
+    h.finish(0);
+    await until(() => h.calls.length === 2);
+    assert.equal(h.calls[1].item.modelId, "model-chosen");
+    assert.equal(h.calls[1].item.employeeId, "jamie");
+    assert.equal(h.calls[1].item.focusedMessageId, "draft-chosen");
+    assert.equal(h.calls[1].item.attachments[0].filename, "form.pdf");
+    h.accept(1);
+    h.finish(1);
+    await until(() => !h.session.getSnapshot().streamOpen);
+    assert.deepEqual(
+      h.session.getSnapshot().messages?.map((row) => row.id),
+      ["user-0", "assistant-0", "user-1", "assistant-1"],
+    );
+  });
+
+  test("closing a panel keeps its own stream and queue alive without affecting another conversation", async (t) => {
+    const first = harness();
+    const second = harness();
+    t.after(() => {
+      first.session.dispose();
+      second.session.dispose();
+    });
+    const close = first.session.open();
+    first.session.send({ message: "Original email", attachments: [] });
+    first.session.send({ message: "Follow up on original email", attachments: [] });
+    await until(() => first.calls.length === 1);
+    first.accept(0);
+    close();
+    second.session.open();
+    second.session.send({ message: "Another email", attachments: [] });
+    await until(() => second.calls.length === 1);
+    assert.equal(first.calls[0].signal.aborted, false);
+    first.finish(0);
+    await until(() => first.calls.length === 2);
+    assert.equal(first.calls[1].item.message, "Follow up on original email");
+    assert.equal(second.calls.length, 1);
+  });
+
+  test("recovers a final reply missed by the stream before draining the next message", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    h.session.send({ message: "Second", attachments: [] });
+    await until(() => h.calls.length === 1);
+    // Server accepted and completed before the browser received any events.
+    h.rows.push(message("user-0", "user", "First"));
+    h.rows.push(message("assistant-0", "assistant", "Finished", "ok"));
+    h.calls[0].fail(new Error("Connection closed"));
+    await until(() => h.calls.length === 2);
+    assert.equal(
+      h.calls[1].item.message,
+      "Second",
+      "the accepted first message must never be re-posted",
+    );
+    assert.equal(
+      h.session.getSnapshot().messages?.filter((row) => row.content === "First").length,
+      1,
+    );
+  });
+
+  test("holds follow-ups through an outage until its accepted reply can be read", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    h.session.send({ message: "Second", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.accept(0);
+    h.setOffline(true);
+    h.calls[0].fail(new Error("Connection dropped"));
+    await until(() => h.loads() >= 3);
+    assert.equal(h.calls.length, 1);
+    assert.equal(h.session.getSnapshot().reconnecting, true);
+    h.finish(0, "ok", false);
+    h.setOffline(false);
+    await until(() => h.calls.length === 2);
+    assert.equal(h.calls[1].item.message, "Second");
+  });
+
+  test("a failed reply pauses the queue until an explicit continuation, and waiting messages can be removed", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    h.session.send({ message: "Remove me", attachments: [] });
+    h.session.send({ message: "Keep me", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.accept(0);
+    h.finish(0, "error");
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    assert.equal(h.calls.length, 1);
+    h.session.removeQueuedMessage(h.session.getSnapshot().queuedMessages[0].id);
+    h.session.resumeQueue();
+    await until(() => h.calls.length === 2);
+    assert.equal(h.calls[1].item.message, "Keep me");
+  });
+
+  test("an unconfirmed send preserves the whole queued payload for review without automatic retry", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [], modelId: "chosen" });
+    h.session.send({ message: "Second", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.calls[0].fail(new Error("Network failure before confirmation"));
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    assert.equal(h.calls.length, 1);
+    assert.deepEqual(
+      h.session.getSnapshot().queuedMessages.map((item) => item.message),
+      ["First", "Second"],
+    );
+    assert.equal(h.session.getSnapshot().queuedMessages[0].modelId, "chosen");
+    assert.match(h.session.getSnapshot().queuePaused!, /avoid repeating work/);
+    assert.deepEqual(h.session.getSnapshot().messages, []);
+  });
+
+  test("an older identical message cannot confirm acceptance of a new dropped request", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.rows.push(
+      message("old-user", "user", "Repeat this"),
+      message("old-assistant", "assistant", "Previous reply", "ok"),
+    );
+    h.session.send({ message: "Repeat this", attachments: [] });
+    h.session.send({ message: "Later message", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.calls[0].fail(new Error("Disconnected before confirmation"));
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    assert.equal(h.calls.length, 1);
+    assert.deepEqual(
+      h.session.getSnapshot().queuedMessages.map((item) => item.message),
+      ["Repeat this", "Later message"],
+    );
+    assert.deepEqual(
+      h.session.getSnapshot().messages?.map((row) => row.id),
+      ["old-user", "old-assistant"],
+    );
+  });
+
+  test("a deliberately submitted recovery message continues an otherwise empty paused queue", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.accept(0);
+    h.finish(0, "error");
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    h.session.send({ message: "Try a different approach", attachments: [] });
+    await until(() => h.calls.length === 2);
+    assert.equal(h.calls[1].item.message, "Try a different approach");
+    assert.equal(h.session.getSnapshot().queuePaused, null);
+  });
+
+  test("retrying a failed predecessor runs before its waiting followers", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "Prepare the draft", attachments: [] });
+    h.session.send({ message: "Review the draft", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.accept(0);
+    h.finish(0, "error");
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    h.session.retry({
+      message: "Prepare the draft",
+      attachments: [],
+      employeeId: "employee",
+      modelId: "original-model",
+    });
+    await until(() => h.calls.length === 2);
+    assert.equal(h.calls[1].item.message, "Prepare the draft");
+    assert.equal(h.calls[1].item.modelId, "original-model");
+    assert.equal(h.session.getSnapshot().queuedMessages[0].message, "Review the draft");
+    h.accept(1);
+    h.finish(1);
+    await until(() => h.calls.length === 3);
+    assert.equal(h.calls[2].item.message, "Review the draft");
+  });
+
+  test("submitting during a cached panel refresh waits for the authoritative running turn", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    const close = h.session.open();
+    await until(() => !h.session.getSnapshot().loading);
+    close();
+    let resolveRefresh!: (value: Awaited<ReturnType<typeof h.adapter.load>>) => void;
+    let refreshed = false;
+    h.session.setAdapter({
+      ...h.adapter,
+      load: () => {
+        if (refreshed) return h.adapter.load();
+        refreshed = true;
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+    });
+    h.session.open();
+    assert.equal(h.session.getSnapshot().loading, true);
+    h.session.send({ message: "Follow up", attachments: [] });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(h.calls.length, 0);
+    h.rows.push(
+      message("external-user", "user", "Started elsewhere"),
+      message("external-assistant", "assistant", "", "working"),
+    );
+    resolveRefresh({ messages: h.rows.map((row) => ({ ...row })), roster: [], modelId: null });
+    await until(() => h.loads() >= 2);
+    assert.equal(h.calls.length, 0);
+    h.rows[1] = message("external-assistant", "assistant", "Finished", "ok");
+    await until(() => h.calls.length === 1);
+    assert.equal(h.calls[0].item.message, "Follow up");
+  });
+
+  test("an older refresh snapshot cannot replace a newer persisted message update", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.rows.push(message("assistant-old", "assistant", "Original reply", "ok"));
+    const close = h.session.open();
+    await until(() => !h.session.getSnapshot().loading);
+    close();
+    let resolveRefresh!: (value: Awaited<ReturnType<typeof h.adapter.load>>) => void;
+    h.session.setAdapter({
+      ...h.adapter,
+      load: () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    });
+    h.session.open();
+    h.session.updateMessage(message("assistant-old", "assistant", "Updated reply", "ok"));
+    resolveRefresh({ messages: [...h.rows], roster: [], modelId: null });
+    await until(() => !h.session.getSnapshot().loading);
+    assert.equal(h.session.getSnapshot().messages?.[0].content, "Updated reply");
+  });
+
+  test("an employee selection changed while a message waits survives that queued turn's target event", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [], employeeId: "employee" });
+    h.session.send({ message: "Queued for Jamie", attachments: [], employeeId: "employee" });
+    await until(() => h.calls.length === 1);
+    h.accept(0);
+    h.session.setTarget({ id: "next-employee", name: "Next", slug: "next" });
+    h.finish(0);
+    await until(() => h.calls.length === 2);
+    h.calls[1].emit("target", { employee: { id: "employee", name: "Jamie", slug: "jamie" } });
+    assert.equal(h.calls[1].item.employeeId, "employee");
+    assert.equal(h.session.getSnapshot().target?.id, "next-employee");
+  });
+
+  test("follows a previously running reply before sending and pauses if that reply fails", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.rows.push(
+      message("old-user", "user", "Already running"),
+      message("old-assistant", "assistant", "", "working"),
+    );
+    h.session.open();
+    h.session.send({ message: "Follow up", attachments: [] });
+    await until(() => h.loads() >= 2);
+    assert.equal(h.calls.length, 0);
+    h.rows[1] = message("old-assistant", "assistant", "Failed", "error");
+    await until(() => Boolean(h.session.getSnapshot().queuePaused));
+    assert.equal(h.calls.length, 0);
+    h.session.resumeQueue();
+    await until(() => h.calls.length === 1);
+    assert.equal(h.calls[0].item.message, "Follow up");
+  });
+
+  test("clearing cannot delete an active reply or a waiting follow-up", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    await until(() => h.calls.length === 1);
+    await assert.rejects(h.session.clear(), /Wait for the current reply/);
+    assert.equal(h.clears(), 0);
+    h.accept(0);
+    h.finish(0);
+    await until(() => !h.session.getSnapshot().streamOpen);
+    await h.session.clear();
+    assert.equal(h.clears(), 1);
+    assert.deepEqual(h.session.getSnapshot().messages, []);
+  });
+
+  test("late target and bootstrap results do not overwrite the next message's employee or model selection", async (t) => {
+    const h = harness();
+    t.after(() => h.session.dispose());
+    h.session.send({ message: "First", attachments: [] });
+    await until(() => h.calls.length === 1);
+    h.session.setTarget({ id: "next-employee", name: "Next", slug: "next" });
+    h.session.setModelId("next-model");
+    h.calls[0].emit("target", { employee: { id: "employee", name: "Jamie", slug: "jamie" } });
+    h.accept(0);
+    h.calls[0].fail(new Error("Dropped stream"));
+    await until(() => h.loads() >= 2);
+    assert.equal(h.session.getSnapshot().target?.id, "next-employee");
+    assert.equal(h.session.getSnapshot().modelId, "next-model");
+  });
+});

--- a/App/client/lib/assistantChatSessions.ts
+++ b/App/client/lib/assistantChatSessions.ts
@@ -1,0 +1,532 @@
+import React from "react";
+import type { ChatAttachment } from "@/lib/api";
+
+export type AssistantChatTarget = { id: string; name: string; slug: string };
+
+export type AssistantChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  employeeId: string | null;
+  content: string;
+  status: "working" | "ok" | "skipped" | "error" | null;
+  attachments: ChatAttachment[];
+};
+
+/** A follow-up owns its files, employee, model and focused draft at submission. */
+export type AssistantQueuedMessage = {
+  id: string;
+  message: string;
+  attachments: ChatAttachment[];
+  employeeId?: string;
+  modelId?: string | null;
+  focusedMessageId?: string | null;
+  queuedAt: string;
+};
+
+export type AssistantChatBootstrap<M, R> = {
+  messages: M[];
+  roster: R[];
+  modelId: string | null;
+};
+
+export type AssistantChatAdapter<M extends AssistantChatMessage, R> = {
+  load: () => Promise<AssistantChatBootstrap<M, R>>;
+  send: (
+    item: AssistantQueuedMessage,
+    onEvent: (event: string, data: unknown) => void,
+    signal: AbortSignal,
+  ) => Promise<void>;
+  clear: () => Promise<unknown>;
+  createUserMessage: (item: AssistantQueuedMessage) => M;
+  initialTarget?: (result: AssistantChatBootstrap<M, R>) => AssistantChatTarget | null;
+};
+
+export type AssistantChatState<M, R> = {
+  messages: M[] | null;
+  roster: R[];
+  target: AssistantChatTarget | null;
+  modelId: string | null;
+  streaming: string | null;
+  /** An owned turn is still being submitted or followed, even without SSE. */
+  streamOpen: boolean;
+  reconnecting: boolean;
+  loading: boolean;
+  loadError: string | null;
+  queuedMessages: AssistantQueuedMessage[];
+  queuePaused: string | null;
+};
+
+type SubmitInput = Omit<AssistantQueuedMessage, "id" | "queuedAt">;
+
+const POLL_MS = 2_000;
+const MAX_IDLE_SESSIONS = 40;
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Could not reach Genosyn.";
+}
+
+function upsert<M extends AssistantChatMessage>(messages: M[] | null, row: M): M[] {
+  const previous = messages ?? [];
+  const index = previous.findIndex((message) => message.id === row.id);
+  if (index === -1) return [...previous, row];
+  return previous.map((message, i) => (i === index ? row : message));
+}
+
+/**
+ * One session, independent of the panel displaying it. Keeping the worker
+ * outside React lets a follow-up finish in its original email or Routine
+ * when the Member closes the panel or opens another conversation.
+ *
+ * Waiting messages stay in this browser session, like employee-chat queues;
+ * only submitted turns are persisted by the server. Never retry an uncertain
+ * POST automatically: first recover its persisted user/assistant rows.
+ */
+export class AssistantChatSession<M extends AssistantChatMessage, R> {
+  private state: AssistantChatState<M, R> = {
+    messages: null,
+    roster: [],
+    target: null,
+    modelId: null,
+    streaming: null,
+    streamOpen: false,
+    reconnecting: false,
+    loading: true,
+    loadError: null,
+    queuedMessages: [],
+    queuePaused: null,
+  };
+  private listeners = new Set<() => void>();
+  private loadPromise: Promise<AssistantChatBootstrap<M, R>> | null = null;
+  private worker = false;
+  private clearing = false;
+  private disposed = false;
+  private openPanels = 0;
+  private targetVersion = 0;
+  private modelVersion = 0;
+  private queuedTargetVersions = new Map<string, number>();
+  private messageRevision = 0;
+  private messageChanges = new Map<string, number>();
+  private controller: AbortController | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private wake: (() => void) | null = null;
+  private optimisticId: string | null = null;
+
+  constructor(
+    private adapter: AssistantChatAdapter<M, R>,
+    private readonly pollMs = POLL_MS,
+  ) {}
+
+  getSnapshot = (): AssistantChatState<M, R> => this.state;
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+  setAdapter(adapter: AssistantChatAdapter<M, R>): void {
+    this.adapter = adapter;
+  }
+  private patch(patch: Partial<AssistantChatState<M, R>>): void {
+    if (this.disposed) return;
+    this.state = { ...this.state, ...patch };
+    this.listeners.forEach((listener) => listener());
+  }
+  setTarget = (target: AssistantChatTarget | null): void => {
+    this.targetVersion += 1;
+    this.patch({ target });
+  };
+  setModelId = (modelId: string | null): void => {
+    this.modelVersion += 1;
+    this.patch({ modelId });
+  };
+  updateMessage = (row: M): void => {
+    this.messageChanges.set(row.id, ++this.messageRevision);
+    this.patch({ messages: upsert(this.state.messages, row) });
+  };
+
+  /** Refresh an idle conversation on return; an active worker already follows it. */
+  open = (): (() => void) => {
+    this.openPanels += 1;
+    if (this.openPanels === 1 && !this.worker && !this.clearing) {
+      void this.load().then(
+        () => this.kick(),
+        () => undefined,
+      );
+    }
+    return () => {
+      this.openPanels -= 1;
+    };
+  };
+
+  private async load(): Promise<AssistantChatBootstrap<M, R>> {
+    if (this.loadPromise) return this.loadPromise;
+    const targetVersion = this.targetVersion;
+    const modelVersion = this.modelVersion;
+    const messageRevision = this.messageRevision;
+    const adapter = this.adapter;
+    if (!this.worker || this.state.messages === null) this.patch({ loading: true });
+    this.loadPromise = adapter
+      .load()
+      .then(
+        (result) => {
+          const newer = new Map(
+            (this.state.messages ?? [])
+              .filter(
+                (message) =>
+                  message.id === this.optimisticId ||
+                  (this.messageChanges.get(message.id) ?? 0) > messageRevision,
+              )
+              .map((message) => [message.id, message]),
+          );
+          const messages = result.messages.map((message) => newer.get(message.id) ?? message);
+          const known = new Set(messages.map((message) => message.id));
+          messages.push(...[...newer.values()].filter((message) => !known.has(message.id)));
+          this.patch({
+            messages,
+            roster: result.roster,
+            loading: false,
+            loadError: null,
+            ...(this.targetVersion === targetVersion && this.targetVersion === 0
+              ? { target: adapter.initialTarget?.(result) ?? this.state.target }
+              : {}),
+            ...(this.modelVersion === modelVersion && this.modelVersion === 0
+              ? { modelId: result.modelId }
+              : {}),
+          });
+          // Callers recovering acceptance must inspect only server rows,
+          // never mistake the preserved optimistic bubble for a receipt.
+          return result;
+        },
+        (error: unknown) => {
+          this.patch({ loading: false, loadError: failureMessage(error) });
+          throw error;
+        },
+      )
+      .finally(() => {
+        this.loadPromise = null;
+      });
+    return this.loadPromise;
+  }
+
+  send = (input: SubmitInput): void => this.enqueue(input, false);
+  /** A failed predecessor must be retried before the follow-ups waiting on it. */
+  retry = (input: SubmitInput): void => this.enqueue(input, true);
+  private enqueue(input: SubmitInput, first: boolean): void {
+    const message = input.message.trim();
+    if ((!message && input.attachments.length === 0) || this.disposed) return;
+    if (this.clearing) throw new Error("Wait for the new context to finish opening.");
+    const item: AssistantQueuedMessage = {
+      ...input,
+      message,
+      attachments: input.attachments.map((attachment) => ({ ...attachment })),
+      // Local display identity only; self-hosted HTTP pages need not expose
+      // the secure-context-only crypto.randomUUID browser API.
+      id: `queued-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+      queuedAt: new Date().toISOString(),
+    };
+    // A retry belongs to its failed turn; it does not change a new draft's
+    // selected employee. Ordinary messages may update only the selection
+    // that was current when the Member put them in the queue.
+    this.queuedTargetVersions.set(item.id, first ? -1 : this.targetVersion);
+    this.patch({
+      queuedMessages: first
+        ? [item, ...this.state.queuedMessages]
+        : [...this.state.queuedMessages, item],
+      // With nothing waiting, a deliberately submitted new message already
+      // expresses the Member's choice to continue after a failed reply.
+      ...(first || this.state.queuedMessages.length === 0 ? { queuePaused: null } : {}),
+    });
+    this.kick();
+  }
+  removeQueuedMessage = (id: string): void => {
+    this.queuedTargetVersions.delete(id);
+    this.patch({ queuedMessages: this.state.queuedMessages.filter((item) => item.id !== id) });
+  };
+  resumeQueue = (): void => {
+    this.patch({ queuePaused: null });
+    this.kick();
+  };
+
+  clear = async (): Promise<void> => {
+    if (
+      this.worker ||
+      this.clearing ||
+      this.loadPromise ||
+      this.state.loading ||
+      this.state.streamOpen ||
+      this.state.queuedMessages.length > 0 ||
+      this.workingMessage()
+    ) {
+      throw new Error(
+        "Wait for the current reply and remove queued messages before starting a new context.",
+      );
+    }
+    this.clearing = true;
+    try {
+      await this.adapter.clear();
+      this.targetVersion = 0;
+      this.modelVersion = 0;
+      this.messageChanges.clear();
+      this.patch({ messages: [], target: null, modelId: null, queuePaused: null });
+    } finally {
+      this.clearing = false;
+    }
+  };
+
+  private workingMessage(): M | undefined {
+    return this.state.messages?.find((row) => row.role === "assistant" && row.status === "working");
+  }
+  private wait(): Promise<void> {
+    return new Promise((resolve) => {
+      this.wake = resolve;
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.wake = null;
+        resolve();
+      }, this.pollMs);
+    });
+  }
+  private kick(): void {
+    if (this.worker || this.disposed || this.clearing || this.state.queuePaused) return;
+    this.worker = true;
+    void this.drain()
+      .catch((error: unknown) => {
+        this.patch({ queuePaused: failureMessage(error), streamOpen: false, reconnecting: false });
+      })
+      .finally(() => {
+        this.worker = false;
+        if (!this.disposed && !this.state.queuePaused && this.state.queuedMessages.length > 0) {
+          this.kick();
+        }
+      });
+  }
+  private async drain(): Promise<void> {
+    while (!this.disposed && !this.state.queuePaused) {
+      if (
+        this.loadPromise ||
+        this.state.loading ||
+        this.state.messages === null ||
+        this.workingMessage()
+      ) {
+        const followedId = this.workingMessage()?.id;
+        try {
+          await this.load();
+          if (this.disposed) return;
+          this.patch({ reconnecting: false });
+          const followed = this.state.messages?.find((row) => row.id === followedId);
+          if (followed && (followed.status === "error" || followed.status === "skipped")) {
+            this.pauseAfterReply();
+            return;
+          }
+          if (this.workingMessage()) {
+            await this.wait();
+            continue;
+          }
+        } catch {
+          this.patch({ reconnecting: true });
+          await this.wait();
+          continue;
+        }
+      }
+      const [next, ...queuedMessages] = this.state.queuedMessages;
+      if (!next) return;
+      this.patch({ queuedMessages, streamOpen: true, streaming: null, reconnecting: false });
+      await this.sendTurn(next);
+    }
+  }
+
+  private pauseAfterReply(): void {
+    this.patch({
+      queuePaused:
+        "The last reply did not finish successfully. Review it, then continue your queued messages when ready.",
+    });
+  }
+
+  private async sendTurn(item: AssistantQueuedMessage): Promise<void> {
+    const adapter = this.adapter;
+    const baseline = new Set((this.state.messages ?? []).map((row) => row.id));
+    const targetVersion = this.queuedTargetVersions.get(item.id);
+    const temp = adapter.createUserMessage(item);
+    this.optimisticId = temp.id;
+    this.updateMessage(temp);
+    let userId: string | null = null;
+    let workingId: string | null = null;
+    let terminal: M | null = null;
+    let requestError: unknown;
+    let explicitError = false;
+    let accumulated = "";
+    const controller = new AbortController();
+    this.controller = controller;
+    try {
+      await adapter.send(
+        item,
+        (event, data) => {
+          if (this.disposed) return;
+          if (event === "user") {
+            const row = data as M;
+            userId = row.id;
+            this.optimisticId = null;
+            this.patch({ messages: (this.state.messages ?? []).filter((m) => m.id !== temp.id) });
+            this.updateMessage(row);
+          } else if (event === "target") {
+            if (this.targetVersion === targetVersion) {
+              this.patch({ target: (data as { employee: AssistantChatTarget | null }).employee });
+            }
+          } else if (event === "working") {
+            const row = data as M;
+            workingId = row.id;
+            this.updateMessage(row);
+          } else if (event === "chunk") {
+            accumulated += (data as { text: string }).text;
+            this.patch({ streaming: accumulated });
+          } else if (event === "assistant") {
+            terminal = data as M;
+            this.updateMessage(terminal);
+            this.patch({ streaming: null });
+          } else if (event === "error") {
+            explicitError = true;
+            throw new Error((data as { message: string }).message);
+          }
+        },
+        controller.signal,
+      );
+    } catch (error) {
+      requestError = error;
+    }
+
+    // The HTTP reader can finish without a final event (including a clean
+    // truncated SSE response). Recover before allowing the next POST.
+    while (!terminal && !this.disposed) {
+      this.patch({ reconnecting: true });
+      try {
+        const result = await this.load();
+        if (this.disposed) return;
+        if (!userId) {
+          const candidates = result.messages.filter(
+            (row) =>
+              !baseline.has(row.id) &&
+              row.role === "user" &&
+              row.content === item.message &&
+              row.attachments.length === item.attachments.length &&
+              row.attachments.every((attachment) =>
+                item.attachments.some((a) => a.id === attachment.id),
+              ),
+          );
+          if (candidates.length === 1) userId = candidates[0].id;
+        }
+        if (userId) {
+          this.optimisticId = null;
+          this.patch({ messages: result.messages });
+        }
+        if (workingId) {
+          const row = result.messages.find((message) => message.id === workingId);
+          if (row && row.status !== "working") terminal = row;
+        } else if (userId) {
+          const index = result.messages.findIndex((row) => row.id === userId);
+          // No request id is exposed by these panels. Only adopt the next
+          // reply when no intervening Member message makes ownership unclear.
+          const reply = index >= 0 ? result.messages[index + 1] : undefined;
+          if (reply?.role === "assistant" && !baseline.has(reply.id)) {
+            if (reply.status === "working") workingId = reply.id;
+            else terminal = reply;
+          }
+        }
+        if (!terminal && !workingId && !userId) {
+          // Even an authoritative empty read cannot prove a dropped request
+          // will never arrive. Preserve the draft and require a deliberate
+          // continuation; never silently re-submit it or drain its followers.
+          this.optimisticId = null;
+          this.patch({
+            messages: result.messages,
+            queuedMessages: [item, ...this.state.queuedMessages],
+            queuePaused: explicitError
+              ? `Genosyn could not start this message: ${failureMessage(requestError)} Review it before continuing the queue.`
+              : "The connection ended before Genosyn confirmed this message. Review the conversation before continuing the queue to avoid repeating work.",
+          });
+          break;
+        }
+        if (!terminal && explicitError && userId && !workingId) {
+          this.patch({
+            queuePaused: `Your message was saved, but the reply could not start: ${failureMessage(requestError)}`,
+          });
+          break;
+        }
+      } catch {
+        // A server outage is not proof the request failed. Keep all later
+        // messages waiting until a successful read tells us what happened.
+      }
+      if (!terminal && !this.state.queuePaused) await this.wait();
+    }
+    if (this.disposed) return;
+    if (!this.state.queuedMessages.some((queued) => queued.id === item.id)) {
+      this.queuedTargetVersions.delete(item.id);
+    }
+    if (terminal && (terminal.status === "error" || terminal.status === "skipped")) {
+      this.pauseAfterReply();
+    }
+    this.controller = null;
+    this.patch({ streamOpen: false, streaming: null, reconnecting: false });
+  }
+
+  /** Auth reset stops local subscribers and drops unsent follow-ups. */
+  dispose(): void {
+    this.disposed = true;
+    this.controller?.abort();
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.wake?.();
+    this.listeners.clear();
+  }
+  get idle(): boolean {
+    return (
+      this.openPanels === 0 &&
+      !this.worker &&
+      !this.clearing &&
+      this.state.queuedMessages.length === 0
+    );
+  }
+}
+
+const sessions = new Map<string, AssistantChatSession<AssistantChatMessage, unknown>>();
+
+export function clearAssistantChatSessions(): void {
+  for (const session of sessions.values()) session.dispose();
+  sessions.clear();
+}
+
+export function useAssistantChatSession<M extends AssistantChatMessage, R>(
+  scopeKey: string,
+  adapter: AssistantChatAdapter<M, R>,
+) {
+  let session = sessions.get(scopeKey) as AssistantChatSession<M, R> | undefined;
+  if (!session) {
+    for (const [key, entry] of sessions) {
+      if (sessions.size < MAX_IDLE_SESSIONS) break;
+      if (entry.idle) {
+        entry.dispose();
+        sessions.delete(key);
+      }
+    }
+    session = new AssistantChatSession(adapter);
+    sessions.set(
+      scopeKey,
+      session as unknown as AssistantChatSession<AssistantChatMessage, unknown>,
+    );
+  }
+  session.setAdapter(adapter);
+  const state = React.useSyncExternalStore(
+    session.subscribe,
+    session.getSnapshot,
+    session.getSnapshot,
+  );
+  const current = session;
+  React.useEffect(() => current.open(), [current]);
+  return {
+    ...state,
+    send: session.send,
+    retry: session.retry,
+    clear: session.clear,
+    updateMessage: session.updateMessage,
+    setTarget: session.setTarget,
+    setModelId: session.setModelId,
+    removeQueuedMessage: session.removeQueuedMessage,
+    resumeQueue: session.resumeQueue,
+  };
+}

--- a/App/client/pages/MailAssistant.tsx
+++ b/App/client/pages/MailAssistant.tsx
@@ -1,4 +1,13 @@
 import React from "react";
+import {
+  useAssistantChatSession,
+  type AssistantQueuedMessage,
+  type AssistantChatBootstrap,
+} from "@/lib/assistantChatSessions";
+import {
+  AssistantWorkStatus,
+  AssistantMessageQueue,
+} from "@/components/chat/AssistantMessageQueue";
 import { chatRetryText } from "../lib/chatRetry";
 import { useComposerFileDrop } from "../lib/fileDrop";
 import { useChatAttachments } from "../lib/stagedChatAttachments";
@@ -11,6 +20,7 @@ import {
   Bot,
   Brain,
   Check,
+  Clock,
   ExternalLink,
   FileText,
   Inbox,
@@ -70,60 +80,6 @@ import {
  * whether re-sending would duplicate the work.
  */
 
-/** How often a panel that lost its stream re-reads the in-flight turn. */
-const FOLLOW_POLL_MS = 2_000;
-
-/** Replace a row by id, or append it when this panel hasn't seen it yet. */
-function upsertAssistantMessage(
-  prev: MailAssistantMessage[] | null,
-  incoming: MailAssistantMessage,
-): MailAssistantMessage[] {
-  const list = prev ?? [];
-  const index = list.findIndex((m) => m.id === incoming.id);
-  if (index === -1) return [...list, incoming];
-  const next = [...list];
-  next[index] = incoming;
-  return next;
-}
-
-/**
- * Fold a freshly fetched conversation into what this panel is showing. The
- * server list wins for anything persisted; purely local rows (an optimistic
- * bubble, a transport-error notice) are kept unless the server now has the
- * real thing.
- */
-function mergeAssistantMessages(
-  prev: MailAssistantMessage[] | null,
-  incoming: MailAssistantMessage[],
-): MailAssistantMessage[] {
-  if (!prev || prev.length === 0) return incoming;
-  const known = new Set(incoming.map((m) => m.id));
-  const local = prev.filter((m) => {
-    if (known.has(m.id)) return false;
-    // A turn accepted while the stream was down persisted the human's
-    // message server-side; drop the optimistic twin rather than show both.
-    if (m.id.startsWith("temp-") && m.role === "user") {
-      return !incoming.some((row) => row.role === "user" && row.content === m.content);
-    }
-    return true;
-  });
-  return [...incoming, ...local];
-}
-
-/**
- * Only shown once the server has confirmed it has no reply running for this
- * message — so it can say plainly that nothing started, rather than leaving
- * the human guessing whether a retry would duplicate the work.
- */
-function formatSendFailure(detail: string): string {
-  const clean = detail.replace(/\s+/g, " ").trim() || "Unknown network error";
-  return [
-    `Genosyn didn’t start a reply to this message: ${clean}`,
-    "",
-    "Nothing was sent from your mailbox. Check that the Genosyn server is reachable from this browser, then try again.",
-  ].join("\n");
-}
-
 type Props = {
   company: Company;
   account: MailAccount;
@@ -145,36 +101,77 @@ export function MailAssistant({
 }: Props) {
   const dialog = useDialog();
   const navigate = useNavigate();
-  const [messages, setMessages] = React.useState<MailAssistantMessage[] | null>(null);
-  const [loadError, setLoadError] = React.useState<string | null>(null);
-  const [roster, setRoster] = React.useState<MailAssistantRosterEntry[]>([]);
   const [draft, setDraft] = React.useState("");
-  /** Failure of something started from the composer — a /new, an upload. */
   const [composerError, setComposerError] = React.useState<string | null>(null);
-  /** True only while this panel holds the live SSE stream for a turn. */
-  const [streamOpen, setStreamOpen] = React.useState(false);
-  /** True once following the persisted turn has fallen back to polling. */
-  const [reconnecting, setReconnecting] = React.useState(false);
-  const [streaming, setStreaming] = React.useState<string | null>(null);
-  const [target, setTarget] = React.useState<{
-    id: string;
-    name: string;
-    slug: string;
-  } | null>(null);
-  /** Files chosen for the next message — uploaded already, bound on send. */
-
-  /**
-   * The brain for the next turn. Null means "whatever the employee's active
-   * model is" until the server tells us which one this email's chat has been
-   * running on, or the human picks one.
-   */
-  const [modelId, setModelId] = React.useState<string | null>(null);
   const scrollerRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
-  // In-flight SSE turn — aborted when the mailbox changes or the panel
-  // unmounts, so a slow reply can't paint into the wrong conversation.
-  const streamAbortRef = React.useRef<AbortController | null>(null);
+  const scopeKey = `mail:${company.id}:${account.id}:${threadId}`;
+  const adapter = React.useMemo(
+    () => ({
+      load: () => mailApi.assistant(company.id, account.id, threadId),
+      send: (
+        item: AssistantQueuedMessage,
+        onEvent: (event: string, data: unknown) => void,
+        signal: AbortSignal,
+      ) =>
+        mailApi.assistantSend(
+          company.id,
+          account.id,
+          {
+            message: item.message,
+            threadId,
+            focusedMessageId: item.focusedMessageId ?? undefined,
+            employeeId: item.employeeId,
+            modelId: item.modelId,
+            attachmentIds: item.attachments.map((a) => a.id),
+          },
+          onEvent,
+          { signal },
+        ),
+      clear: () => mailApi.assistantClear(company.id, account.id, threadId),
+      createUserMessage: (item: AssistantQueuedMessage): MailAssistantMessage => ({
+        id: `temp-${item.id}`,
+        accountId: account.id,
+        threadId,
+        role: "user",
+        employeeId: null,
+        modelId: null,
+        content: item.message,
+        status: null,
+        actions: [],
+        suggestions: [],
+        attachments: item.attachments,
+        createdAt: item.queuedAt,
+      }),
+      initialTarget: (
+        bootstrap: AssistantChatBootstrap<MailAssistantMessage, MailAssistantRosterEntry>,
+      ) => {
+        const last = [...bootstrap.messages]
+          .reverse()
+          .find((row) => row.role === "assistant" && row.employeeId);
+        return bootstrap.roster.find((entry) => entry.id === last?.employeeId) ?? null;
+      },
+    }),
+    [company.id, account.id, threadId],
+  );
+  const session = useAssistantChatSession(scopeKey, adapter);
+  const {
+    messages,
+    roster,
+    loadError,
+    streaming,
+    streamOpen,
+    reconnecting,
+    target,
+    modelId,
+    setTarget,
+    setModelId,
+    queuedMessages,
+    queuePaused,
+  } = session;
+  const activeScopeRef = React.useRef(scopeKey);
+  activeScopeRef.current = scopeKey;
 
   const attachmentDraft = useChatAttachments({
     scopeKey: `${company.id}:${account.id}:${threadId}`,
@@ -195,54 +192,13 @@ export function MailAssistant({
   );
 
   React.useEffect(() => {
-    let cancelled = false;
-    setMessages(null);
-    setLoadError(null);
     setComposerError(null);
-    setTarget(null);
     setDraft("");
     setMentionQuery(null);
     setResourceQuery(null);
     setResourceStart(null);
-    setStreaming(null);
-    setStreamOpen(false);
-    setReconnecting(false);
     clearAttachments();
-    setModelId(null);
-    mailApi
-      .assistant(company.id, account.id, threadId)
-      .then((res) => {
-        if (cancelled) return;
-        // Merge rather than replace: a message sent while the bootstrap was
-        // in flight must survive (its optimistic bubble isn't in `res`).
-        // A `working` row in the response means a turn started elsewhere —
-        // another tab, or this panel before it was closed — is still running;
-        // the follow effect below takes it from here.
-        setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-        setRoster(res.roster);
-        const lastAnswered = [...res.messages]
-          .reverse()
-          .find((m) => m.role === "assistant" && m.employeeId);
-        if (lastAnswered?.employeeId) {
-          const emp = res.roster.find((r) => r.id === lastAnswered.employeeId);
-          if (emp) {
-            setTarget((cur) => cur ?? { id: emp.id, name: emp.name, slug: emp.slug });
-          }
-        }
-        // Carry on with the brain this email's chat has been using, so
-        // reopening the panel doesn't quietly switch models mid-conversation.
-        setModelId((cur) => cur ?? res.modelId);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setLoadError(errorMessage(err, "Could not load this email’s chat"));
-      });
-    return () => {
-      cancelled = true;
-      streamAbortRef.current?.abort();
-      streamAbortRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [company.id, account.id, threadId]);
+  }, [scopeKey, clearAttachments]);
 
   const scrollToBottom = React.useCallback(() => {
     requestAnimationFrame(() => {
@@ -263,7 +219,9 @@ export function MailAssistant({
     [messages],
   );
   const workingId = workingMessage?.id ?? null;
-  const turnInFlight = streamOpen || workingId !== null;
+  const turnInFlight = streamOpen || workingId !== null || reconnecting;
+  const workingEmployee = roster.find((entry) => entry.id === workingMessage?.employeeId);
+  const queueing = turnInFlight || queuedMessages.length > 0;
 
   /** The models the employee on this conversation can actually answer on. */
   const targetModels = React.useMemo(
@@ -283,194 +241,64 @@ export function MailAssistant({
     return targetModels.find((m) => m.isActive)?.id ?? targetModels[0].id;
   }, [modelId, targetModels]);
 
-  // Follow a turn this panel is not streaming: the stream dropped, the panel
-  // was reopened mid-reply, or another tab started it. Polling the bootstrap
-  // is enough — the row finalizes exactly once, whoever is watching.
-  React.useEffect(() => {
-    if (!workingId || streamOpen) return;
-    let cancelled = false;
-    let timer = 0;
-    const tick = async () => {
-      try {
-        const res = await mailApi.assistant(company.id, account.id, threadId);
-        if (cancelled) return;
-        setRoster(res.roster);
-        setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-        setReconnecting(false);
-      } catch {
-        // The server may be restarting. Keep waiting: the row outlives it,
-        // and boot recovery closes it out if the turn really was lost.
-        if (!cancelled) setReconnecting(true);
-      }
-      if (!cancelled) timer = window.setTimeout(tick, FOLLOW_POLL_MS);
-    };
-    timer = window.setTimeout(tick, FOLLOW_POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [workingId, streamOpen, company.id, account.id, threadId]);
-
-  // Partial text from a stream that died has already been persisted on the
-  // finalized row, so drop the local copy once the turn resolves.
-  React.useEffect(() => {
-    if (!turnInFlight) {
-      setStreaming(null);
-      setReconnecting(false);
-    }
-  }, [turnInFlight]);
-
   const send = React.useCallback(
     async (text: string) => {
       const message = text.trim();
-      if ((!message && pending.length === 0) || turnInFlight || isUploading()) return;
+      if ((!message && pending.length === 0) || isUploading() || messages === null) return;
       setComposerError(null);
       if (message === "/new" && pending.length === 0) {
-        try {
-          await mailApi.assistantClear(company.id, account.id, threadId);
-          setMessages([]);
-          setTarget(null);
-          setDraft("");
-          clearAttachments();
-          setMentionQuery(null);
-          setResourceQuery(null);
-        } catch (err) {
-          setComposerError(errorMessage(err, "Could not start a new context"));
-        }
-        return;
-      }
-      setStreamOpen(true);
-      setReconnecting(false);
-      setDraft("");
-      setMentionQuery(null);
-      setResourceQuery(null);
-      // Hand the files to this turn and clear the tray: a second send must
-      // not re-attach what the first one already carried.
-      const attachments = pending.map(({ previewUrl: _previewUrl, ...attachment }) => attachment);
-      // Optimistic bubble; swapped for the persisted row on the `user` event.
-      const temp: MailAssistantMessage = {
-        id: `temp-${Date.now()}`,
-        accountId: account.id,
-        threadId,
-        role: "user",
-        employeeId: null,
-        modelId: null,
-        content: message,
-        status: null,
-        actions: [],
-        suggestions: [],
-        attachments,
-        createdAt: new Date().toISOString(),
-      };
-      setMessages((prev) => [...(prev ?? []), temp]);
-      // Once the server has persisted the in-flight row, this stream is only
-      // a subscriber: losing it is not losing the reply.
-      let accepted = false;
-      let accumulated = "";
-      const controller = new AbortController();
-      streamAbortRef.current?.abort();
-      streamAbortRef.current = controller;
-      try {
-        await mailApi.assistantSend(
-          company.id,
-          account.id,
-          {
-            message,
-            threadId,
-            focusedMessageId: focusedMessageId ?? undefined,
-            employeeId: target?.id,
-            attachmentIds: attachments.map((a) => a.id),
-            modelId: selectedModelId,
-          },
-          (event, data) => {
-            if (event === "user") {
-              accepted = true;
-              clearAttachments();
-              const row = data as MailAssistantMessage;
-              setMessages((prev) => (prev ?? []).map((m) => (m.id === temp.id ? row : m)));
-            } else if (event === "target") {
-              const emp = (
-                data as {
-                  employee: { id: string; name: string; slug: string } | null;
-                }
-              ).employee;
-              setTarget(emp);
-            } else if (event === "working") {
-              accepted = true;
-              clearAttachments();
-              setMessages((prev) => upsertAssistantMessage(prev, data as MailAssistantMessage));
-            } else if (event === "chunk") {
-              accumulated += (data as { text: string }).text;
-              setStreaming(accumulated);
-            } else if (event === "assistant") {
-              accepted = true;
-              setStreaming(null);
-              setMessages((prev) => upsertAssistantMessage(prev, data as MailAssistantMessage));
-            } else if (event === "error") {
-              throw new Error((data as { message: string }).message);
-            }
-          },
-          { signal: controller.signal },
-        );
-      } catch (err) {
-        // A deliberate cancel (mailbox switch, unmount) is not an error the
-        // human needs a bubble for. Neither is a dropped connection once the
-        // turn was accepted: the follow effect polls that row to its answer.
-        const aborted = (err as Error).name === "AbortError" || controller.signal.aborted;
-        if (aborted) return;
-        if (!accepted) {
-          // The connection can also die between the server accepting the turn
-          // and this stream hearing about it. Ask the server before telling
-          // the human nothing ran — the answer decides which is true.
-          try {
-            const res = await mailApi.assistant(company.id, account.id, threadId);
-            setRoster(res.roster);
-            setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-            accepted = res.messages.some((m) => m.role === "assistant" && m.status === "working");
-          } catch {
-            // Server unreachable; fall through to the honest failure below.
-          }
-        }
-        if (accepted) {
-          clearAttachments();
-          setReconnecting(true);
+        if (turnInFlight || queuedMessages.length > 0) {
+          setComposerError("Wait for the reply and queued messages before starting a new context.");
           return;
         }
-        setDraft(message);
-        setMessages((prev) => [
-          ...(prev ?? []).filter((row) => row.id !== temp.id),
-          {
-            ...temp,
-            id: `temp-err-${Date.now()}`,
-            role: "assistant",
-            status: "error",
-            content: formatSendFailure((err as Error).message),
-            attachments: [],
-          },
-        ]);
-      } finally {
-        if (streamAbortRef.current === controller) streamAbortRef.current = null;
-        setStreamOpen(false);
-        scrollToBottom();
+        try {
+          await session.clear();
+        } catch (err) {
+          if (activeScopeRef.current === scopeKey) {
+            setComposerError(errorMessage(err, "Could not start a new context"));
+          }
+          return;
+        }
+        if (activeScopeRef.current !== scopeKey) return;
+      } else {
+        try {
+          session.send({
+            message,
+            attachments: pending.map(({ previewUrl: _previewUrl, ...attachment }) => attachment),
+            employeeId: target?.id,
+            modelId: selectedModelId,
+            focusedMessageId: focusedMessageId ?? undefined,
+          });
+        } catch (err) {
+          setComposerError(errorMessage(err, "Could not queue this message"));
+          return;
+        }
       }
+      // Transfer this draft once. Later stream events must never clear files
+      // the Member has already attached to their next follow-up.
+      setDraft("");
+      clearAttachments();
+      setMentionQuery(null);
+      setResourceQuery(null);
+      textareaRef.current?.focus();
     },
     [
-      turnInFlight,
-      company.id,
-      account.id,
-      threadId,
-      focusedMessageId,
-      target,
       pending,
       isUploading,
-      clearAttachments,
+      messages,
+      turnInFlight,
+      queuedMessages.length,
+      session,
+      scopeKey,
+      target,
       selectedModelId,
-      scrollToBottom,
+      clearAttachments,
+      focusedMessageId,
     ],
   );
 
   const { onPaste, dragProps } = useComposerFileDrop(addFiles, {
-    disabled: turnInFlight,
+    disabled: messages === null,
   });
 
   /**
@@ -484,23 +312,30 @@ export function MailAssistant({
       const index = list.findIndex((m) => m.id === failed.id);
       for (let i = index - 1; i >= 0; i -= 1) {
         if (list[i].role === "user") {
-          void send(chatRetryText(list[i]));
+          try {
+            setComposerError(null);
+            session.retry({
+              message: chatRetryText(list[i]),
+              attachments: [],
+              employeeId: failed.employeeId ?? target?.id,
+              modelId: failed.modelId ?? selectedModelId,
+              focusedMessageId: focusedMessageId ?? undefined,
+            });
+          } catch (err) {
+            setComposerError(errorMessage(err, "Could not retry this message"));
+          }
           return;
         }
       }
     },
-    [messages, send],
+    [messages, session, target?.id, selectedModelId, focusedMessageId],
   );
 
-  const markExecuted = React.useCallback((updated: MailAssistantMessage) => {
-    setMessages((prev) => (prev ?? []).map((m) => (m.id === updated.id ? updated : m)));
-  }, []);
+  const markExecuted = session.updateMessage;
 
   const clearConversation = async () => {
     try {
-      await mailApi.assistantClear(company.id, account.id, threadId);
-      setMessages([]);
-      setTarget(null);
+      await session.clear();
     } catch (err) {
       void dialog.error(err, { title: "Couldn’t clear the conversation" });
     }
@@ -644,7 +479,8 @@ export function MailAssistant({
         {messages !== null && messages.length > 0 && (
           <button
             onClick={() => void clearConversation()}
-            className="rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300"
+            disabled={turnInFlight || queuedMessages.length > 0 || session.loading}
+            className="rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-slate-800 dark:hover:text-slate-300"
             title="Clear conversation"
           >
             <Trash2 size={14} />
@@ -698,16 +534,23 @@ export function MailAssistant({
             ))}
           </>
         )}
-        {streamOpen && workingId === null && (
-          <div className="flex items-center gap-2 text-xs text-slate-400">
-            <Spinner size={12} />
-            {target ? `${target.name} is thinking…` : "Thinking…"}
-          </div>
-        )}
       </div>
 
       {/* Composer */}
       <div className="relative border-t border-slate-200 p-3 dark:border-slate-800">
+        {turnInFlight && (
+          <AssistantWorkStatus
+            name={workingEmployee?.name ?? target?.name ?? "The AI Employee"}
+            startedAt={workingMessage?.createdAt}
+            reconnecting={reconnecting}
+          />
+        )}
+        <AssistantMessageQueue
+          messages={queuedMessages}
+          paused={queuePaused}
+          onRemove={session.removeQueuedMessage}
+          onResume={session.resumeQueue}
+        />
         {mentionQuery !== null && resourceQuery === null && mentionCandidates.length > 0 && (
           <div className="absolute bottom-full left-3 right-3 z-10 mb-1 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
             {mentionCandidates.map((r, i) => (
@@ -780,7 +623,7 @@ export function MailAssistant({
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            disabled={turnInFlight}
+            disabled={messages === null || uploading > 0}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:opacity-40 dark:hover:bg-slate-800 dark:hover:text-slate-300"
             title="Attach a file"
           >
@@ -792,7 +635,7 @@ export function MailAssistant({
             rows={2}
             placeholder={
               turnInFlight
-                ? `${target?.name ?? "The employee"} is still on your last message…`
+                ? `Add a follow-up for ${target?.name ?? "the AI Employee"}…`
                 : "Ask AI to summarize, reply, edit, or triage…"
             }
             onChange={(e) => {
@@ -815,14 +658,15 @@ export function MailAssistant({
           />
           <button
             onClick={() => void send(draft)}
-            disabled={(!draft.trim() && pending.length === 0) || turnInFlight || uploading > 0}
+            disabled={(!draft.trim() && pending.length === 0) || messages === null || uploading > 0}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-indigo-600 text-white transition-opacity hover:bg-indigo-500 disabled:opacity-40"
-            title="Send (Enter)"
+            aria-label={queueing ? "Queue message" : "Send message"}
+            title={queueing ? "Queue message (Enter)" : "Send (Enter)"}
           >
-            <Send size={14} />
+            {queueing ? <Clock size={14} /> : <Send size={14} />}
           </button>
         </div>
-        <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400 dark:text-slate-500">
+        <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400 dark:text-slate-500">
           <span>
             <span className="font-mono">@</span> AI employee · <span className="font-mono">#</span>{" "}
             resource · <span className="font-mono">/new</span> new context
@@ -1023,7 +867,7 @@ function MessageRow({
           {isWorking ? (
             <WorkingBody
               name={emp?.name ?? "The employee"}
-              text={streamingText ?? null}
+              text={streamingText ?? (message.content || null)}
               reconnecting={Boolean(reconnecting)}
             />
           ) : isError || isSkipped ? (
@@ -1077,7 +921,10 @@ function WorkingBody({
     return (
       <div>
         <ChatMarkdown content={text} />
-        <span className="ml-0.5 inline-block h-3.5 w-[2px] animate-pulse bg-slate-400 align-middle" />
+        <div className="mt-2 flex items-center gap-1.5 text-xs text-indigo-600 dark:text-indigo-300">
+          <Spinner size={12} />
+          {reconnecting ? "Reconnecting…" : "Still working…"}
+        </div>
       </div>
     );
   }

--- a/App/client/pages/RoutineAssistant.tsx
+++ b/App/client/pages/RoutineAssistant.tsx
@@ -1,4 +1,13 @@
 import React from "react";
+import {
+  useAssistantChatSession,
+  type AssistantQueuedMessage,
+  type AssistantChatBootstrap,
+} from "@/lib/assistantChatSessions";
+import {
+  AssistantWorkStatus,
+  AssistantMessageQueue,
+} from "@/components/chat/AssistantMessageQueue";
 import { chatRetryText } from "../lib/chatRetry";
 import { useComposerFileDrop } from "../lib/fileDrop";
 import { useChatAttachments } from "../lib/stagedChatAttachments";
@@ -8,6 +17,7 @@ import {
   Bot,
   Brain,
   Check,
+  Clock,
   FileText,
   Paperclip,
   RotateCcw,
@@ -64,62 +74,7 @@ import {
  * whether re-sending would duplicate the work.
  */
 
-/** How often a panel that lost its stream re-reads the in-flight turn. */
-const FOLLOW_POLL_MS = 2_000;
-
 const WIDTH_STORAGE_KEY = "genosyn.routineAssistant.width";
-
-/** Replace a row by id, or append it when this panel hasn't seen it yet. */
-function upsertAssistantMessage(
-  prev: RoutineAssistantMessage[] | null,
-  incoming: RoutineAssistantMessage,
-): RoutineAssistantMessage[] {
-  const list = prev ?? [];
-  const index = list.findIndex((m) => m.id === incoming.id);
-  if (index === -1) return [...list, incoming];
-  const next = [...list];
-  next[index] = incoming;
-  return next;
-}
-
-/**
- * Fold a server page into what this panel already has.
- *
- * Replacing outright would drop an optimistic bubble sent while the bootstrap
- * was in flight; appending outright would duplicate every row. So: server rows
- * win by id, and anything local the server hasn't heard of yet (a `temp-`
- * bubble) is kept at the end.
- */
-function mergeAssistantMessages(
-  prev: RoutineAssistantMessage[] | null,
-  incoming: RoutineAssistantMessage[],
-): RoutineAssistantMessage[] {
-  if (!prev || prev.length === 0) return incoming;
-  const known = new Set(incoming.map((m) => m.id));
-  const local = prev.filter((m) => {
-    if (known.has(m.id)) return false;
-    // A turn accepted while the stream was down persisted the human's
-    // message server-side under a real id, so the optimistic twin can only be
-    // recognised by what it says. Matching on id alone would leave the
-    // question rendered twice, the second copy stranded below the reply.
-    if (m.id.startsWith("temp-") && m.role === "user") {
-      return !incoming.some((row) => row.role === "user" && row.content === m.content);
-    }
-    return true;
-  });
-  return [...incoming, ...local];
-}
-
-function formatSendFailure(detail: string): string {
-  const clean = detail.replace(/\s+/g, " ").trim();
-  return [
-    "This message couldn’t be sent.",
-    "",
-    `Details: ${clean || "Unknown error"}`,
-    "",
-    "Nothing about the routine was changed. Try again in a moment.",
-  ].join("\n");
-}
 
 type Props = {
   company: Company;
@@ -139,36 +94,78 @@ export function RoutineAssistant({
   const dialog = useDialog();
   const { width, resizing, startResize, onResizeKeyDown } = useSidePanelWidth(WIDTH_STORAGE_KEY);
   const wide = useWideViewport(SIDE_PANEL_MIN_SIDE_BY_SIDE_VIEWPORT);
-  const [messages, setMessages] = React.useState<RoutineAssistantMessage[] | null>(null);
-  const [loadError, setLoadError] = React.useState<string | null>(null);
-  const [roster, setRoster] = React.useState<RoutineAssistantRosterEntry[]>([]);
   const [draft, setDraft] = React.useState("");
-  /** Failure of something started from the composer — a /new, an upload. */
   const [composerError, setComposerError] = React.useState<string | null>(null);
-  /** True only while this panel holds the live SSE stream for a turn. */
-  const [streamOpen, setStreamOpen] = React.useState(false);
-  /** True once following the persisted turn has fallen back to polling. */
-  const [reconnecting, setReconnecting] = React.useState(false);
-  const [streaming, setStreaming] = React.useState<string | null>(null);
-  const [target, setTarget] = React.useState<{
-    id: string;
-    name: string;
-    slug: string;
-  } | null>(null);
-  /** Files chosen for the next message — uploaded already, bound on send. */
-
-  /**
-   * The brain for the next turn. Null means "whatever the employee's active
-   * model is" until the server tells us which one this routine's chat has been
-   * running on, or the human picks one.
-   */
-  const [modelId, setModelId] = React.useState<string | null>(null);
   const scrollerRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
-  // In-flight SSE turn — aborted when the routine changes or the panel
-  // unmounts, so a slow reply can't paint into the wrong conversation.
-  const streamAbortRef = React.useRef<AbortController | null>(null);
+  const routineId = routine.id;
+  const scopeKey = `routine:${company.id}:${routineId}`;
+  const adapter = React.useMemo(
+    () => ({
+      load: () => routineAssistantApi.load(company.id, routineId),
+      send: (
+        item: AssistantQueuedMessage,
+        onEvent: (event: string, data: unknown) => void,
+        signal: AbortSignal,
+      ) =>
+        routineAssistantApi.send(
+          company.id,
+          routineId,
+          {
+            message: item.message,
+            employeeId: item.employeeId,
+            modelId: item.modelId,
+            attachmentIds: item.attachments.map((a) => a.id),
+          },
+          onEvent,
+          { signal },
+        ),
+      clear: () => routineAssistantApi.clear(company.id, routineId),
+      createUserMessage: (item: AssistantQueuedMessage): RoutineAssistantMessage => ({
+        id: `temp-${item.id}`,
+        routineId,
+        role: "user",
+        employeeId: null,
+        modelId: null,
+        content: item.message,
+        status: null,
+        actions: [],
+        attachments: item.attachments,
+        createdAt: item.queuedAt,
+      }),
+      initialTarget: (
+        bootstrap: AssistantChatBootstrap<RoutineAssistantMessage, RoutineAssistantRosterEntry>,
+      ) => {
+        const last = [...bootstrap.messages]
+          .reverse()
+          .find((row) => row.role === "assistant" && row.employeeId);
+        return (
+          bootstrap.roster.find((entry) => entry.id === last?.employeeId) ??
+          bootstrap.roster.find((entry) => entry.ownsRoutine) ??
+          null
+        );
+      },
+    }),
+    [company.id, routineId],
+  );
+  const session = useAssistantChatSession(scopeKey, adapter);
+  const {
+    messages,
+    roster,
+    loadError,
+    streaming,
+    streamOpen,
+    reconnecting,
+    target,
+    modelId,
+    setTarget,
+    setModelId,
+    queuedMessages,
+    queuePaused,
+  } = session;
+  const activeScopeRef = React.useRef(scopeKey);
+  activeScopeRef.current = scopeKey;
 
   const attachmentDraft = useChatAttachments({
     scopeKey: `${company.id}:${routine.id}`,
@@ -188,57 +185,14 @@ export function RoutineAssistant({
     resourceQuery,
   );
 
-  const routineId = routine.id;
-
   React.useEffect(() => {
-    let cancelled = false;
-    setMessages(null);
-    setLoadError(null);
     setComposerError(null);
-    setTarget(null);
     setDraft("");
     setMentionQuery(null);
     setResourceQuery(null);
     setResourceStart(null);
-    setStreaming(null);
-    setStreamOpen(false);
-    setReconnecting(false);
     clearAttachments();
-    setModelId(null);
-    routineAssistantApi
-      .load(company.id, routineId)
-      .then((res) => {
-        if (cancelled) return;
-        // Merge rather than replace: a message sent while the bootstrap was
-        // in flight must survive (its optimistic bubble isn't in `res`).
-        // A `working` row in the response means a turn started elsewhere —
-        // another tab, or this panel before it was closed — is still running;
-        // the follow effect below takes it from here.
-        setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-        setRoster(res.roster);
-        const lastAnswered = [...res.messages]
-          .reverse()
-          .find((m) => m.role === "assistant" && m.employeeId);
-        const startOn = lastAnswered?.employeeId
-          ? res.roster.find((r) => r.id === lastAnswered.employeeId)
-          : res.roster.find((r) => r.ownsRoutine);
-        if (startOn) {
-          setTarget((cur) => cur ?? { id: startOn.id, name: startOn.name, slug: startOn.slug });
-        }
-        // Carry on with the brain this routine's chat has been using, so
-        // reopening the panel doesn't quietly switch models mid-conversation.
-        setModelId((cur) => cur ?? res.modelId);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setLoadError(errorMessage(err, "Could not load this routine’s chat"));
-      });
-    return () => {
-      cancelled = true;
-      streamAbortRef.current?.abort();
-      streamAbortRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [company.id, routineId]);
+  }, [scopeKey, clearAttachments]);
 
   const scrollToBottom = React.useCallback(() => {
     requestAnimationFrame(() => {
@@ -259,7 +213,9 @@ export function RoutineAssistant({
     [messages],
   );
   const workingId = workingMessage?.id ?? null;
-  const turnInFlight = streamOpen || workingId !== null;
+  const turnInFlight = streamOpen || workingId !== null || reconnecting;
+  const workingEmployee = roster.find((entry) => entry.id === workingMessage?.employeeId);
+  const queueing = turnInFlight || queuedMessages.length > 0;
 
   /** The models the employee on this conversation can actually answer on. */
   const targetModels = React.useMemo(
@@ -279,188 +235,62 @@ export function RoutineAssistant({
     return targetModels.find((m) => m.isActive)?.id ?? targetModels[0].id;
   }, [modelId, targetModels]);
 
-  // Follow a turn this panel is not streaming: the stream dropped, the panel
-  // was reopened mid-reply, or another tab started it. Polling the bootstrap
-  // is enough — the row finalizes exactly once, whoever is watching.
-  React.useEffect(() => {
-    if (!workingId || streamOpen) return;
-    let cancelled = false;
-    let timer = 0;
-    const tick = async () => {
-      try {
-        const res = await routineAssistantApi.load(company.id, routineId);
-        if (cancelled) return;
-        setRoster(res.roster);
-        setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-        setReconnecting(false);
-      } catch {
-        // The server may be restarting. Keep waiting: the row outlives it,
-        // and boot recovery closes it out if the turn really was lost.
-        if (!cancelled) setReconnecting(true);
-      }
-      if (!cancelled) timer = window.setTimeout(tick, FOLLOW_POLL_MS);
-    };
-    timer = window.setTimeout(tick, FOLLOW_POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [workingId, streamOpen, company.id, routineId]);
-
-  // Partial text from a stream that died has already been persisted on the
-  // finalized row, so drop the local copy once the turn resolves.
-  React.useEffect(() => {
-    if (!turnInFlight) {
-      setStreaming(null);
-      setReconnecting(false);
-    }
-  }, [turnInFlight]);
-
   const send = React.useCallback(
     async (text: string) => {
       const message = text.trim();
-      if ((!message && pending.length === 0) || turnInFlight || isUploading()) return;
+      if ((!message && pending.length === 0) || isUploading() || messages === null) return;
       setComposerError(null);
       if (message === "/new" && pending.length === 0) {
-        try {
-          await routineAssistantApi.clear(company.id, routineId);
-          setMessages([]);
-          setTarget(null);
-          setDraft("");
-          clearAttachments();
-          setMentionQuery(null);
-          setResourceQuery(null);
-        } catch (err) {
-          setComposerError(errorMessage(err, "Could not start a new context"));
-        }
-        return;
-      }
-      setStreamOpen(true);
-      setReconnecting(false);
-      setDraft("");
-      setMentionQuery(null);
-      setResourceQuery(null);
-      // Hand the files to this turn and clear the tray: a second send must
-      // not re-attach what the first one already carried.
-      const attachments = pending.map(({ previewUrl: _previewUrl, ...attachment }) => attachment);
-      // Optimistic bubble; swapped for the persisted row on the `user` event.
-      const temp: RoutineAssistantMessage = {
-        id: `temp-${Date.now()}`,
-        routineId,
-        role: "user",
-        employeeId: null,
-        modelId: null,
-        content: message,
-        status: null,
-        actions: [],
-        attachments,
-        createdAt: new Date().toISOString(),
-      };
-      setMessages((prev) => [...(prev ?? []), temp]);
-      // Once the server has persisted the in-flight row, this stream is only
-      // a subscriber: losing it is not losing the reply.
-      let accepted = false;
-      let accumulated = "";
-      const controller = new AbortController();
-      streamAbortRef.current?.abort();
-      streamAbortRef.current = controller;
-      try {
-        await routineAssistantApi.send(
-          company.id,
-          routineId,
-          {
-            message,
-            employeeId: target?.id,
-            attachmentIds: attachments.map((a) => a.id),
-            modelId: selectedModelId,
-          },
-          (event, data) => {
-            if (event === "user") {
-              accepted = true;
-              clearAttachments();
-              const row = data as RoutineAssistantMessage;
-              setMessages((prev) => (prev ?? []).map((m) => (m.id === temp.id ? row : m)));
-            } else if (event === "target") {
-              const emp = (
-                data as {
-                  employee: { id: string; name: string; slug: string } | null;
-                }
-              ).employee;
-              setTarget(emp);
-            } else if (event === "working") {
-              accepted = true;
-              clearAttachments();
-              setMessages((prev) => upsertAssistantMessage(prev, data as RoutineAssistantMessage));
-            } else if (event === "chunk") {
-              accumulated += (data as { text: string }).text;
-              setStreaming(accumulated);
-            } else if (event === "assistant") {
-              accepted = true;
-              setStreaming(null);
-              setMessages((prev) => upsertAssistantMessage(prev, data as RoutineAssistantMessage));
-            } else if (event === "error") {
-              throw new Error((data as { message: string }).message);
-            }
-          },
-          { signal: controller.signal },
-        );
-      } catch (err) {
-        // A deliberate cancel (routine switch, unmount) is not an error the
-        // human needs a bubble for. Neither is a dropped connection once the
-        // turn was accepted: the follow effect polls that row to its answer.
-        const aborted = (err as Error).name === "AbortError" || controller.signal.aborted;
-        if (aborted) return;
-        if (!accepted) {
-          // The connection can also die between the server accepting the turn
-          // and this stream hearing about it. Ask the server before telling
-          // the human nothing ran — the answer decides which is true.
-          try {
-            const res = await routineAssistantApi.load(company.id, routineId);
-            setRoster(res.roster);
-            setMessages((prev) => mergeAssistantMessages(prev, res.messages));
-            accepted = res.messages.some((m) => m.role === "assistant" && m.status === "working");
-          } catch {
-            // Server unreachable; fall through to the honest failure below.
-          }
-        }
-        if (accepted) {
-          clearAttachments();
-          setReconnecting(true);
+        if (turnInFlight || queuedMessages.length > 0) {
+          setComposerError("Wait for the reply and queued messages before starting a new context.");
           return;
         }
-        setDraft(message);
-        setMessages((prev) => [
-          ...(prev ?? []).filter((row) => row.id !== temp.id),
-          {
-            ...temp,
-            id: `temp-err-${Date.now()}`,
-            role: "assistant",
-            status: "error",
-            content: formatSendFailure((err as Error).message),
-            attachments: [],
-          },
-        ]);
-      } finally {
-        if (streamAbortRef.current === controller) streamAbortRef.current = null;
-        setStreamOpen(false);
-        scrollToBottom();
+        try {
+          await session.clear();
+        } catch (err) {
+          if (activeScopeRef.current === scopeKey) {
+            setComposerError(errorMessage(err, "Could not start a new context"));
+          }
+          return;
+        }
+        if (activeScopeRef.current !== scopeKey) return;
+      } else {
+        try {
+          session.send({
+            message,
+            attachments: pending.map(({ previewUrl: _previewUrl, ...attachment }) => attachment),
+            employeeId: target?.id,
+            modelId: selectedModelId,
+          });
+        } catch (err) {
+          setComposerError(errorMessage(err, "Could not queue this message"));
+          return;
+        }
       }
+      // Transfer this draft once. Later stream events must never clear files
+      // the Member has already attached to their next follow-up.
+      setDraft("");
+      clearAttachments();
+      setMentionQuery(null);
+      setResourceQuery(null);
+      textareaRef.current?.focus();
     },
     [
-      turnInFlight,
-      company.id,
-      routineId,
-      target,
       pending,
-      selectedModelId,
-      scrollToBottom,
       isUploading,
+      messages,
+      turnInFlight,
+      queuedMessages.length,
+      session,
+      scopeKey,
+      target,
+      selectedModelId,
       clearAttachments,
     ],
   );
 
   const { onPaste, dragProps } = useComposerFileDrop(addFiles, {
-    disabled: turnInFlight,
+    disabled: messages === null,
   });
 
   /**
@@ -474,19 +304,27 @@ export function RoutineAssistant({
       const index = list.findIndex((m) => m.id === failed.id);
       for (let i = index - 1; i >= 0; i -= 1) {
         if (list[i].role === "user") {
-          void send(chatRetryText(list[i]));
+          try {
+            setComposerError(null);
+            session.retry({
+              message: chatRetryText(list[i]),
+              attachments: [],
+              employeeId: failed.employeeId ?? target?.id,
+              modelId: failed.modelId ?? selectedModelId,
+            });
+          } catch (err) {
+            setComposerError(errorMessage(err, "Could not retry this message"));
+          }
           return;
         }
       }
     },
-    [messages, send],
+    [messages, session, target?.id, selectedModelId],
   );
 
   const clearConversation = async () => {
     try {
-      await routineAssistantApi.clear(company.id, routineId);
-      setMessages([]);
-      setTarget(null);
+      await session.clear();
     } catch (err) {
       void dialog.error(err, { title: "Couldn’t clear the conversation" });
     }
@@ -683,7 +521,8 @@ export function RoutineAssistant({
         {messages !== null && messages.length > 0 && (
           <button
             onClick={() => void clearConversation()}
-            className="rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300"
+            disabled={turnInFlight || queuedMessages.length > 0 || session.loading}
+            className="rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-slate-800 dark:hover:text-slate-300"
             title="Clear conversation"
           >
             <Trash2 size={14} />
@@ -743,16 +582,23 @@ export function RoutineAssistant({
             ))}
           </>
         )}
-        {streamOpen && workingId === null && (
-          <div className="flex items-center gap-2 text-xs text-slate-400">
-            <Spinner size={12} />
-            {target ? `${target.name} is thinking…` : "Thinking…"}
-          </div>
-        )}
       </div>
 
       {/* Composer */}
       <div className="relative shrink-0 border-t border-slate-200 p-3 dark:border-slate-800">
+        {turnInFlight && (
+          <AssistantWorkStatus
+            name={workingEmployee?.name ?? target?.name ?? "The AI Employee"}
+            startedAt={workingMessage?.createdAt}
+            reconnecting={reconnecting}
+          />
+        )}
+        <AssistantMessageQueue
+          messages={queuedMessages}
+          paused={queuePaused}
+          onRemove={session.removeQueuedMessage}
+          onResume={session.resumeQueue}
+        />
         {mentionQuery !== null && resourceQuery === null && mentionCandidates.length > 0 && (
           <div className="absolute bottom-full left-3 right-3 z-10 mb-1 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
             {mentionCandidates.map((r, i) => (
@@ -825,7 +671,7 @@ export function RoutineAssistant({
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            disabled={turnInFlight}
+            disabled={messages === null || uploading > 0}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:opacity-40 dark:hover:bg-slate-800 dark:hover:text-slate-300"
             title="Attach a file"
           >
@@ -837,7 +683,7 @@ export function RoutineAssistant({
             rows={2}
             placeholder={
               turnInFlight
-                ? `${target?.name ?? "The employee"} is still on your last message…`
+                ? `Add a follow-up for ${target?.name ?? "the AI Employee"}…`
                 : "Ask about this routine, its schedule, or its runs…"
             }
             onChange={(e) => {
@@ -860,14 +706,15 @@ export function RoutineAssistant({
           />
           <button
             onClick={() => void send(draft)}
-            disabled={(!draft.trim() && pending.length === 0) || turnInFlight || uploading > 0}
+            disabled={(!draft.trim() && pending.length === 0) || messages === null || uploading > 0}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-indigo-600 text-white transition-opacity hover:bg-indigo-500 disabled:opacity-40"
-            title="Send (Enter)"
+            aria-label={queueing ? "Queue message" : "Send message"}
+            title={queueing ? "Queue message (Enter)" : "Send (Enter)"}
           >
-            <Send size={14} />
+            {queueing ? <Clock size={14} /> : <Send size={14} />}
           </button>
         </div>
-        <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400 dark:text-slate-500">
+        <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400 dark:text-slate-500">
           <span>
             <span className="font-mono">@</span> AI employee · <span className="font-mono">#</span>{" "}
             resource · <span className="font-mono">/new</span> new context
@@ -1068,7 +915,7 @@ function MessageRow({
           {isWorking ? (
             <WorkingBody
               name={emp?.name ?? "The employee"}
-              text={streamingText ?? null}
+              text={streamingText ?? (message.content || null)}
               reconnecting={Boolean(reconnecting)}
             />
           ) : isError || isSkipped ? (
@@ -1112,7 +959,10 @@ function WorkingBody({
     return (
       <div>
         <ChatMarkdown content={text} />
-        <span className="ml-0.5 inline-block h-3.5 w-[2px] animate-pulse bg-slate-400 align-middle" />
+        <div className="mt-2 flex items-center gap-1.5 text-xs text-indigo-600 dark:text-indigo-300">
+          <Spinner size={12} />
+          {reconnecting ? "Reconnecting…" : "Still working…"}
+        </div>
       </div>
     );
   }

--- a/App/scripts/chatImageHarness.tsx
+++ b/App/scripts/chatImageHarness.tsx
@@ -83,6 +83,44 @@ function StagingFixture() {
     </div>
   );
 }
+function AssistantFixture() {
+  const [visible, setVisible] = React.useState(true);
+  const [alternate, setAlternate] = React.useState(false);
+  return (
+    <>
+      <div className="flex gap-4 p-2">
+        <button onClick={() => setVisible(!visible)}>
+          {visible ? "Close AI panel" : "Reopen AI panel"}
+        </button>
+        <button onClick={() => setAlternate(!alternate)}>Switch conversation</button>
+      </div>
+      {visible &&
+        (surface === "mail" ? (
+          <MailAssistant
+            company={company}
+            account={{ id: "account", email: "demo@example.test" } as MailAccount}
+            threadId={alternate ? "other-thread" : "thread"}
+            openCompose={() => {}}
+          />
+        ) : (
+          <RoutineAssistant
+            company={company}
+            routine={
+              {
+                id: alternate ? "other-routine" : "routine",
+                name: alternate ? "Other review" : "Review",
+                employeeId: employee.id,
+                employee,
+              } as RoutineWithMeta
+            }
+            collapsed={false}
+            onCollapsedChange={() => {}}
+            onClose={() => setVisible(false)}
+          />
+        ))}
+    </>
+  );
+}
 function Fixture() {
   if (surface === "staging") return <StagingFixture />;
   if (surface === "todo")
@@ -108,27 +146,7 @@ function Fixture() {
         onClose={() => {}}
       />
     );
-  if (surface === "mail")
-    return (
-      <MailAssistant
-        company={company}
-        account={{ id: "account", email: "demo@example.test" } as MailAccount}
-        threadId="thread"
-        openCompose={() => {}}
-      />
-    );
-  if (surface === "routine")
-    return (
-      <RoutineAssistant
-        company={company}
-        routine={
-          { id: "routine", name: "Review", employeeId: employee.id, employee } as RoutineWithMeta
-        }
-        collapsed={false}
-        onCollapsedChange={() => {}}
-        onClose={() => {}}
-      />
-    );
+  if (surface === "mail" || surface === "routine") return <AssistantFixture />;
   if (surface === "tldr")
     return (
       <TldrQuestions

--- a/App/scripts/test-chat-images.ts
+++ b/App/scripts/test-chat-images.ts
@@ -1,9 +1,11 @@
 /** Run with `npm run test:chat-images`; uses local Chrome or GENOSYN_TEST_BROWSER.
+ * Add `-- "check name substring"` to run one regression group while iterating.
  * Uses actual React composers and real browser clipboard/file events. APIs are
  * stubbed here; server regression tests cover authorization, persistence and models.
  */
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import type { ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createServer } from "vite";
@@ -18,6 +20,31 @@ import type { TldrQuestionsResponse } from "../client/lib/tldrQuestions";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 let completedWorkbook: Buffer = Buffer.alloc(0);
+type ControlledReply = {
+  body: Record<string, unknown>;
+  response: ServerResponse;
+  assistant: Record<string, unknown>;
+  completed: boolean;
+};
+let controlledReplies = false;
+let activeReplies = 0;
+let maxActiveReplies = 0;
+const replies: ControlledReply[] = [];
+const assistantHistory = new Map<string, Array<Record<string, unknown>>>();
+function streamEvent(response: ServerResponse, event: string, data: unknown) {
+  response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+function finishReply(reply: ControlledReply, status: "ok" | "error" = "ok") {
+  assert.equal(reply.completed, false, "Each reply finishes only once");
+  reply.completed = true;
+  activeReplies--;
+  reply.assistant.status = status;
+  reply.assistant.content =
+    status === "ok" ? `Finished: ${reply.body.message}` : "Model temporarily unavailable";
+  streamEvent(reply.response, "assistant", reply.assistant);
+  streamEvent(reply.response, "done", {});
+  reply.response.end();
+}
 const server = await createServer({
   ...browserTestVite,
   configFile: path.join(root, "vite.config.ts"),
@@ -27,6 +54,63 @@ const server = await createServer({
     {
       name: "chat-image-browser-fixture",
       configureServer(dev) {
+        // Real HTTP streaming lets the member interact after partial text has
+        // appeared and before the AI finishes. Intercepted fulfill responses
+        // arrive all at once, which cannot exercise a busy composer or queue.
+        dev.middlewares.use(async (req, res, next) => {
+          const pathname = new URL(req.url ?? "/", "http://fixture").pathname;
+          if (
+            !controlledReplies ||
+            req.method !== "POST" ||
+            !pathname.endsWith("/assistant/messages")
+          )
+            return next();
+          let raw = "";
+          for await (const chunk of req) raw += chunk.toString();
+          const body = JSON.parse(raw) as Record<string, unknown>;
+          sends.push(body);
+          const createdAt = new Date().toISOString();
+          const user = {
+            id: `controlled-user-${replies.length}`,
+            role: "user",
+            content: body.message,
+            attachments: ((body.attachmentIds ?? []) as string[]).map((id) => ({
+              id,
+              filename: "screenshot.png",
+              mimeType: "image/png",
+              isImage: true,
+              sizeBytes: 68,
+            })),
+            actions: [],
+            suggestions: [],
+            createdAt,
+          };
+          const assistant = {
+            id: `controlled-assistant-${replies.length}`,
+            role: "assistant",
+            employeeId: employee.id,
+            content: `Checking: ${body.message}`,
+            status: "working",
+            attachments: [],
+            actions: [],
+            suggestions: [],
+            createdAt,
+          };
+          const key = `${pathname.replace(/\/messages$/, "")}:${body.threadId ?? ""}`;
+          const history = assistantHistory.get(key) ?? [];
+          history.push(user, assistant);
+          assistantHistory.set(key, history);
+          replies.push({ body, response: res, assistant, completed: false });
+          activeReplies++;
+          maxActiveReplies = Math.max(maxActiveReplies, activeReplies);
+          res.setHeader("Content-Type", "text/event-stream");
+          res.setHeader("Cache-Control", "no-cache");
+          res.flushHeaders();
+          streamEvent(res, "user", user);
+          streamEvent(res, "target", { employee });
+          streamEvent(res, "working", { ...assistant, content: "" });
+          streamEvent(res, "chunk", { text: assistant.content });
+        });
         // Chromium downloads can bypass page request interception. Serve the
         // real workbook bytes so the browser exercises a complete HTTP download.
         dev.middlewares.use(
@@ -124,6 +208,8 @@ await context.route("**/api/**", async (route) => {
   const url = new URL(request.url());
   const pathname = url.pathname;
   const json = (body: unknown, status = 200) => route.fulfill({ json: body, status });
+  if (controlledReplies && request.method() === "POST" && pathname.endsWith("/assistant/messages"))
+    return route.continue();
   if (workbookMode && request.method() === "GET" && pathname.endsWith("/workbook-completed")) {
     return route.continue();
   }
@@ -291,7 +377,13 @@ await context.route("**/api/**", async (route) => {
   if (pathname.endsWith("/conversations/conversation"))
     return json({ conversation: { id: "conversation", surface: "help" }, messages: [] });
   if (pathname.endsWith("/assistant"))
-    return json({ messages: [], roster: [employee], modelId: "model" });
+    return json({
+      messages: controlledReplies
+        ? (assistantHistory.get(`${pathname}:${url.searchParams.get("threadId") ?? ""}`) ?? [])
+        : [],
+      roster: [employee],
+      modelId: "model",
+    });
   if (pathname.endsWith("/questions"))
     return json({
       questions: [],
@@ -357,7 +449,9 @@ async function waitUploads(page: Page, count: number) {
     .waitFor();
 }
 let checks = 0;
+const checkName = process.argv[2];
 async function check(name: string, run: () => Promise<void>) {
+  if (checkName && !name.includes(checkName)) return;
   console.log(`RUN ${name}`);
   await run();
   console.log(`PASS ${name}`);
@@ -393,7 +487,10 @@ try {
       const download = await downloadPromise;
       assert.equal(download.suggestedFilename(), "supplier-edited.xlsx");
       const downloaded = await fs.readFile((await download.path())!);
-      assert.ok(downloaded.equals(completedWorkbook), `Downloaded the completed workbook from ${download.url()}`);
+      assert.ok(
+        downloaded.equals(completedWorkbook),
+        `Downloaded the completed workbook from ${download.url()}`,
+      );
       const result = await readXlsx(downloaded);
       assert.equal(
         result.sheets[0].cells.find((cell) => cell.cell === "B1")?.value,
@@ -416,6 +513,162 @@ try {
       );
       await page.close();
       workbookMode = false;
+    },
+  );
+  await check(
+    "Mail and Routine show ongoing work and drain removable follow-ups serially across panel navigation",
+    async () => {
+      controlledReplies = true;
+      for (const surface of ["mail", "routine"]) {
+        assistantHistory.clear();
+        maxActiveReplies = 0;
+        const before = sends.length;
+        const page = await open(surface);
+        const composer = page.locator("textarea").first();
+        const queue = page.getByRole("region", { name: "Queued messages", exact: true });
+        const working = page.getByRole("status").filter({ hasText: "Alex is working" });
+        await composer.fill("Review the original request");
+        await page.getByRole("button", { name: "Send message", exact: true }).click();
+        await page.getByText("Checking: Review the original request", { exact: true }).waitFor();
+        await working.waitFor();
+        assert.equal(await composer.isEnabled(), true, surface);
+        assert.equal(await composer.getAttribute("placeholder"), "Add a follow-up for Alex…");
+        const firstReply = replies.at(-1)!;
+
+        await composer.fill("Use this attachment in the follow-up");
+        await paste(page);
+        await waitUploads(page, 1);
+        const queuedAttachmentId = `image-${uploads}`;
+        await page.getByRole("button", { name: "Queue message", exact: true }).click();
+        await queue.getByText("Use this attachment in the follow-up", { exact: true }).waitFor();
+        await queue.getByText("screenshot.png", { exact: true }).waitFor();
+        assert.equal(await composer.inputValue(), "");
+        await composer.fill("Remove this queued request");
+        await composer.press("Enter");
+        await queue.getByText("Remove this queued request", { exact: true }).waitFor();
+        await composer.fill("Check the totals afterwards");
+        await composer.press("Enter");
+        await queue.getByText("Check the totals afterwards", { exact: true }).waitFor();
+        assert.equal(
+          sends.length,
+          before + 1,
+          `${surface}: queued messages do not start concurrent work`,
+        );
+        await queue.getByRole("button", { name: "Remove queued message 2", exact: true }).click();
+        assert.equal(
+          await queue.getByText("Remove this queued request", { exact: true }).count(),
+          0,
+        );
+
+        // A later composer attachment has its own lifetime. Removing it must
+        // not mutate the image already captured by the queued message.
+        await paste(page);
+        await waitUploads(page, 1);
+        await page.getByRole("button", { name: "Remove screenshot.png", exact: true }).click();
+        assert.equal(await queue.getByText("screenshot.png", { exact: true }).count(), 1);
+        await working.waitFor();
+        await fs.mkdir(path.resolve(root, "../output/playwright"), { recursive: true });
+        await page.screenshot({
+          path: path.resolve(root, `../output/playwright/${surface}-assistant-queue.png`),
+          fullPage: true,
+        });
+        await page.setViewportSize({ width: 390, height: 844 });
+        assert.equal(
+          await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+          true,
+          `${surface}: queued messages fit a narrow screen`,
+        );
+        await page.screenshot({
+          path: path.resolve(root, `../output/playwright/${surface}-assistant-queue-mobile.png`),
+          fullPage: true,
+        });
+        await page.setViewportSize({ width: 1440, height: 1000 });
+
+        await page.getByRole("button", { name: "Switch conversation", exact: true }).click();
+        await page.getByRole("button", { name: "Send message", exact: true }).waitFor();
+        assert.equal(
+          await queue.count(),
+          0,
+          `${surface}: a different conversation has its own queue`,
+        );
+        assert.equal(await working.count(), 0);
+        await page.getByRole("button", { name: "Switch conversation", exact: true }).click();
+        await queue.getByText("Use this attachment in the follow-up", { exact: true }).waitFor();
+        await working.waitFor();
+        await page.getByRole("button", { name: "Close AI panel", exact: true }).click();
+        const nextStarted = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            response.request().postDataJSON()?.message === "Use this attachment in the follow-up",
+        );
+        finishReply(firstReply);
+        await nextStarted;
+        assert.equal(
+          sends.length,
+          before + 2,
+          `${surface}: the queue continues while the panel is closed`,
+        );
+        const secondReply = replies.at(-1)!;
+        assert.deepEqual(secondReply.body.attachmentIds, [queuedAttachmentId]);
+        await page.getByRole("button", { name: "Reopen AI panel", exact: true }).click();
+        await page
+          .getByText("Checking: Use this attachment in the follow-up", { exact: true })
+          .waitFor();
+        await queue.getByText("Check the totals afterwards", { exact: true }).waitFor();
+        await working.waitFor();
+        finishReply(secondReply);
+        await page.getByText("Checking: Check the totals afterwards", { exact: true }).waitFor();
+        const thirdReply = replies.at(-1)!;
+        assert.deepEqual(thirdReply.body.attachmentIds, []);
+        finishReply(thirdReply);
+        await page.getByRole("button", { name: "Send message", exact: true }).waitFor();
+        assert.equal(await working.count(), 0);
+        assert.equal(await queue.count(), 0);
+        assert.equal(maxActiveReplies, 1, `${surface}: only one reply runs at a time`);
+        assert.deepEqual(
+          sends.slice(before).map((body) => body.message),
+          [
+            "Review the original request",
+            "Use this attachment in the follow-up",
+            "Check the totals afterwards",
+          ],
+        );
+        await page.close();
+      }
+      controlledReplies = false;
+    },
+  );
+  await check(
+    "Mail and Routine retain and pause queued messages when an AI reply fails",
+    async () => {
+      controlledReplies = true;
+      for (const surface of ["mail", "routine"]) {
+        assistantHistory.clear();
+        const before = sends.length;
+        const page = await open(surface);
+        const composer = page.locator("textarea").first();
+        const queue = page.getByRole("region", { name: "Queued messages", exact: true });
+        await composer.fill("Start the review");
+        await composer.press("Enter");
+        await page.getByText("Checking: Start the review", { exact: true }).waitFor();
+        await composer.fill("Keep this follow-up after a failure");
+        await composer.press("Enter");
+        await queue.getByText("Keep this follow-up after a failure", { exact: true }).waitFor();
+        finishReply(replies.at(-1)!, "error");
+        await page.getByRole("button", { name: "Resume queue", exact: true }).waitFor();
+        assert.equal(sends.length, before + 1, `${surface}: a failure pauses pending work`);
+        await queue.getByText("Keep this follow-up after a failure", { exact: true }).waitFor();
+        await page.getByRole("button", { name: "Resume queue", exact: true }).click();
+        await page
+          .getByText("Checking: Keep this follow-up after a failure", { exact: true })
+          .waitFor();
+        assert.equal(sends.length, before + 2);
+        finishReply(replies.at(-1)!);
+        await page.getByRole("button", { name: "Send message", exact: true }).waitFor();
+        assert.equal(await queue.count(), 0);
+        await page.close();
+      }
+      controlledReplies = false;
     },
   );
   await check("every AI composer accepts pasted screenshots with a removable preview", async () => {
@@ -479,42 +732,53 @@ try {
     failSend = false;
     await page.close();
   });
-  await check("rejected sends retain images and text in every other AI composer", async () => {
-    failSend = true;
-    for (const surface of ["help", "mail", "routine", "base", "tldr", "todo"]) {
-      const page = await open(surface);
-      await page.locator("textarea").first().fill("Inspect this screenshot");
-      await paste(page);
-      await waitUploads(page, 1);
-      const sent = page.waitForRequest(
-        (request) =>
-          request.method() === "POST" &&
-          !request.headers()["content-type"]?.includes("multipart/form-data"),
-      );
-      await page
-        .locator("textarea")
-        .first()
-        .press(
-          surface === "base" || surface === "todo"
-            ? process.platform === "darwin"
-              ? "Meta+Enter"
-              : "Control+Enter"
-            : "Enter",
+  await check(
+    "rejected sends retain images and text in every other AI composer or its queue",
+    async () => {
+      failSend = true;
+      for (const surface of ["help", "mail", "routine", "base", "tldr", "todo"]) {
+        const page = await open(surface);
+        await page.locator("textarea").first().fill("Inspect this screenshot");
+        await paste(page);
+        await waitUploads(page, 1);
+        const sent = page.waitForRequest(
+          (request) =>
+            request.method() === "POST" &&
+            !request.headers()["content-type"]?.includes("multipart/form-data"),
         );
-      const request = await sent;
-      assert.equal(request.postDataJSON().attachmentIds.length, 1, surface);
-      await page.waitForFunction(
-        () => document.querySelector("textarea")?.value === "Inspect this screenshot",
-      );
-      assert.equal(
-        await page.getByRole("button", { name: "Remove screenshot.png", exact: true }).count(),
-        1,
-        surface,
-      );
-      await page.close();
-    }
-    failSend = false;
-  });
+        await page
+          .locator("textarea")
+          .first()
+          .press(
+            surface === "base" || surface === "todo"
+              ? process.platform === "darwin"
+                ? "Meta+Enter"
+                : "Control+Enter"
+              : "Enter",
+          );
+        const request = await sent;
+        assert.equal(request.postDataJSON().attachmentIds.length, 1, surface);
+        if (surface === "mail" || surface === "routine") {
+          const queue = page.getByRole("region", { name: "Queued messages", exact: true });
+          await queue.getByRole("button", { name: "Resume queue", exact: true }).waitFor();
+          await queue.getByText("Inspect this screenshot", { exact: true }).waitFor();
+          await queue.getByText("screenshot.png", { exact: true }).waitFor();
+          assert.equal(await page.locator("textarea").first().inputValue(), "");
+        } else {
+          await page.waitForFunction(
+            () => document.querySelector("textarea")?.value === "Inspect this screenshot",
+          );
+          assert.equal(
+            await page.getByRole("button", { name: "Remove screenshot.png", exact: true }).count(),
+            1,
+            surface,
+          );
+        }
+        await page.close();
+      }
+      failSend = false;
+    },
+  );
   await check(
     "an accepted image-only message can be retried after the AI reply fails",
     async () => {
@@ -529,9 +793,23 @@ try {
           await page.getByRole("button", { name: "Remove screenshot.png", exact: true }).count(),
           0,
         );
+        await page.locator("textarea").first().fill("Keep this unsent follow-up draft");
+        await paste(page);
+        await waitUploads(page, 1);
         const sent = page.waitForRequest((request) => request.method() === "POST");
         await page.getByRole("button", { name: "Try again", exact: true }).click();
-        assert.ok((await sent).postDataJSON().message.trim().length > 0, surface);
+        const retry = (await sent).postDataJSON();
+        assert.ok(retry.message.trim().length > 0, surface);
+        assert.notEqual(retry.message, "Keep this unsent follow-up draft");
+        assert.deepEqual(retry.attachmentIds, []);
+        assert.equal(
+          await page.locator("textarea").first().inputValue(),
+          "Keep this unsent follow-up draft",
+        );
+        assert.equal(
+          await page.getByRole("button", { name: "Remove screenshot.png", exact: true }).count(),
+          1,
+        );
         await page.close();
       }
       modelFailure = false;
@@ -626,6 +904,7 @@ try {
     await page.close();
   });
   assert.deepEqual(browserErrors, [], "No browser runtime errors");
+  assert.ok(checks > 0, `No browser regression group matched ${checkName}`);
   console.log(`${checks} browser regression groups passed.`);
 } finally {
   await browser.close();

--- a/Home/client/docs/pages/Email.tsx
+++ b/Home/client/docs/pages/Email.tsx
@@ -386,6 +386,15 @@ export function Email() {
         Everything it actually does appears as a small action pill under its reply.
       </P>
       <P>
+        A visible working status stays beside the composer while the employee replies, including
+        after text starts appearing. You can keep typing, attach files, and press{" "}
+        <Strong>Queue message</Strong> to add a follow-up. Pending messages appear in order above
+        the composer; remove any message before it starts. Each one sends after the reply ahead of
+        it finishes. Switching emails or navigating elsewhere in the app keeps the queue with its
+        original conversation. If a reply fails, pending messages stay queued until you resume
+        them.
+      </P>
+      <P>
         Replies can also carry <Strong>action buttons</Strong> — concrete next steps the employee
         proposes that run with <em>your</em> authority when you click them: open a pre-filled reply,
         send a draft it just wrote, archive or label the thread, start a handover, or create an

--- a/Home/client/docs/pages/Routines.tsx
+++ b/Home/client/docs/pages/Routines.tsx
@@ -384,6 +384,14 @@ Post it to the #morning channel.`}</Pre>
         from somewhere else.
       </P>
       <P>
+        The working status remains visible beside the composer throughout the reply. Keep typing
+        or attaching files and press <Strong>Queue message</Strong> to add a follow-up. Pending
+        messages appear above the composer and send one at a time after the preceding reply
+        finishes; remove a message before it starts if it is no longer needed. The queue stays
+        with this routine&apos;s conversation as you navigate around the app. If a reply fails,
+        pending messages remain available for you to resume.
+      </P>
+      <P>
         Each routine&apos;s chat is independent, and a reply in progress belongs to the server
         rather than to your browser tab. A long answer shows as <Strong>working</Strong>; if the
         connection drops the panel says <Strong>reconnecting</Strong> and picks the same reply back

--- a/Home/client/docs/pages/WorkspaceChat.tsx
+++ b/Home/client/docs/pages/WorkspaceChat.tsx
@@ -138,6 +138,15 @@ export function WorkspaceChat() {
         it starts, or navigate around the app and return—the queue remains with that employee&apos;s
         chat session.
       </P>
+      <P>
+        The <Strong>Ask AI</Strong> panels beside an{" "}
+        <DocLink to="/docs/email#assistant">email</DocLink> or{" "}
+        <DocLink to="/docs/routines#assistant">Routine</DocLink> also keep the composer available
+        and show a working status throughout each reply. Use <Strong>Queue message</Strong> to add
+        follow-ups with attachments, then review or remove pending messages above the composer.
+        They send in order within that conversation. A failed reply leaves its pending follow-ups
+        queued for you to resume.
+      </P>
 
       <H2 id="new-context">Start a new AI context</H2>
       <P>


### PR DESCRIPTION
Mail and Routine Ask AI panels disabled follow-up sends while an AI Employee was replying, and the working state became easy to miss once partial text appeared. Keep a visible working indicator beside the composer and let Members queue follow-ups with attachments while the reply continues.

Pending messages can be removed and send in order in their original conversation, including after closing the panel or navigating elsewhere in the app. Each message captures its employee, model, attachments, and focused draft. Dropped streams reconcile with persisted replies before advancing; failed replies retain pending messages, and **Try again** retries the failed message before dependent follow-ups without clearing the next draft.

The shared session store replaces duplicate panel transport logic and is cleared on logout or a Member change. Waiting messages remain in the current browser page; submitted replies remain server-persisted. No new dependency or database migration is needed. Updated Email, Routine, and chat documentation.

Validation:
- 15 focused session tests for ordering, payload snapshots, navigation, connection recovery, failure/resume, retries, and stale response/selection races.
- Real-browser composer regressions: partial replies retain working status; enqueue and remove multiple messages; attach during work; navigate and close/reopen panels; verify serial delivery and conversation isolation; recover failed sends; preserve a new draft during retry.
- Inspected Mail and Routine screenshots on desktop and at 390px mobile width; no horizontal overflow.
- App and Home lint, TypeScript checks, and production builds.
